### PR TITLE
fix: themes state management

### DIFF
--- a/client/src/lib/getDefaultStaticProps.ts
+++ b/client/src/lib/getDefaultStaticProps.ts
@@ -22,6 +22,6 @@ export const defaultStaticPropsWithThemes = wrapper.getStaticProps((store) => as
     props: {
       ...(await serverSideTranslations(getLanguageFromLocale(locale), ["common"])),
     },
-    revalidate: 60 * 60 // need to rebuild the page every 60 mins to update themes
+    revalidate: 60 * 10 // need to rebuild the page every 10 mins to update themes
   };
 });

--- a/client/src/services/rootReducer.ts
+++ b/client/src/services/rootReducer.ts
@@ -124,7 +124,7 @@ export const appReducer: Reducer<any, any> = (state, action) => {
     if (action.payload.langue.langues.length > 0 && nextState.langue.langues.length === 0) {
       nextState.langue = action.payload.langue;
     }
-    if (action.payload.themes.activeThemes.length > 0 && nextState.themes.activeThemes.length === 0) {
+    if (action.payload.themes.activeThemes.length > 0) { // keep new themes even if already in store
       nextState.themes = action.payload.themes;
     }
     if (action.payload.needs.length > 0 && nextState.needs.length === 0) {


### PR DESCRIPTION
Bug: when a theme is edited in the backoffice, changes are not reflected on the website

Fix: 
- reduce cache time before revalidation of the homepage (from 1h to 10min)
- when a server side rendered page is called, keep the new fetched themes in state to ensure they are up to date