### PR TITLE
perf: :zap: add cache control for medias

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -5,16 +5,13 @@ module.exports = {
   reactStrictMode: true, // Fix for https://github.com/kirill-konshin/next-redux-wrapper/issues/422
   i18n,
   images: {
-    domains: [
-      "storage.googleapis.com",
-      "res.cloudinary.com"
-    ],
+    domains: ["storage.googleapis.com", "res.cloudinary.com"]
   },
   webpack: (config) => {
     config.resolve.fallback = {
       events: false,
       buffer: false,
-      process: require.resolve("process/browser"),
+      process: require.resolve("process/browser")
     };
     return config;
   },
@@ -22,12 +19,23 @@ module.exports = {
     styledComponents: true
   },
   async rewrites() {
-    return rewrites
+    return rewrites;
   },
-   async redirects() {
-     return [
-       ...oldPathsRedirects,
-       ...translatedRedirects,
-     ]
+  async redirects() {
+    return [...oldPathsRedirects, ...translatedRedirects];
   },
-}
+  async headers() {
+    return [
+      {
+        source: "/:all*(svg|jpg|png|woff2|mp4)",
+        locale: false,
+        headers: [
+          {
+            key: "Cache-Control",
+            value: "public, max-age=31536000, must-revalidate"
+          }
+        ]
+      }
+    ];
+  }
+};

--- a/client/src/scss/_fonts.scss
+++ b/client/src/scss/_fonts.scss
@@ -1,15 +1,13 @@
 @font-face {
   font-family: "Marianne";
-  src: local("Marianne-Bold"),
-    url(https://storage.googleapis.com/refugies-info-assets/fonts/Marianne/Marianne-Bold.woff) format("woff");
+  src: local("Marianne-Bold"), url(/fonts/Marianne-Bold.woff2) format("woff2");
   font-weight: bold;
   font-style: normal;
 }
 
 @font-face {
   font-family: "Marianne";
-  src: local("Marianne-Regular"),
-    url(https://storage.googleapis.com/refugies-info-assets/fonts/Marianne/Marianne-Regular.woff) format("woff");
+  src: local("Marianne-Regular"), url(/fonts/Marianne-Regular.woff2) format("woff2");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
[Ticket](https://app.asana.com/0/1200625325783854/1203409239267904/f)

- ajouter un cache-control pour les ressources du dossier `/public`
- utiliser les fonts du dossier public pour ne pas les télécharger 2 fois (le dsfr utilise celles-ci)