### PR TITLE
fix(server): :bug: get content for app filter

### DIFF
--- a/server/src/workflows/dispositif/getFilteredContentsForApp/getFilteredContentsForApp.ts
+++ b/server/src/workflows/dispositif/getFilteredContentsForApp/getFilteredContentsForApp.ts
@@ -109,9 +109,11 @@ const getFilteredContentsForApp = async (req: GetContentsForAppRequest) => {
       break;
   }
 
-  query.push({
-    $or: frenchLevelFilter,
-  });
+  if (!isEmpty(frenchLevelFilter)) {
+    query.push({
+      $or: frenchLevelFilter,
+    });
+  }
 
   /**
    * Location


### PR DESCRIPTION
fix error: `MongoServerError: $and/$or/$nor must be a nonempty array`