### PR TITLE
fix(server): :bug: notif not sent because of wrong location format

### DIFF
--- a/server/src/modules/notifications/__tests__/helpers.test.ts
+++ b/server/src/modules/notifications/__tests__/helpers.test.ts
@@ -102,7 +102,7 @@ describe("notification helpers", () => {
 
     const req2 = {
       age: { min: 18, max: 25 },
-      departments: ["Ille-et-Vilaine"],
+      departments: ["35 - Ille-et-Vilaine"],
       type: ContentType.DISPOSITIF,
       mainThemeId: "theme1"
     }

--- a/server/src/modules/notifications/helpers.ts
+++ b/server/src/modules/notifications/helpers.ts
@@ -86,7 +86,7 @@ export const filterTargets = (targets: AppUser[], requirements: Requirements, la
 
     const ageOk = !target.age || (parsedAge.min >= age.min && parsedAge.max <= age.max);
     const departmentsOk =
-      (Array.isArray(departments) && departments.includes(target.department) && notificationsSettings.local) ||
+      (Array.isArray(departments) && departments.map(dep => dep.split(" - ")[1]).includes(target.department) && notificationsSettings.local) ||
       (departments === ALL && notificationsSettings.global);
 
     const typeOk = type === ContentType.DISPOSITIF ? true : notificationsSettings?.demarches;


### PR DESCRIPTION
[Ticket](https://refugies.monday.com/boards/1257177994/pulses/1372308137)

Migration script to apply to remove `notificationsSent` from dispositif when it's not the case:
```javascript
  const dispositifs = await dispositifsColl.find({ notificationsSent: { $exists: true } }).toArray();
  await Promise.all(
    dispositifs.map((dispositif) => {
      if (Object.keys(dispositif.notificationsSent).length > 0) {
        // if dispositif has notifications sent
        return notificationsColl.findOne({ "data.contentId": dispositif._id.toString() }).then((hasNotif) => {
          // and has no notif in db
          if (!hasNotif) {
            // remove notificationsSent
            return dispositifsColl.updateOne({ _id: dispositif._id }, { $set: { notificationsSent: {} } });
          }
          return;
        });
      }
      return;
    }),
  );
```