### PR TITLE
fix(client): :bug: wrong content loading language

### DIFF
--- a/client/src/pages/demarche/[id]/edit.tsx
+++ b/client/src/pages/demarche/[id]/edit.tsx
@@ -41,7 +41,7 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
   if (query.id) {
     const action = fetchSelectedDispositifActionCreator({
       selectedDispositifId: query.id as string,
-      locale: locale || "fr",
+      locale: "fr",
       token: req.cookies.authorization,
     });
     store.dispatch(action);

--- a/client/src/pages/dispositif/[id]/edit.tsx
+++ b/client/src/pages/dispositif/[id]/edit.tsx
@@ -45,7 +45,7 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
   if (query.id) {
     const action = fetchSelectedDispositifActionCreator({
       selectedDispositifId: query.id as string,
-      locale: locale || "fr",
+      locale: "fr",
       token: req.cookies.authorization,
     });
     store.dispatch(action);


### PR DESCRIPTION
To reproduce the bug:
- go on a dispositif in english
- click on "Modifier le dispositif"

-> the content is loaded in english. When edited, it overwrites content in french