### PR TITLE
fix(server): :bug: fix duplicate add of toReview keys

### DIFF
--- a/server/src/modules/traductions/traductions.repository.ts
+++ b/server/src/modules/traductions/traductions.repository.ts
@@ -75,9 +75,9 @@ export const addToReview = async (dispositifId: Id, toReview: string[], disposit
   const result = await TraductionsModel.updateMany(
     query,
     {
-      $push: {
-        toReview: { $each: toReview },
-        toReviewCache: { $each: toReview }
+      $addToSet: {
+        toReview: toReview,
+        toReviewCache: toReview
       }
     }
   );


### PR DESCRIPTION
Keys of sections to review were duplicated in DB, which caused wrong word count : sections were counted multiple times.

[Ticket](https://refugies.monday.com/boards/1257177994/pulses/1401143857)