### PR TITLE
fix(server): :bug: fix copy toReviewCache when validated by someone else

### DIFF
--- a/server/src/modules/traductions/traductions.repository.ts
+++ b/server/src/modules/traductions/traductions.repository.ts
@@ -20,6 +20,9 @@ export const getTraductionsByLanguageAndDispositif = (
 export const getValidation = (language: Languages, dispositifId: DispositifId, userId: UserId) =>
   TraductionsModel.findOne({ language, dispositifId, userId });
 
+export const getOtherValidationForDispositif = (language: Languages, dispositifId: DispositifId, userId: UserId) =>
+  TraductionsModel.findOne({ language, dispositifId, userId: { $ne: userId }, type: TraductionsType.VALIDATION });
+
 export const deleteTradsInDB = (dispositifId: DispositifId, language: Languages): Promise<DeleteResult> =>
   TraductionsModel.deleteMany({
     dispositifId,


### PR DESCRIPTION
Description du bug :

Le problème se pose avec le scénario suivant (un exemple) :

- je modifie une fiche (je suis `user_2`). Ça fait tomber la trad en anglais. C'est le `user_1` qui avait validé cette trad.
- quand j'ouvre la fiche pour la revoir, je vois que l'ancien nom `user_1` associé. 
- Je revois 1 ligne, mon nom `user_2` est appliqué à toutes les trads. Concrètement, ça a créé une nouvelle trad associée à mon user en base.

-> Problème, à ce moment on ne copie pas la liste des lignes "à revoir" utilisées pour calculer le nombre de mots pour airtable.