### PR TITLE
fix(server): :goal_net: Send a 404 when using outdated getContentById API.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,23 @@
 {
   "scss.lint.unknownAtRules": "ignore",
-  "eslint.workingDirectories": ["./client", "./server"],
+  "eslint.workingDirectories": [
+    "./client",
+    "./server"
+  ],
   "typescript.tsdk": "client/node_modules/typescript/lib",
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "conventionalCommits.scopes": ["api-types", "client", "server"],
+  "conventionalCommits.scopes": [
+    "api-types",
+    "client",
+    "server"
+  ],
   // i18n-ally
-  "i18n-ally.localesPaths": ["client/src/locales"],
-  "i18n-ally.ignoreFiles": ["**/unused.json"],
+  "i18n-ally.localesPaths": [
+    "client/src/locales"
+  ],
+  "i18n-ally.ignoreFiles": [
+    "**/unused.json"
+  ],
   "i18n-ally.keystyle": "nested",
   "i18n-ally.keysInUse": [
     "StructureType.*",
@@ -29,7 +40,10 @@
     "Translate.weak"
   ],
   "i18n-ally.dirStructure": "auto",
-  "i18n-ally.enabledFrameworks": ["i18next", "react-i18next"],
+  "i18n-ally.enabledFrameworks": [
+    "i18next",
+    "react-i18next"
+  ],
   "i18n-ally.extract.keygenStyle": "snake_case",
   "i18n-ally.displayLanguage": "fr",
   "i18n-ally.extract.ignoredByFiles": {},
@@ -37,5 +51,7 @@
   "prettier.configPath": ".prettierrc",
   // Github
   "githubPullRequests.fileListLayout": "flat",
-  "githubPullRequests.pullBranch": "never"
+  "githubPullRequests.pullBranch": "never",
+  "javascript.preferences.importModuleSpecifier": "relative",
+  "typescript.preferences.importModuleSpecifier": "relative"
 }

--- a/server/src/controllers/dispositifController.ts
+++ b/server/src/controllers/dispositifController.ts
@@ -31,8 +31,8 @@ import {
   UpdateDispositifResponse
 } from "@refugies-info/api-types"
 import express from "express"
-import { NotFoundError } from "src/errors"
 import { Body, Controller, Delete, Get, Patch, Path, Post, Put, Queries, Query, Request, Route, Security } from "tsoa"
+import { NotFoundError } from "../errors"
 import logger from "../logger"
 import { Response, ResponseWithData } from "../types/interface"
 import {

--- a/server/src/controllers/dispositifController.ts
+++ b/server/src/controllers/dispositifController.ts
@@ -1,5 +1,3 @@
-import { Controller, Get, Route, Path, Query, Security, Queries, Patch, Body, Request, Post, Put, Delete } from "tsoa";
-import express from "express";
 import {
   AddSuggestionDispositifRequest,
   AddViewsRequest,
@@ -30,8 +28,13 @@ import {
   StructureReceiveDispositifRequest,
   UpdateDispositifPropertiesRequest,
   UpdateDispositifRequest,
-  UpdateDispositifResponse,
-} from "@refugies-info/api-types";
+  UpdateDispositifResponse
+} from "@refugies-info/api-types"
+import express from "express"
+import { NotFoundError } from "src/errors"
+import { Body, Controller, Delete, Get, Patch, Path, Post, Put, Queries, Query, Request, Route, Security } from "tsoa"
+import logger from "../logger"
+import { Response, ResponseWithData } from "../types/interface"
 import {
   addMerci,
   addSuggestion,
@@ -46,8 +49,7 @@ import {
   getContentsForApp,
   getCountDispositifs,
   getDispositifs,
-  getDispositifsWithTranslationAvancement,
-  getNbContentsForCounty,
+  getDispositifsWithTranslationAvancement, getHasTextChanges, getNbContentsForCounty,
   getNbDispositifsByRegion,
   getStatistics,
   getUserContributions,
@@ -60,11 +62,8 @@ import {
   updateDispositifProperties,
   updateDispositifStatus,
   updateDispositifTagsOrNeeds,
-  updateNbVuesOrFavoritesOnContent,
-  getHasTextChanges,
-} from "../workflows";
-import logger from "../logger";
-import { Response, ResponseWithData } from "../types/interface";
+  updateNbVuesOrFavoritesOnContent
+} from "../workflows"
 
 @Route("dispositifs")
 export class DispositifController extends Controller {
@@ -358,6 +357,7 @@ export class DispositifController extends Controller {
     @Query() locale: Languages,
     @Request() request: express.Request,
   ): ResponseWithData<GetDispositifResponse> {
+    if (id === "getContentById") throw new NotFoundError("Outdated route, please use /dispositifs/{id} instead.");
     return getContentById(id, locale, request.user);
   }
 }


### PR DESCRIPTION
- added check for getContentById route to ensure more graceful failure
- added vscode setting to use relative imports with auto import

Fixes: #2142 