### PR TITLE
Fix query search parameter initialization

### DIFF
--- a/client/src/services/User/user.saga.ts
+++ b/client/src/services/User/user.saga.ts
@@ -6,9 +6,11 @@ import { addToQueryActionCreator } from "services/SearchResults/searchResults.ac
 import { logger } from "../../logger";
 import API from "../../utils/API";
 import { finishLoading, LoadingStatusKey, setError, startLoading } from "../LoadingStatus/loadingStatus.actions";
+import { searchQuerySelector } from "../SearchResults/searchResults.selector"
 import { fetchUserStructureActionCreator } from "../UserStructure/userStructure.actions";
 import { fetchUserActionCreator, saveUserActionCreator, setUserActionCreator } from "./user.actions";
 import { FETCH_USER, SAVE_USER } from "./user.actionTypes";
+import { userSelector } from "./user.selectors"
 
 export function* fetchUser(action: ReturnType<typeof fetchUserActionCreator>): SagaIterator {
   try {
@@ -17,13 +19,13 @@ export function* fetchUser(action: ReturnType<typeof fetchUserActionCreator>): S
     const isAuth = yield call(API.isAuth);
     const authenticated = isAuth || action.payload?.token;
     if (authenticated) {
-      const currentUser = yield select((state) => state.user);
+      const currentUser = yield select(userSelector);
       // Only fetch user if it is not already set
       if (!currentUser || !currentUser.id) {
         const data: GetUserInfoResponse = yield call(API.getUser, { token: action.payload?.token });
         yield put(setUserActionCreator(data));
         // Only add departments from user profile to query if they are not already set
-        const currentQuery = yield select((state) => state.searchResults.query);
+        const currentQuery = yield select(searchQuerySelector);
         if (
           (data.departments?.length || 0) > 0 &&
           (!currentQuery.departments || currentQuery.departments.length === 0)

--- a/client/src/services/User/user.saga.ts
+++ b/client/src/services/User/user.saga.ts
@@ -1,5 +1,5 @@
 import { SagaIterator } from "redux-saga";
-import { takeLatest, put, call } from "redux-saga/effects";
+import { takeLatest, put, call, select } from "redux-saga/effects";
 import { FETCH_USER, SAVE_USER } from "./user.actionTypes";
 import API from "../../utils/API";
 import {
@@ -30,7 +30,9 @@ export function* fetchUser(
     if (authenticated) {
       const data: GetUserInfoResponse = yield call(API.getUser, { token: action.payload?.token });
       yield put(setUserActionCreator(data));
-      if ((data.departments?.length || 0) > 0) {
+      // Only add departments from user profile to query if they are not already set
+      const currentQuery = yield select((state) => state.searchResults.query);
+      if ((data.departments?.length || 0) > 0 && (!currentQuery.departments || currentQuery.departments.length === 0)) {
         yield put(addToQueryActionCreator({ departments: (data.departments || [])?.map(dep => dep.split(" - ")[1]), sort: "location" }))
       }
       if (data.structures && data.structures.length > 0) {


### PR DESCRIPTION
Fixes an issue where the default initialization of the department search parameter was overriding query parameters specified by the user or existing in the URL.

Fixes: https://refugies.monday.com/boards/1257177994/pulses/1554515213

> Lorsque l'utilisateur est connecté, la recherche sur la Home et la page Trouver de l'info est automatiquement filtrée.
>
> Problème : ce filtre remplace tout filtre de département initialement choisi.
> 
> Exemples :
> 
> Envoi d'une URL avec filtre sur un département --> l'user clique sur l'URL --> lorsque la page s'ouvre, le département se rétablit sur celui qu'il a choisi dans son profil
> Home : choix d'un département --> clique sur "Rechercher" --> le département change et revient à celui du profil dans les résultats de la recherche
> Comportement souhaité
> 
> Si un département est déjà sélectionné dans le filtre de l'URL (URL ouverte en direct, ou via la recherche de la home etc), alors ce département doit rester sélectionner. Le département du profil ne doit pas prendre le pas sur ce département initialement choisi dans l'URL