### PR TITLE
Expire utmz cookie after one day

### DIFF
--- a/client/src/lib/tracking.ts
+++ b/client/src/lib/tracking.ts
@@ -1,4 +1,3 @@
-import Cookies from "js-cookie";
 import { isEmpty } from "lodash";
 import { logger } from "logger";
 import ReactGA from "react-ga4";
@@ -38,8 +37,12 @@ const storeCampaignInfosInCookie = () => {
       .map((key) => key + "=" + utmData[key])
       .join("&");
 
+    // expire utmz cookie after 1 day
+    let expires = new Date();
+    expires.setFullYear(expires.getFullYear() + 1);
+
     // Créer un cookie __utmz de remplacement
-    Cookies.set("__utmz", utmQueryString, { path: "/", expires: 1 });
+    document.cookie = `__utmz=${utmQueryString}; path=/; expires=${expires.toUTCString()}`;
   }
 };
 

--- a/client/src/lib/tracking.ts
+++ b/client/src/lib/tracking.ts
@@ -39,7 +39,7 @@ const storeCampaignInfosInCookie = () => {
 
     // expire utmz cookie after 1 day
     let expires = new Date();
-    expires.setFullYear(expires.getFullYear() + 1);
+    expires.setTime(expires.getTime() + 24 * 60 * 60 * 1000);
 
     // Créer un cookie __utmz de remplacement
     document.cookie = `__utmz=${utmQueryString}; path=/; expires=${expires.toUTCString()}`;

--- a/client/src/lib/tracking.ts
+++ b/client/src/lib/tracking.ts
@@ -1,6 +1,7 @@
-import ReactGA from "react-ga4";
-import { logger } from "logger";
+import Cookies from "js-cookie";
 import { isEmpty } from "lodash";
+import { logger } from "logger";
+import ReactGA from "react-ga4";
 
 /**
  * Le code suivant permet de stocker dans un cookie
@@ -38,9 +39,9 @@ const storeCampaignInfosInCookie = () => {
       .join("&");
 
     // Créer un cookie __utmz de remplacement
-    document.cookie = "__utmz=" + utmQueryString + "; path=/; expires=0";
+    Cookies.set("__utmz", utmQueryString, { path: "/", expires: 1 });
   }
-}
+};
 
 /**
  * Event - Add custom tracking event.
@@ -60,16 +61,20 @@ export const Event = (category: string, action: string, label: string) => {
   });
   //@ts-ignore
   // eslint-disable-next-line no-undef
-  if (!!window.plausible) plausible(category, { props: { action, label } })
+  if (!!window.plausible) plausible(category, { props: { action, label } });
   window._paq?.push(["trackEvent", category, action, label]);
 };
 
 const initMatomo = () => {
-  var _mtm = window._mtm = window._mtm || [];
-  _mtm.push({ "mtm.startTime": (new Date().getTime()), "event": "mtm.Start" });
-  var d = document, g = d.createElement("script"), s = d.getElementsByTagName("script")[0];
-  g.async = true; g.src = "https://cdn.matomo.cloud/refugies.matomo.cloud/container_ZxAXaEFC.js"; s.parentNode?.insertBefore(g, s);
-}
+  var _mtm = (window._mtm = window._mtm || []);
+  _mtm.push({ "mtm.startTime": new Date().getTime(), "event": "mtm.Start" });
+  var d = document,
+    g = d.createElement("script"),
+    s = d.getElementsByTagName("script")[0];
+  g.async = true;
+  g.src = "https://cdn.matomo.cloud/refugies.matomo.cloud/container_ZxAXaEFC.js";
+  s.parentNode?.insertBefore(g, s);
+};
 
 /**
  * Inits GA with consent option, or update if already initialized


### PR DESCRIPTION
Here we set a one day expiry date for the utm cookie to resolve the issue of the cookie persisting after the end of the session.  This happens because modern browsers don't respect the expiry of session cookies when users choose to restore open tabs when launching the browser. 

Fixes: https://refugies.monday.com/boards/1257177994/pulses/1561251832