### PR TITLE
style(client): :lipstick: Set the bootstrap table background color

### DIFF
--- a/client/src/scss/_variables.scss
+++ b/client/src/scss/_variables.scss
@@ -7,6 +7,7 @@
 $font-family-sans-serif: "Marianne", "Arial", "sans-serif";
 $body-color: $gray90;
 $body-bg: white;
+$table-bg: #0000;
 
 // Colors
 $light: $gray20;


### PR DESCRIPTION
The table background color was off in the current version because of an update of bootstrap/scss css variable default values 