### PR TITLE
chore(server): :pushpin: Use workspace dependency for @refugies-info/api-types

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@azure/msal-node": "^2.6.2",
     "@google-cloud/translate": "^8.3.0",
-    "@refugies-info/api-types": "1.0.51",
+    "@refugies-info/api-types": "*",
     "@sendgrid/mail": "^8.1.3",
     "@sendinblue/client": "^3.2.2",
     "@slack/webhook": "^7.0.1",


### PR DESCRIPTION
Use the workspace dependency instead of the package on npm