### PR TITLE
chore: :wrench: Remove lint-staged eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "yarn": "1.22.22"
   },
   "lint-staged": {
-    "*.{js,ts,tsx}": "eslint --fix",
     "*.{css,scss}": "stylelint --fix"
   }
 }


### PR DESCRIPTION
Unfortunately not working well, see https://github.com/vercel/turborepo/issues/3364