### PR TITLE
ci: :construction_worker: Make sure the migration jobs can run one at a time

### DIFF
--- a/.github/workflows/migrate_production.yaml
+++ b/.github/workflows/migrate_production.yaml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: master-migrate
+    concurrency:
+      group: master-migrate
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/migrate_staging.yaml
+++ b/.github/workflows/migrate_staging.yaml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: staging-migrate
+    concurrency:
+      group: staging-migrate
+      cancel-in-progress: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The [mono-migrate-ts](https://github.com/mycodeself/mongo-migrate-ts) library we use for migrations doesn't seem to have a locking mechanism at the db level that guarantees mutual exclusion.  Here we explicitly configure the migration workflows to only execute one at a time.