### PR TITLE
fix: :bug: fix show right languages for draft versions

### DIFF
--- a/apps/client/src/pages/demarche/[id]/translate.tsx
+++ b/apps/client/src/pages/demarche/[id]/translate.tsx
@@ -48,7 +48,7 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     const action = fetchSelectedDispositifActionCreator({
       selectedDispositifId: dispositifId,
       locale: locale || "fr",
-      token: req.cookies.authorization,
+      // token: req.cookies.authorization, // fetch demarche as anonymous user to use the published version as reference
     });
     store.dispatch(action);
     store.dispatch(fetchThemesActionCreator());

--- a/apps/client/src/pages/dispositif/[id]/translate.tsx
+++ b/apps/client/src/pages/dispositif/[id]/translate.tsx
@@ -50,7 +50,7 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     const action = fetchSelectedDispositifActionCreator({
       selectedDispositifId: dispositifId as string,
       locale: "fr",
-      token: req.cookies.authorization,
+      // token: req.cookies.authorization, // fetch dispositif as anonymous user to use the published version as reference
     });
     store.dispatch(action);
     store.dispatch(fetchThemesActionCreator());


### PR DESCRIPTION
Changements :
1. affiche la version publiée plutôt que le brouillon de travail en référence lors d'une traduction
2. récupère les langues dispos depuis le dispositif publié plutôt que le brouillon de travail