### PR TITLE
fix(client): :bug: fix accordions disappearing in react strict mode

### DIFF
--- a/apps/client/src/components/Pages/dispositif/Edition/AccordionsEdit/AccordionItem/AccordionItem.tsx
+++ b/apps/client/src/components/Pages/dispositif/Edition/AccordionsEdit/AccordionItem/AccordionItem.tsx
@@ -57,6 +57,15 @@ const AccordionItem = (props: Props) => {
     );
   };
 
+  /* caused the bug https://github.com/refugies-info/karfur/pull/2293
+  TODO: uncomment if it creates a regression, clean up otherwise
+
+  // when item unmounted, delete it from form values
+  useEffect(() => {
+    return () => unregister(props.id);
+  }, [unregister, props.id]);
+  */
+
   const pageContext = useContext(PageContext);
   useEffect(() => {
     if (isActive) {

--- a/apps/client/src/components/Pages/dispositif/Edition/AccordionsEdit/AccordionItem/AccordionItem.tsx
+++ b/apps/client/src/components/Pages/dispositif/Edition/AccordionsEdit/AccordionItem/AccordionItem.tsx
@@ -31,7 +31,7 @@ interface Props {
  */
 const AccordionItem = (props: Props) => {
   const [isActive, setIsActive] = useState(false);
-  const { unregister, register, getValues, setValue } = useFormContext();
+  const { register, getValues, setValue } = useFormContext();
 
   const currentTheme = useSelector(themeSelector(getValues("theme")));
   const color = currentTheme?.colors.color100 || "#000";
@@ -56,11 +56,6 @@ const AccordionItem = (props: Props) => {
       </div>
     );
   };
-
-  // when item unmounted, delete it from form values
-  useEffect(() => {
-    return () => unregister(props.id);
-  }, [unregister, props.id]);
 
   const pageContext = useContext(PageContext);
   useEffect(() => {


### PR DESCRIPTION
@ledjay @kaaloo je veux bien votre avis sur celui-ci.

Le bug : En dev, quand on charge la page de dispo create pour modifier un dispositif, les accordéons disparaissent et on ne peut plus en ajouter.

Le problème : avec le strict mode de react, les composants sont rendus 2 fois dès le chargement (quand on le retire, ça fonctionne correctement). Dans notre cas, l'`AccordionItem` s'`unregister` au `unmount`.

Résolution : j'ai l'impression qu'on peut simplement supprimer cette ligne, puisque dans le composant parent (`AccordionsEdit`), on a la logique de suppression de définie : https://github.com/refugies-info/karfur/blob/dev/apps/client/src/components/Pages/dispositif/Edition/AccordionsEdit/AccordionsEdit.tsx#L38-L42 

Est-ce que je rate quelque chose ou c'est censé marcher comme ça ? 