### PR TITLE
fix(server): :bug: Return a 404 if the dispositif id is invalid

### DIFF
--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -31,6 +31,7 @@ import {
   UpdateDispositifResponse,
 } from "@refugies-info/api-types";
 import express from "express";
+import { ObjectId } from "mongodb";
 import { Body, Controller, Delete, Get, Patch, Path, Post, Put, Queries, Query, Request, Route, Security } from "tsoa";
 import { NotFoundError } from "~/errors";
 import logger from "~/logger";
@@ -360,6 +361,9 @@ export class DispositifController extends Controller {
     @Request() request: express.Request,
   ): ResponseWithData<GetDispositifResponse> {
     if (id === "getContentById") throw new NotFoundError("Outdated route, please use /dispositifs/{id} instead.");
+    if (!ObjectId.isValid(id)) {
+      throw new NotFoundError("Invalid dispostif ID");
+    }
     return getContentById(id, locale, request.user);
   }
 }


### PR DESCRIPTION
The purpose of this PR is to tone down 500 error alerts when the backend receives requests with malformed ids such as:

`"https://api.refugies.info/dispositifs/NjRlZjU0Nj?locale=fr"`