### PR TITLE
fix: various improvements

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -71,6 +71,7 @@
     "redux-saga": "^1.2.3",
     "remixicon": "^4.3.0",
     "remove": "^0.1.5",
+    "reselect": "^5.1.1",
     "sortablejs": "^1.15.0",
     "styled-components": "^6.1.12",
     "sweetalert2": "^11.14.2",

--- a/apps/client/src/components/UI/Checkbox/CheckboxIcon.tsx
+++ b/apps/client/src/components/UI/Checkbox/CheckboxIcon.tsx
@@ -5,8 +5,8 @@ const CheckboxIcon: React.FC = () => (
   <div className={styles.container}>
     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none">
       <path
-        fill-rule="evenodd"
-        clip-rule="evenodd"
+        fillRule="evenodd"
+        clipRule="evenodd"
         d="M6.66649 10.113L12.7945 3.98438L13.7378 4.92704L6.66649 11.9984L2.42383 7.75571L3.36649 6.81304L6.66649 10.113Z"
         fill="#F5F5FE"
       />

--- a/apps/client/src/services/SearchResults/searchResults.selector.ts
+++ b/apps/client/src/services/SearchResults/searchResults.selector.ts
@@ -1,4 +1,5 @@
 import { GetDispositifsResponse } from "@refugies-info/api-types";
+import { createSelector } from "reselect";
 import { getThemesDisplayed } from "~/lib/recherche/functions";
 import { RootState } from "../rootReducer";
 import { Results, SearchQuery } from "./searchResults.reducer";
@@ -9,21 +10,19 @@ export const noResultsSelector = (state: RootState): GetDispositifsResponse[] =>
 
 export const searchQuerySelector = (state: RootState): SearchQuery => state.searchResults.query;
 
-export const themesDisplayedSelector = (state: RootState) => {
-  return getThemesDisplayed(
-    state.themes.activeThemes,
-    state.needs,
-    state.searchResults.query.themes,
-    state.searchResults.query.needs,
-  );
-};
+const selectActiveThemes = (state: RootState) => state.themes.activeThemes;
+const selectNeeds = (state: RootState) => state.needs;
+const selectQueryThemes = (state: RootState) => state.searchResults.query.themes;
+const selectQueryNeeds = (state: RootState) => state.searchResults.query.needs;
+const selectLanguage = (state: RootState) => state.langue.languei18nCode;
 
-export const themesDisplayedValueSelector = (state: RootState) => {
-  const themesDisplayed = getThemesDisplayed(
-    state.themes.activeThemes,
-    state.needs,
-    state.searchResults.query.themes,
-    state.searchResults.query.needs,
-  );
-  return themesDisplayed.map((t) => t.short[state.langue.languei18nCode] || t.short.fr);
-};
+export const themesDisplayedSelector = createSelector(
+  [selectActiveThemes, selectNeeds, selectQueryThemes, selectQueryNeeds],
+  (selectActiveThemes, selectNeeds, selectQueryThemes, selectQueryNeeds) =>
+    getThemesDisplayed(selectActiveThemes, selectNeeds, selectQueryThemes, selectQueryNeeds),
+);
+
+export const themesDisplayedValueSelector = createSelector(
+  [themesDisplayedSelector, selectLanguage],
+  (themesDisplayed, selectLanguage) => themesDisplayed.map((t) => t.short[selectLanguage] || t.short.fr),
+);

--- a/apps/client/src/services/User/user.selectors.ts
+++ b/apps/client/src/services/User/user.selectors.ts
@@ -1,4 +1,5 @@
 import { GetUserInfoResponse, Id } from "@refugies-info/api-types";
+import { createSelector } from "reselect";
 import { RootState } from "../rootReducer";
 import { UserState } from "./user.reducer";
 
@@ -11,5 +12,9 @@ export const userIdSelector = (state: RootState): Id | null => state.user.userId
 export const userStructureIdSelector = (state: RootState): Id | null =>
   state.user.user?.structures ? state.user.user.structures[0] : null;
 
-export const userSelectedLanguageSelector = (state: RootState): Id[] =>
-  state.user.user?.selectedLanguages ? state.user.user.selectedLanguages : [];
+const selectSelectedLanguage = (state: RootState) => state.user.user?.selectedLanguages;
+
+export const userSelectedLanguageSelector = createSelector(
+  [selectSelectedLanguage],
+  (selectSelectedLanguage) => selectSelectedLanguage ?? [],
+);

--- a/apps/client/src/services/UserStructure/userStructure.selectors.ts
+++ b/apps/client/src/services/UserStructure/userStructure.selectors.ts
@@ -1,16 +1,22 @@
-import { GetStructureDispositifResponse, GetStructureResponse } from "@refugies-info/api-types";
+import { GetStructureResponse } from "@refugies-info/api-types";
+import { createSelector } from "reselect";
 import { areDispositifsAssociesPopulate } from "../../types/typeGuards";
 import { RootState } from "../rootReducer";
 
 export const userStructureSelector = (state: RootState): GetStructureResponse | null => state.userStructure;
 
-export const userStructureDisposAssociesSelector = (state: RootState): GetStructureDispositifResponse[] => {
-  if (!state.userStructure) return [];
-  if (areDispositifsAssociesPopulate(state.userStructure.dispositifsAssocies)) {
-    return state.userStructure.dispositifsAssocies;
-  }
-  return [];
-};
+const selectUserStructureDisposAssociesSelector = (state: RootState) => state.userStructure?.dispositifsAssocies;
+
+export const userStructureDisposAssociesSelector = createSelector(
+  [selectUserStructureDisposAssociesSelector],
+  (selectUserStructureDisposAssociesSelector) => {
+    if (!selectUserStructureDisposAssociesSelector) return [];
+    if (areDispositifsAssociesPopulate(selectUserStructureDisposAssociesSelector)) {
+      return selectUserStructureDisposAssociesSelector;
+    }
+    return [];
+  },
+);
 
 export const userStructureHasResponsibleSeenNotification = (state: RootState): boolean =>
   state.userStructure ? !!state.userStructure.hasResponsibleSeenNotification : false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -14062,12 +14062,7 @@ path-scurry@^1.10.1, path-scurry@^1.11.1:
     lru-cache "^10.2.0"
     minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
-path-to-regexp@0.1.10:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.10.tgz#67e9108c5c0551b9e5326064387de4763c4d5f8b"
-  integrity sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==
-
-path-to-regexp@^1.7.0:
+path-to-regexp@0.1.10, path-to-regexp@1.9.0, path-to-regexp@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
   integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
@@ -15816,39 +15811,12 @@ selfsigned@^2.4.1:
     "@types/node-forge" "^1.3.0"
     node-forge "^1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
-  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
-
-semver@7.3.2:
-  version "7.3.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
-  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
-
-semver@7.5.3:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
-  integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^6.3.0, semver@^6.3.1:
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
-  integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
-
-semver@^7.1.3, semver@^7.3.5, semver@^7.5.1, semver@^7.5.2:
+"semver@2 || 3 || 4 || 5", semver@7.3.2, semver@7.5.2, semver@7.5.3, semver@^5.5.0, semver@^5.6.0, semver@^6.3.0, semver@^6.3.1, semver@^7.1.3, semver@^7.3.5, semver@^7.5.1, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
   version "7.5.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.2.tgz#5b851e66d1be07c1cdaf37dfc856f543325a2beb"
   integrity sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==
   dependencies:
     lru-cache "^6.0.0"
-
-semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.2, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 send@0.18.0, send@^0.18.0:
   version "0.18.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15516,6 +15516,11 @@ requires-port@^1.0.0:
   resolved "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
   integrity sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==
 
+reselect@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-5.1.1.tgz#c766b1eb5d558291e5e550298adb0becc24bb72e"
+  integrity sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==
+
 reserved-words@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"


### PR DESCRIPTION
@ledjay @kaloo j'ai ajouté 2 mini correctifs qui créaient beaucoup d'erreurs ou warnings en console : 
- attributs `clip-rule` et `fill-rule` -> `clipRule` et `fillRule` 
- utilisation de reselect pour memoizer les sélecteurs (voir [ici](https://redux.js.org/usage/deriving-data-selectors#writing-memoized-selectors-with-reselect))

Je vous laisse décider si on passe ça dans cette version ou on garde au chaud pour la suivante pour limiter le risque de bug