### PR TITLE
RI-65: Eléments à revoir

### DIFF
--- a/apps/client/src/components/Backend/screens/Admin/AdminStructures/SelectFirstResponsableModal/SelectFirstResponsableModal.tsx
+++ b/apps/client/src/components/Backend/screens/Admin/AdminStructures/SelectFirstResponsableModal/SelectFirstResponsableModal.tsx
@@ -73,7 +73,7 @@ export const SelectFirstResponsableModal = (props: Props) => {
         action: "create",
       };
 
-      await API.updateStructureRoles(props.selectedStructureId, structure);
+      await API.updateStructureMembers(props.selectedStructureId, structure);
 
       Swal.fire({
         title: "Yay...",

--- a/apps/client/src/components/Backend/screens/UserStructure/UserStructureAdmin.component.tsx
+++ b/apps/client/src/components/Backend/screens/UserStructure/UserStructureAdmin.component.tsx
@@ -54,7 +54,7 @@ export const UserStructureAdminComponent = (props: Props) => {
       action: "create",
     };
     setIsLoading(true);
-    await API.updateStructureRoles(structure._id, query);
+    await API.updateStructureMembers(structure._id, query);
     setIsLoading(false);
     toggleReload();
   };
@@ -78,7 +78,7 @@ export const UserStructureAdminComponent = (props: Props) => {
           action: "delete",
         };
         setIsLoading(true);
-        await API.updateStructureRoles(structure._id, query);
+        await API.updateStructureMembers(structure._id, query);
         setIsLoading(false);
         toggleReload();
       }

--- a/apps/client/src/services/UserStructure/__tests__/userStructure.saga.test.ts
+++ b/apps/client/src/services/UserStructure/__tests__/userStructure.saga.test.ts
@@ -150,7 +150,7 @@ describe("[Saga] Structures", () => {
         .next()
         .put(startLoading(LoadingStatusKey.UPDATE_USER_STRUCTURE))
         .next()
-        .call(API.updateStructureRoles, "structureId", {
+        .call(API.updateStructureMembers, "structureId", {
           membreId: "userId",
           action: "create",
         })
@@ -214,7 +214,7 @@ describe("[Saga] Structures", () => {
         .next()
         .put(startLoading(LoadingStatusKey.UPDATE_USER_STRUCTURE))
         .next()
-        .call(API.updateStructureRoles, "structureId", {
+        .call(API.updateStructureMembers, "structureId", {
           membreId: "userId",
           action: "delete",
         })

--- a/apps/client/src/services/UserStructure/userStructure.saga.ts
+++ b/apps/client/src/services/UserStructure/userStructure.saga.ts
@@ -106,7 +106,7 @@ export function* updateUserStructure(action: ReturnType<typeof updateUserStructu
       }
       structureId = membres.structureId;
 
-      yield call(API.updateStructureRoles, membres.structureId, query);
+      yield call(API.updateStructureMembers, membres.structureId, query);
     } else {
       throw new Error("NO_DATA");
     }

--- a/apps/client/src/utils/API.ts
+++ b/apps/client/src/utils/API.ts
@@ -419,9 +419,9 @@ const API = {
     const headers = getHeaders();
     return instance.patch<any, null>(`/structures/${id}`, body, { headers }).then(() => null);
   },
-  updateStructureRoles: (id: Id, body: PatchStructureRolesRequest): Promise<null> => {
+  updateStructureMembers: (id: Id, body: PatchStructureRolesRequest): Promise<null> => {
     const headers = getHeaders();
-    return instance.patch<any, null>(`/structures/${id}/roles`, body, { headers }).then(() => null);
+    return instance.patch<any, null>(`/structures/${id}/members`, body, { headers }).then(() => null);
   },
   getStructureById: (id: string, locale: string, options?: RequestOptions): Promise<GetStructureResponse> => {
     const headers = getHeaders(options?.token);

--- a/apps/server/src/connectors/sendgrid/templatesIds.ts
+++ b/apps/server/src/connectors/sendgrid/templatesIds.ts
@@ -13,7 +13,7 @@ declare type templateIds = {
   publishedTradForTraductors: string;
   subscriptionReminderMail: string;
   resetPassword: string;
-  newResponsable: string;
+  newMember: string;
   accountDeleted: string;
 };
 
@@ -30,7 +30,7 @@ export const templatesIds: templateIds = {
   publishedTradForTraductors: "d-f933396f06ac43c9aadfbcf41288fbb3",
   subscriptionReminderMail: "d-7b825e600f5c46ad9a1666e4431d2c97",
   resetPassword: "d-30e42b33779d48b093958e10fb639d0e",
-  newResponsable: "d-efb7b79df19a454caa52473ffa517fe6",
+  newMember: "d-ed89408e5f6e4eeca77c395b3a8e7003",
   secondOneDraftReminder: "d-7fc299960fca4d9db6b78b494ce84689",
   secondMultipleDraftReminder: "d-d0cd2b645a194866980a3288ddfc4b27",
   accountDeleted: "d-70d86dadbdcd4f8bb02984c227c90c85",

--- a/apps/server/src/controllers/structureController.ts
+++ b/apps/server/src/controllers/structureController.ts
@@ -17,7 +17,7 @@ import { getActiveStructures } from "~/workflows/structure/getActiveStructures";
 import { getAllStructures } from "~/workflows/structure/getAllStructures";
 import { getStatistics } from "~/workflows/structure/getStatistics";
 import { getStructureById } from "~/workflows/structure/getStructureById";
-import { modifyUserRoleInStructure } from "~/workflows/structure/modifyUserRoleInStructure";
+import { modifyUserMembershipInStructure } from "~/workflows/structure/modifyUserRoleInStructure";
 import { updateStructure } from "~/workflows/structure/updateStructure";
 
 @Route("structures")
@@ -80,12 +80,12 @@ export class StructureController extends Controller {
     jwt: [],
     fromSite: [],
   })
-  @Patch("{id}/roles")
-  public async updateRoles(
+  @Patch("{id}/members")
+  public async updateMembers(
     @Path() id: string,
     @Body() body: PatchStructureRolesRequest,
     @Request() request: ExRequest,
   ): Response {
-    return modifyUserRoleInStructure(id, body, request.user);
+    return modifyUserMembershipInStructure(id, body, request.user);
   }
 }

--- a/apps/server/src/modules/mail/data.ts
+++ b/apps/server/src/modules/mail/data.ts
@@ -19,7 +19,7 @@ export const PREFS: Record<string, Record<TemplateName, boolean>> = {
     newFicheEnAttente: false,
     publishedTradForTraductors: false,
     reviewFiche: false,
-    newResponsable: false,
+    newMember: false,
     accountDeleted: true,
   },
 };

--- a/apps/server/src/modules/mail/mail.service.ts
+++ b/apps/server/src/modules/mail/mail.service.ts
@@ -518,17 +518,17 @@ export const sendAdminImprovementsMailService = async (data: AdminImprovementsMa
   }
 };
 
-interface NewResponsableMail {
+interface NewMemberMail {
   userId: UserId;
   email: string;
   firstName: string;
   nomstructure: string;
 }
 
-export const sendNewReponsableMailService = async (data: NewResponsableMail) => {
-  if (consentsToEmail(data.userId, "newResponsable")) {
+export const sendNewMemberMailService = async (data: NewMemberMail) => {
+  if (consentsToEmail(data.userId, "newMember")) {
     try {
-      logger.info("[sendNewReponsableMailService] received");
+      logger.info("[sendNewMemberMailService] received");
 
       const dynamicData = {
         to: data.email,
@@ -542,7 +542,7 @@ export const sendNewReponsableMailService = async (data: NewResponsableMail) => 
           nomstructure: data.nomstructure,
         },
       };
-      const templateName = "newResponsable";
+      const templateName = "newMember";
       sendMail(templateName, dynamicData, true);
       await addMailEvent({
         templateName,
@@ -551,12 +551,12 @@ export const sendNewReponsableMailService = async (data: NewResponsableMail) => 
       });
       return;
     } catch (error) {
-      logger.error("[sendNewReponsableMailService] error", {
+      logger.error("[sendNewMemberMailService] error", {
         error: error.message,
       });
     }
   } else {
-    logger.info("[sendNewReponsableMailService] user has not consented to email", { email: data.email });
+    logger.info("[sendNewMemberMailService] user has not consented to email", { email: data.email });
   }
 };
 

--- a/apps/server/src/workflows/structure/modifyUserRoleInStructure/index.ts
+++ b/apps/server/src/workflows/structure/modifyUserRoleInStructure/index.ts
@@ -1,1 +1,1 @@
-export { modifyUserRoleInStructure } from "./modifyUserRoleInStructure";
+export { modifyUserMembershipInStructure } from "./modifyUserMembershipInStructure";

--- a/apps/server/src/workflows/structure/modifyUserRoleInStructure/modifyUserMembershipInStructure.test.ts
+++ b/apps/server/src/workflows/structure/modifyUserRoleInStructure/modifyUserMembershipInStructure.test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-/* import { modifyUserRoleInStructure } from "./modifyUserRoleInStructure";
+/* import { modifyUserMembershipInStructure } from "./modifyUserMembershipInStructure";
 import { checkIfUserIsAuthorizedToModifyStructure } from "~/modules/structure/structure.service";
 import { updateStructureMember, getStructureFromDB } from "~/modules/structure/structure.repository";
 import { removeStructureOfUser, addStructureForUsers } from "~/modules/users/users.service";
@@ -45,7 +45,7 @@ jest.mock("./log", () => ({
   log: jest.fn().mockResolvedValue(undefined)
 })); */
 
-describe.skip("modifyUserRoleInStructure", () => {
+describe.skip("modifyUserMembershipInStructure", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -53,14 +53,14 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 405 if not from site", async () => {
     const req = { test: "a", fromSite: false };
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(sendNewReponsableMailService).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(405);
     expect(res.json).toHaveBeenCalledWith({ text: "Requête bloquée par API" });
   });
   it("should return 400 if no body", async () => {
     const req = { fromSite: true };
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(sendNewReponsableMailService).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ text: "Requête invalide" });
@@ -68,7 +68,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 400 if no body query", async () => {
     const req = { fromSite: true, body: { test: "s" } };
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(sendNewReponsableMailService).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
     expect(res.json).toHaveBeenCalledWith({ text: "Requête invalide" });
@@ -97,7 +97,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 402 if checkIfUserIsAuthorizedToModifyStructure throws NO_STRUCTURE_WITH_THIS_ID", async () => {
     checkIfUserIsAuthorizedToModifyStructure.mockRejectedValueOnce(new Error("NO_STRUCTURE_WITH_THIS_ID"));
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(checkIfUserIsAuthorizedToModifyStructure).toHaveBeenCalledWith("structureId", "userId", ["test"]);
     expect(updateStructureMember).not.toHaveBeenCalled();
     expect(addStructureForUsers).not.toHaveBeenCalled();
@@ -108,7 +108,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 401 if user not authorized", async () => {
     checkIfUserIsAuthorizedToModifyStructure.mockRejectedValueOnce(new Error("USER_NOT_AUTHORIZED"));
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(checkIfUserIsAuthorizedToModifyStructure).toHaveBeenCalledWith("structureId", "userId", ["test"]);
     expect(addStructureForUsers).not.toHaveBeenCalled();
     expect(updateStructureMember).not.toHaveBeenCalled();
@@ -118,7 +118,7 @@ describe.skip("modifyUserRoleInStructure", () => {
   });
 
   it("should return 200 if modify to contributeur and not send email", async () => {
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(updateStructureMember).toHaveBeenCalledWith("membreId", {
       _id: "structureId",
       $set: { "membres.$.roles": ["contributeur"] },
@@ -136,7 +136,7 @@ describe.skip("modifyUserRoleInStructure", () => {
     requestResponsable.body.query.role = "administrateur";
 
     getUserById.mockResolvedValueOnce(user);
-    await modifyUserRoleInStructure(requestResponsable, res);
+    await modifyUserMembershipInStructure(requestResponsable, res);
     expect(updateStructureMember).toHaveBeenCalledWith("membreId", {
       _id: "structureId",
       $set: { "membres.$.roles": ["administrateur"] },
@@ -159,7 +159,7 @@ describe.skip("modifyUserRoleInStructure", () => {
   });
 
   it("should return 500 if modify and no role", async () => {
-    await modifyUserRoleInStructure(
+    await modifyUserMembershipInStructure(
       {
         user: { roles: ["test"] },
         userId: "userId",
@@ -193,7 +193,7 @@ describe.skip("modifyUserRoleInStructure", () => {
     },
   };
   it("should return 200 if delete ", async () => {
-    await modifyUserRoleInStructure(reqDelete, res);
+    await modifyUserMembershipInStructure(reqDelete, res);
     expect(updateStructureMember).toHaveBeenCalledWith("membreId", structureDelete);
     expect(removeStructureOfUser).toHaveBeenCalledWith("membreId", "structureId");
     expect(addStructureForUsers).not.toHaveBeenCalled();
@@ -205,7 +205,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 500 if updateStructureMember throws", async () => {
     updateStructureMember.mockRejectedValueOnce(new Error("erreur"));
-    await modifyUserRoleInStructure(req, res);
+    await modifyUserMembershipInStructure(req, res);
     expect(updateStructureMember).toHaveBeenCalledWith("membreId", {
       _id: "structureId",
       $set: { "membres.$.roles": ["contributeur"] },
@@ -220,7 +220,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 500 if delete and removeStructureOfUser throws", async () => {
     removeStructureOfUser.mockRejectedValueOnce(new Error("erreur"));
-    await modifyUserRoleInStructure(reqDelete, res);
+    await modifyUserMembershipInStructure(reqDelete, res);
     expect(updateStructureMember).toHaveBeenCalledWith("membreId", structureDelete);
     expect(removeStructureOfUser).toHaveBeenCalledWith("membreId", "structureId");
     expect(addStructureForUsers).not.toHaveBeenCalled();
@@ -262,7 +262,7 @@ describe.skip("modifyUserRoleInStructure", () => {
   jest.spyOn(global, "Date").mockImplementation(() => mockDate);
 
   it("should return 200 if create and not send email", async () => {
-    await modifyUserRoleInStructure(reqCreate, res);
+    await modifyUserMembershipInStructure(reqCreate, res);
     expect(updateStructureMember).toHaveBeenCalledWith(null, structureCreate);
     expect(addStructureForUsers).toHaveBeenCalledWith(["membreId"], "structureId");
     expect(sendNewReponsableMailService).not.toHaveBeenCalled();
@@ -277,7 +277,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
     getUserById.mockResolvedValueOnce(user);
 
-    await modifyUserRoleInStructure(requestResponsable, res);
+    await modifyUserMembershipInStructure(requestResponsable, res);
     expect(updateStructureMember).toHaveBeenCalledWith(null, structureCreateResponsable);
     expect(addStructureForUsers).toHaveBeenCalledWith(["membreId"], "structureId");
     expect(getUserById).toHaveBeenCalled();
@@ -295,7 +295,7 @@ describe.skip("modifyUserRoleInStructure", () => {
   });
 
   it("should return 500 if create and no role", async () => {
-    await modifyUserRoleInStructure(
+    await modifyUserMembershipInStructure(
       {
         user: { roles: ["test"] },
         userId: "userId",
@@ -320,7 +320,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
     getUserById.mockResolvedValueOnce({ ...user, roles: ["adminRole"] });
 
-    await modifyUserRoleInStructure(requestResponsable, res);
+    await modifyUserMembershipInStructure(requestResponsable, res);
     expect(updateStructureMember).toHaveBeenCalledWith(null, structureCreateResponsable);
     expect(addStructureForUsers).toHaveBeenCalledWith(["membreId"], "structureId");
     expect(sendNewReponsableMailService).not.toHaveBeenCalled();
@@ -330,7 +330,7 @@ describe.skip("modifyUserRoleInStructure", () => {
   });
 
   it("should return 500 if create and no role", async () => {
-    await modifyUserRoleInStructure(
+    await modifyUserMembershipInStructure(
       {
         user: { roles: ["test"] },
         userId: "userId",
@@ -351,7 +351,7 @@ describe.skip("modifyUserRoleInStructure", () => {
 
   it("should return 500 if create and removeStructureOfUser throws", async () => {
     addStructureForUsers.mockRejectedValueOnce(new Error("erreur"));
-    await modifyUserRoleInStructure(reqCreate, res);
+    await modifyUserMembershipInStructure(reqCreate, res);
     expect(updateStructureMember).toHaveBeenCalledWith(null, structureCreate);
     expect(addStructureForUsers).toHaveBeenCalledWith(["membreId"], "structureId");
     expect(removeStructureOfUser).not.toHaveBeenCalled();

--- a/apps/server/src/workflows/structure/modifyUserRoleInStructure/modifyUserMembershipInStructure.ts
+++ b/apps/server/src/workflows/structure/modifyUserRoleInStructure/modifyUserMembershipInStructure.ts
@@ -1,6 +1,6 @@
 import { PatchStructureRolesRequest, RoleName } from "@refugies-info/api-types";
 import logger from "~/logger";
-import { sendNewReponsableMailService } from "~/modules/mail/mail.service";
+import { sendNewMemberMailService } from "~/modules/mail/mail.service";
 import { getRoleByName } from "~/modules/role/role.repository";
 import { getStructureFromDB, updateStructureMember } from "~/modules/structure/structure.repository";
 import { checkIfUserIsAuthorizedToModifyStructure } from "~/modules/structure/structure.service";
@@ -10,10 +10,14 @@ import { User } from "~/typegoose";
 import { Response } from "~/types/interface";
 import { log } from "./log";
 
-export const modifyUserRoleInStructure = async (id: string, body: PatchStructureRolesRequest, user: User): Response => {
+export const modifyUserMembershipInStructure = async (
+  id: string,
+  body: PatchStructureRolesRequest,
+  user: User,
+): Response => {
   const { membreId, action } = body;
 
-  logger.info("[modifyUserRoleInStructure] try to modify structure with id", {
+  logger.info("[modifyUserMembershipInStructure] try to modify structure with id", {
     id,
     action,
     membreId,
@@ -21,7 +25,7 @@ export const modifyUserRoleInStructure = async (id: string, body: PatchStructure
 
   await checkIfUserIsAuthorizedToModifyStructure(id, user);
 
-  logger.info("[modifyUserRoleInStructure] updating stucture", {
+  logger.info("[modifyUserMembershipInStructure] updating stucture", {
     id,
   });
   let structure;
@@ -56,11 +60,11 @@ export const modifyUserRoleInStructure = async (id: string, body: PatchStructure
     const adminRole = await getRoleByName(RoleName.ADMIN);
     const userIsAdmin = (user.roles || []).some((x) => x && x.toString() === adminRole._id.toString());
     if (!user || !structureData) {
-      logger.error("[modifyUserRoleInStructure] mail not sent");
+      logger.error("[modifyUserMembershipInStructure] mail not sent");
     } else if (userIsAdmin) {
-      logger.info("[modifyUserRoleInStructure] user is admin, mail not sent");
+      logger.info("[modifyUserMembershipInStructure] user is admin, mail not sent");
     } else {
-      await sendNewReponsableMailService({
+      await sendNewMemberMailService({
         userId: user._id,
         email: user.email,
         firstName: user.firstName || "",


### PR DESCRIPTION
- meilleur nommage étant donné qu'on ne gère plus de rôles pour le membre d'une structure
- mise à jour de la route /roles ==> /membres