### PR TITLE
RI74: Mise en place d'axe-core dans les tests

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,3 +33,9 @@ jobs:
 
       - name: Lint, Check Types and Test
         run: yarn turbo lint check:types test && yarn lint:style
+
+      - name: Lint for accessibility issues
+        uses: dequelabs/axe-linter-action@v1
+        with:
+          api_key: ${{ secrets.AXE_LINTER_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,8 @@
     "github.vscode-pull-request-github",
     "lokalise.i18n-ally",
     "esbenp.prettier-vscode",
-    "dgeibi.alias-tool"
+    "dgeibi.alias-tool",
+    "deque-systems.vscode-axe-linter"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/apps/mobile/axe-linter.yml
+++ b/apps/mobile/axe-linter.yml
@@ -1,0 +1,2 @@
+global-libraries:
+  - "react-native" # Run React Native rules

--- a/axe-linter.yml
+++ b/axe-linter.yml
@@ -1,0 +1,2 @@
+rules:
+  heading-order: false # Disable this rule


### PR DESCRIPTION
- installation et configuration minimale de l'extension VS Code [axe Acessibility Linter](https://marketplace.visualstudio.com/items?itemName=deque-systems.vscode-axe-linter)
- ajout d'une étape de linting accessibility utilisant [l'axe DevTools Linter GitHub Action](https://docs.deque.com/linter/4.0.0/en/axe-linter-github-action)

⚠️ L'offre DevTools Linter est payante. Nous bénéficions d'un trial de 14 jours, mais malheureusement il y a peu de clarté sur le pricing ⚠️ 
