### PR TITLE
RI-28: D'autres éléments à revoir

### DIFF
--- a/apps/client/src/components/Pages/recherche/SearchHeader/hooks.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchHeader/hooks.tsx
@@ -135,7 +135,8 @@ export const useLanguagesOptions = () => {
 
   const { t } = useTranslation();
 
-  const languages = useSelector(allLanguesSelector);
+  const allLangues = useSelector(allLanguesSelector);
+  const languages = allLangues.filter((langue) => langue.i18nCode !== "fr");
   const getTranslatedLanguage = useMemo(() => {
     return (langueFr: string) => t(`Languages.${langueFr}`, langueFr) as string;
   }, [t]);

--- a/apps/client/src/components/Pages/recherche/SearchHeader/hooks.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchHeader/hooks.tsx
@@ -4,13 +4,20 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { getMatchingAgeOptions } from "~/lib/recherche/filterContents";
+import { filterDispositifs } from "~/lib/recherche/queryContents";
+import { FilterKey } from "~/lib/recherche/resultsDisplayRules";
+import { activeDispositifsSelector } from "~/services/ActiveDispositifs/activeDispositifs.selector";
 import { allLanguesSelector } from "~/services/Langue/langue.selectors";
-import { searchResultsSelector } from "~/services/SearchResults/searchResults.selector";
+import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
 
-const useFilteredDocs = () => {
-  const { matches: dispositifs } = useSelector(searchResultsSelector);
+const useDocsToFilter = (skip: FilterKey) => {
+  const dispositifs = useSelector(activeDispositifsSelector);
+  const query = useSelector(searchQuerySelector);
+  const matches = useMemo(() => {
+    return filterDispositifs(query, dispositifs, false, skip);
+  }, [query, dispositifs, skip]);
 
-  return dispositifs;
+  return matches;
 };
 
 /**
@@ -18,7 +25,7 @@ const useFilteredDocs = () => {
  * @returns
  */
 export const useStatusOptions = () => {
-  const docs = useFilteredDocs();
+  const docs = useDocsToFilter("status");
 
   const counts = useMemo(() => {
     return _(docs)
@@ -38,7 +45,7 @@ export const useStatusOptions = () => {
 };
 
 export const usePublicOptions = () => {
-  const docs = useFilteredDocs();
+  const docs = useDocsToFilter("public");
 
   const counts = useMemo(() => {
     return _(docs)
@@ -58,7 +65,7 @@ export const usePublicOptions = () => {
 };
 
 export const useAgeOptions = () => {
-  const docs = useFilteredDocs();
+  const docs = useDocsToFilter("age");
 
   const counts = useMemo(() => {
     return _(docs)
@@ -78,7 +85,7 @@ export const useAgeOptions = () => {
 };
 
 export const useFrenchLevelOptions = () => {
-  const docs = useFilteredDocs();
+  const docs = useDocsToFilter("frenchLevel");
 
   const counts = useMemo(() => {
     return _(docs)
@@ -124,7 +131,7 @@ export const useFrenchLevelOptions = () => {
 };
 
 export const useLanguagesOptions = () => {
-  const docs = useFilteredDocs();
+  const docs = useDocsToFilter("language");
 
   const { t } = useTranslation();
 

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
@@ -1,11 +1,11 @@
 import { GetDispositifsResponse, Id } from "@refugies-info/api-types";
 import debounce from "lodash/debounce";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import SearchButton from "~/components/UI/SearchButton";
 import { useSearchEventName, useWindowSize } from "~/hooks";
 import { cls } from "~/lib/classname";
-import { queryDispositifsWithoutThemes } from "~/lib/recherche/queryContents";
+import { filterDispositifs, queryDispositifsWithoutThemes } from "~/lib/recherche/queryContents";
 import { sortThemes } from "~/lib/sortThemes";
 import { Event } from "~/lib/tracking";
 import { fetchActiveDispositifsActionsCreator } from "~/services/ActiveDispositifs/activeDispositifs.actions";
@@ -50,7 +50,10 @@ const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
   const sortedThemes = themes.sort(sortThemes);
   const needs = useSelector(needsSelector);
   const query = useSelector(searchQuerySelector);
-  const allDispositifs = useSelector(activeDispositifsSelector);
+  const dispositifs = useSelector(activeDispositifsSelector);
+  const matches = useMemo(() => {
+    return filterDispositifs(query, dispositifs, false, "theme");
+  }, [query, dispositifs]);
   const initialTheme = getInitialTheme(needs, sortedThemes, query.needs, query.themes, mobile);
   const eventName = useSearchEventName();
 
@@ -73,10 +76,10 @@ const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
   const isDispositifsLoading = useSelector(isLoadingSelector(LoadingStatusKey.FETCH_ACTIVE_DISPOSITIFS));
   const hasDispositifsError = useSelector(hasErroredSelector(LoadingStatusKey.FETCH_ACTIVE_DISPOSITIFS));
   useEffect(() => {
-    if (allDispositifs.length === 0 && !isDispositifsLoading && !hasDispositifsError) {
+    if (matches.length === 0 && !isDispositifsLoading && !hasDispositifsError) {
       dispatch(fetchActiveDispositifsActionsCreator());
     }
-  }, [allDispositifs.length, isDispositifsLoading, hasDispositifsError, dispatch]);
+  }, [matches.length, isDispositifsLoading, hasDispositifsError, dispatch]);
 
   // reset selected theme when popup opens
   useEffect(() => {
@@ -93,7 +96,7 @@ const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
   const languei18nCode = useSelector(languei18nSelector);
   useEffect(() => {
     if (isOpen) {
-      debouncedQuery(query, allDispositifs, languei18nCode, (dispositifs) => {
+      debouncedQuery(query, matches, languei18nCode, (dispositifs) => {
         const newNbDispositifsByNeed: Record<string, number> = {};
         const newNbDispositifsByTheme: Record<string, number> = {};
         for (const dispositif of dispositifs) {
@@ -113,7 +116,7 @@ const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
         setNbDispositifsByNeed(newNbDispositifsByNeed);
       });
     }
-  }, [query, allDispositifs, needs, sortedThemes, mobile, languei18nCode, isOpen]);
+  }, [query, matches, needs, sortedThemes, mobile, languei18nCode, isOpen]);
 
   return (
     <ThemeMenuContext.Provider

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
@@ -98,18 +98,18 @@ const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
   useEffect(() => {
     if (isOpen) {
       debouncedQuery(query, matches, languei18nCode, (dispositifs) => {
-        const countDispositifsByTheme = _(dispositifs)
+        const nbDispositifsByTheme = _(dispositifs)
           .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
           .countBy((dispositif) => dispositif.theme?.toString())
           .value();
 
-        const countDispositifsByNeed = _(dispositifs)
+        const nbDispositifsByNeed = _(dispositifs)
           .flatMap((dispositif) => dispositif.needs || [])
           .countBy()
           .value();
 
-        setNbDispositifsByTheme(countDispositifsByTheme);
-        setNbDispositifsByNeed(countDispositifsByNeed);
+        setNbDispositifsByTheme(nbDispositifsByTheme);
+        setNbDispositifsByNeed(nbDispositifsByNeed);
       });
     }
   }, [query, matches, needs, sortedThemes, mobile, languei18nCode, isOpen]);

--- a/apps/client/src/lib/recherche/queryContents.ts
+++ b/apps/client/src/lib/recherche/queryContents.ts
@@ -63,24 +63,29 @@ export const getDefaultSortOption = (query: SearchQuery): SortOptions => {
  * @param secondaryThemes - boolean. Use the primary or secondary theme to filter.
  * @returns - list of dispositifs
  */
-const filterDispositifs = (
+export const filterDispositifs = (
   query: SearchQuery,
   dispositifs: GetDispositifsResponse[],
   secondaryThemes: boolean,
+  skip: FilterKey | undefined = undefined,
 ): GetDispositifsResponse[] => {
   const filterKeys = buildFilterKeys(query);
   const rule = getDisplayRule(query.type, filterKeys, query.sort);
 
   const filteredDispositifs = dispositifs
-    .filter((dispositif) => filterByThemeOrNeed(dispositif, query.themes, query.needs, secondaryThemes))
-    .filter((dispositif) => filterByLocations(dispositif, query.departments))
-    .filter((dispositif) => filterByAge(dispositif, query.age))
-    .filter((dispositif) => filterByFrenchLevel(dispositif, query.frenchLevel))
-    .filter((dispositif) => filterByLanguage(dispositif, query.language))
-    .filter((dispositif) => filterByPublic(dispositif, query.public))
-    .filter((dispositif) => filterByStatus(dispositif, query.status));
+    .filter(
+      (dispositif) => skip === "theme" || filterByThemeOrNeed(dispositif, query.themes, query.needs, secondaryThemes),
+    )
+    .filter((dispositif) => skip === "location" || filterByLocations(dispositif, query.departments))
+    .filter((dispositif) => skip === "age" || filterByAge(dispositif, query.age))
+    .filter((dispositif) => skip === "frenchLevel" || filterByFrenchLevel(dispositif, query.frenchLevel))
+    .filter((dispositif) => skip === "language" || filterByLanguage(dispositif, query.language))
+    .filter((dispositif) => skip === "public" || filterByPublic(dispositif, query.public))
+    .filter((dispositif) => skip === "status" || filterByStatus(dispositif, query.status));
 
-  return rule?.sortFunction ? [...filteredDispositifs].sort((a, b) => rule.sortFunction(a, b)) : filteredDispositifs;
+  return rule?.sortFunction && !!skip
+    ? [...filteredDispositifs].sort((a, b) => rule.sortFunction(a, b))
+    : filteredDispositifs;
 };
 
 const filterSuggestions = (

--- a/apps/client/src/lib/recherche/resultsDisplayRules.ts
+++ b/apps/client/src/lib/recherche/resultsDisplayRules.ts
@@ -3,7 +3,7 @@ import _ from "lodash";
 import { SortOptions, TypeOptions } from "~/data/searchFilters";
 import { noSort, sortByDate, sortByLocation, sortByTheme, sortByView } from "~/lib/recherche/sortContents";
 
-export type FilterKey = "age" | "frenchLevel" | "keywords" | "location" | "public" | "status" | "theme";
+export type FilterKey = "age" | "frenchLevel" | "keywords" | "language" | "location" | "public" | "status" | "theme";
 export type RuleKey = SortOptions | "suggestions";
 export type TabKey = TypeOptions;
 


### PR DESCRIPTION
- mode de calcul du nombre de fiches dans les éléments des filtres ne tient pas compte du filtre en question
- supprimer le français du menu "Traduit en"
- ne pas tenir compte des thèmes secondaires dans le comptage du filtre Thèmes
- simplifier l'algorithme de comptage en utilisant lodash