### PR TITLE
Fix useEffect loop on user structure dashboard page

### DIFF
--- a/apps/client/src/components/Backend/screens/UserStructure/UserStructure.component.tsx
+++ b/apps/client/src/components/Backend/screens/UserStructure/UserStructure.component.tsx
@@ -46,7 +46,7 @@ export const UserStructureComponent = (props: Props) => {
   }, []);
 
   useEffect(() => {
-    if (userStructure) {
+    if (userStructure?._id) {
       dispatch(
         fetchUserStructureActionCreator({
           structureId: userStructure._id,
@@ -55,7 +55,7 @@ export const UserStructureComponent = (props: Props) => {
       );
     }
     window.scrollTo(0, 0);
-  }, [dispatch, userStructure]);
+  }, [dispatch, , userStructure?._id]);
 
   const isLoadingFetch = useSelector(isLoadingSelector(LoadingStatusKey.FETCH_USER_STRUCTURE));
   const isLoadingUpdate = useSelector(isLoadingSelector(LoadingStatusKey.UPDATE_USER_STRUCTURE));


### PR DESCRIPTION
@kaaloo I don't know why but it seems that on load userStructure is set but without an _id.

In that case the dispatch function is triggered and the component is re-rendered, and then the dispatch is triggered and the component...

I managed to make it work by testing "userStructure?._id" instead of "userStructure", sounds good to you ?

It also works when I remove totally the useEffect (and the page loads way faster without it) but I'm afraid to miss something :)