### PR TITLE
ci: :green_heart: Only run migrations when updating the backend

### DIFF
--- a/.github/workflows/migrate_production.yaml
+++ b/.github/workflows/migrate_production.yaml
@@ -3,8 +3,6 @@ name: Migrate Production
 on:
   push:
     branches:
-      - master-mobile
-      - master-frontend
       - master-backend
   workflow_dispatch:
 

--- a/.github/workflows/migrate_staging.yaml
+++ b/.github/workflows/migrate_staging.yaml
@@ -3,8 +3,6 @@ name: Migrate Staging
 on:
   push:
     branches:
-      - staging-mobile
-      - staging-frontend
       - staging-backend
   workflow_dispatch:
 


### PR DESCRIPTION
Migrations were being run on other branches but only the backend branches connect directly to the database.