### PR TITLE
Fix: Search results suggested title size

### DIFF
--- a/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.module.scss
+++ b/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.module.scss
@@ -77,8 +77,7 @@
 }
 
 .no_results_other {
-  @include dsfr-text("h2");
+  @include dsfr-text("h3");
 
   text-align: left;
-  margin-bottom: u(10);
 }

--- a/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
@@ -133,7 +133,9 @@ const SearchResults = (props: Props) => {
         )}
         {showSuggestions && filteredResults.suggestions.length > 0 && (
           <div>
-            <h2>{t("Recherche.suggestedTitle", "Ces fiches peuvent aussi vous intéresser")}</h2>
+            <h2 className={styles.no_results_other}>
+              {t("Recherche.suggestedTitle", "Ces fiches peuvent aussi vous intéresser")}
+            </h2>
             <div className={styles.results}>
               {filteredResults.suggestions.map((d) => {
                 if (typeof d === "string") return null; // d can be a string if it comes from generateLightResults


### PR DESCRIPTION
@kaaloo I reduced the font size for the H2 as requested. 
BUT :) 
It seems that the sass mixin with the DSFR font sizes are outdated (it doesn't fit to the figma's sizes). 
It can work as a quick fix but we need to address this issue ASAP.
@matthieu-fesselier I guess the impact is huge if we update the sizes globally ?