### PR TITLE
fix(client): :bug: Tenir compte des résultats d'algolia dans les comptes des filtres

### DIFF
--- a/apps/client/src/components/Pages/recherche/ResultsFilter/ResultsFilter.tsx
+++ b/apps/client/src/components/Pages/recherche/ResultsFilter/ResultsFilter.tsx
@@ -11,11 +11,7 @@ import { cls } from "~/lib/classname";
 import { getDefaultSortOption, getDisplayRuleForQuery } from "~/lib/recherche/queryContents";
 import { Event } from "~/lib/tracking";
 import { addToQueryActionCreator } from "~/services/SearchResults/searchResults.actions";
-import {
-  searchQuerySelector,
-  searchResultsSelector,
-  themesDisplayedSelector,
-} from "~/services/SearchResults/searchResults.selector";
+import { searchQuerySelector, searchResultsSelector } from "~/services/SearchResults/searchResults.selector";
 import styles from "./ResultsFilter.module.scss";
 
 type TranslationFunction = (key: string, options?: object) => string;
@@ -25,7 +21,6 @@ const ResultsFilter = (): React.ReactNode => {
 
   const dispatch = useDispatch();
   const query = useSelector(searchQuerySelector);
-  const themesDisplayed = useSelector(themesDisplayedSelector);
   const filteredResult = useSelector(searchResultsSelector);
   const [open, setOpen] = useState(false);
   const eventName = useSearchEventName();

--- a/apps/client/src/components/Pages/recherche/SearchHeader/hooks.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchHeader/hooks.tsx
@@ -8,14 +8,15 @@ import { filterDispositifs } from "~/lib/recherche/queryContents";
 import { FilterKey } from "~/lib/recherche/resultsDisplayRules";
 import { activeDispositifsSelector } from "~/services/ActiveDispositifs/activeDispositifs.selector";
 import { allLanguesSelector } from "~/services/Langue/langue.selectors";
-import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
+import { searchQuerySelector, searchResultsSelector } from "~/services/SearchResults/searchResults.selector";
 
 const useDocsToFilter = (skip: FilterKey) => {
   const dispositifs = useSelector(activeDispositifsSelector);
   const query = useSelector(searchQuerySelector);
+  const { algolia } = useSelector(searchResultsSelector);
   const matches = useMemo(() => {
-    return filterDispositifs(query, dispositifs, false, skip);
-  }, [query, dispositifs, skip]);
+    return filterDispositifs(query, algolia || dispositifs, false, skip);
+  }, [query, algolia, dispositifs, skip]);
 
   return matches;
 };

--- a/apps/client/src/lib/recherche/queryContents.ts
+++ b/apps/client/src/lib/recherche/queryContents.ts
@@ -260,7 +260,7 @@ export const queryDispositifsWithAlgolia = async (
   allNeeds: GetNeedResponse[],
 ): Promise<Results> => {
   const filteredDispositifsByAlgolia = await queryOnAlgolia(query.search, dispositifs, locale);
-  return queryDispositifs(query, filteredDispositifsByAlgolia, allNeeds);
+  return { ...queryDispositifs(query, filteredDispositifsByAlgolia, allNeeds), algolia: filteredDispositifsByAlgolia };
 };
 
 /**

--- a/apps/client/src/services/SearchResults/searchResults.reducer.ts
+++ b/apps/client/src/services/SearchResults/searchResults.reducer.ts
@@ -5,6 +5,7 @@ import { getDisplayRuleForQuery } from "~/lib/recherche/queryContents";
 import { SearchResultsActions } from "./searchResults.actions";
 
 export type Results = {
+  algolia?: SimpleDispositif[];
   matches: SimpleDispositif[];
   suggestions: SimpleDispositif[];
 };


### PR DESCRIPTION
Ce PR permet de garder les résultats d'algolia dans le résultats de recherche.  De cette façon les résultats d'algolia peuvent servir si besoin pour calculer le compte des documents pour les différents filtres.