### PR TITLE
feat(server): :sparkles: prevent translation for webonly content

### DIFF
--- a/apps/server/src/workflows/dispositif/getDispositifsWithTranslationAvancement/getDispositifsWithTranslationAvancement.ts
+++ b/apps/server/src/workflows/dispositif/getDispositifsWithTranslationAvancement/getDispositifsWithTranslationAvancement.ts
@@ -46,6 +46,7 @@ export const getDispositifsWithTranslationAvancement = async (locale: Languages)
     nbMots: 1,
     translations: 1,
     typeContenu: 1,
+    webOnly: 1,
   });
 
   const traductions = await getTraductionsByLanguage(locale, {
@@ -61,6 +62,7 @@ export const getDispositifsWithTranslationAvancement = async (locale: Languages)
   let results: GetDispositifsWithTranslationAvancementResponse[] = [];
 
   activeDispositifs.forEach((dispositif: Dispositif) => {
+    if (dispositif.webOnly) return; // do not translate webonly content
     const correspondingTrads = traductions.filter((trad) => trad.dispositifId.toString() === dispositif._id.toString());
 
     const lastTradUpdatedAt = Math.max(


### PR DESCRIPTION
Pour ce ticket, j'ai fait le choix d'uniquement retirer la fiche de la liste des fiches à traduire. 

La page de traduction reste accessible (dans le cas où un admin voudrait quand même s'en servir) mais le lien n'est présent nul part, pas de sécurité côté serveur pour empêcher d'enregistrer une traduction non plus. 