### PR TITLE
RI-430: l'ajout en favori remet le filtre departement par defaut

### DIFF
--- a/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
@@ -539,12 +539,12 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
             </div>
           </div>
           <button
-            class="btn favorite btn btn-secondary"
-            title="Dispositif.addToFavorites"
+            class="btn active favorite btn btn-secondary"
+            title="Dispositif.removeFromFavorites"
             type="button"
           >
             <i
-              class="fr-icon-star-line"
+              class="fr-icon-star-fill"
             />
           </button>
         </div>
@@ -660,12 +660,12 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
             </div>
           </div>
           <button
-            class="btn favorite btn btn-secondary"
-            title="Dispositif.addToFavorites"
+            class="btn active favorite btn btn-secondary"
+            title="Dispositif.removeFromFavorites"
             type="button"
           >
             <i
-              class="fr-icon-star-line"
+              class="fr-icon-star-fill"
             />
           </button>
         </div>
@@ -778,12 +778,12 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
             </div>
           </div>
           <button
-            class="btn favorite btn btn-secondary"
-            title="Dispositif.addToFavorites"
+            class="btn active favorite btn btn-secondary"
+            title="Dispositif.removeFromFavorites"
             type="button"
           >
             <i
-              class="fr-icon-star-line"
+              class="fr-icon-star-fill"
             />
           </button>
         </div>

--- a/apps/client/src/components/Layout/AutoAddFavorite/AutoAddFavorite.tsx
+++ b/apps/client/src/components/Layout/AutoAddFavorite/AutoAddFavorite.tsx
@@ -7,7 +7,7 @@ import Toast from "~/components/UI/Toast";
 import { useAuth } from "~/hooks";
 import { isContentFavorite } from "~/hooks/useFavorites";
 import { fetchUserActionCreator } from "~/services/User/user.actions";
-import { userDetailsSelector } from "~/services/User/user.selectors";
+import { userFavoritesSelector } from "~/services/UserFavoritesInLocale/UserFavoritesInLocale.selectors";
 import API from "~/utils/API";
 
 const AutoAddFavorite = () => {
@@ -16,12 +16,12 @@ const AutoAddFavorite = () => {
   const dispatch = useDispatch();
   const { isAuth } = useAuth();
   const favoriteContentId = router.query.addFavorite as string;
-  const userDetails = useSelector(userDetailsSelector);
+  const favorites = useSelector(userFavoritesSelector);
   const [showFavoriteToast, setShowFavoriteToast] = useState<boolean>(false);
 
   useEffect(() => {
-    if (favoriteContentId && isAuth && userDetails) {
-      const isAlreadyFavorite = isContentFavorite(userDetails, favoriteContentId);
+    if (favoriteContentId && isAuth && favorites) {
+      const isAlreadyFavorite = isContentFavorite(favorites, favoriteContentId);
       if (isAlreadyFavorite) return;
 
       API.addUserFavorite({ dispositifId: favoriteContentId }).then(() => {
@@ -35,7 +35,7 @@ const AutoAddFavorite = () => {
       params.delete("addFavorite");
       router.replace({ pathname, query: params.toString() }, undefined, { shallow: true });
     }
-  }, [favoriteContentId, isAuth, userDetails, dispatch, router]);
+  }, [favoriteContentId, isAuth, favorites, dispatch, router]);
 
   return (
     <Toast open={showFavoriteToast} closeCallback={() => setShowFavoriteToast(false)}>

--- a/apps/client/src/hooks/useFavorites.ts
+++ b/apps/client/src/hooks/useFavorites.ts
@@ -1,18 +1,29 @@
 import { Id, SimpleDispositif } from "@refugies-info/api-types";
 import { useRouter } from "next/router";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchUserFavoritesActionCreator } from "~/services/UserFavoritesInLocale/UserFavoritesInLocale.actions";
 import { userFavoritesSelector } from "~/services/UserFavoritesInLocale/UserFavoritesInLocale.selectors";
 import API from "~/utils/API";
 import useAuth from "./useAuth";
 
+/**
+ * Helper function to check if a content is in the user's favorites list
+ * @param favorites List of user's favorite content
+ * @param id Content ID to check
+ * @returns boolean indicating if the content is favorited
+ */
 export const isContentFavorite = (favorites: SimpleDispositif[], id: Id | null) => {
   if (id === null) return false;
   if (favorites.length === 0) return false;
   return !!favorites.find((c) => c._id === id);
 };
 
+/**
+ * Hook to manage user's favorites for a specific content
+ * @param contentId ID of the content to check/manage favorite status
+ * @returns Object containing favorite status and functions to add/remove from favorites
+ */
 const useFavorites = (contentId: Id | null) => {
   const favorites = useSelector(userFavoritesSelector);
   const router = useRouter();
@@ -21,12 +32,23 @@ const useFavorites = (contentId: Id | null) => {
   const dispatch = useDispatch();
   const { isAuth } = useAuth();
 
+  // Fetch favorites when the hook is initialized and user is authenticated
+  // This ensures favorites are loaded before the selector is used in the UI
+  useEffect(() => {
+    if (isAuth) {
+      dispatch(fetchUserFavoritesActionCreator(locale));
+    }
+  }, [dispatch, locale, isAuth]);
+
+  // Memoized computation of whether the current content is favorited
   const isFavorite = useMemo(() => isContentFavorite(favorites, contentId), [favorites, contentId]);
 
+  // Callback to refresh favorites after successful API operations
   const successCallback = useCallback(() => {
     dispatch(fetchUserFavoritesActionCreator(locale));
   }, [dispatch, locale]);
 
+  // Add content to favorites if authenticated and not already favorited
   const addToFavorites = useCallback(() => {
     if (isAuth) {
       if (isFavorite || !contentId) return;
@@ -34,6 +56,7 @@ const useFavorites = (contentId: Id | null) => {
     }
   }, [contentId, isFavorite, successCallback, isAuth]);
 
+  // Remove content from favorites if authenticated and currently favorited
   const deleteFromFavorites = useCallback(() => {
     if (isAuth) {
       if (!isFavorite || !contentId) return;

--- a/apps/client/src/hooks/useFavorites.ts
+++ b/apps/client/src/hooks/useFavorites.ts
@@ -1,47 +1,45 @@
-import { GetUserInfoResponse, Id } from "@refugies-info/api-types";
+import { Id, SimpleDispositif } from "@refugies-info/api-types";
 import { useRouter } from "next/router";
 import { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchUserActionCreator } from "~/services/User/user.actions";
-import { userDetailsSelector } from "~/services/User/user.selectors";
 import { fetchUserFavoritesActionCreator } from "~/services/UserFavoritesInLocale/UserFavoritesInLocale.actions";
+import { userFavoritesSelector } from "~/services/UserFavoritesInLocale/UserFavoritesInLocale.selectors";
 import API from "~/utils/API";
 import useAuth from "./useAuth";
 
-export const isContentFavorite = (userDetails: GetUserInfoResponse | null, id: Id | null) => {
+export const isContentFavorite = (favorites: SimpleDispositif[], id: Id | null) => {
   if (id === null) return false;
-  if ((userDetails?.favorites || []).length === 0) return false;
-  return !!(userDetails?.favorites || []).find((c) => c.dispositifId === id);
+  if (favorites.length === 0) return false;
+  return !!favorites.find((c) => c._id === id);
 };
 
 const useFavorites = (contentId: Id | null) => {
-  const userDetails = useSelector(userDetailsSelector);
+  const favorites = useSelector(userFavoritesSelector);
   const router = useRouter();
   const locale = useMemo(() => router.locale || "fr", [router.locale]);
 
   const dispatch = useDispatch();
   const { isAuth } = useAuth();
 
-  const isFavorite = useMemo(() => isContentFavorite(userDetails, contentId), [userDetails, contentId]);
+  const isFavorite = useMemo(() => isContentFavorite(favorites, contentId), [favorites, contentId]);
 
   const successCallback = useCallback(() => {
-    dispatch(fetchUserActionCreator());
     dispatch(fetchUserFavoritesActionCreator(locale));
   }, [dispatch, locale]);
 
   const addToFavorites = useCallback(() => {
-    if (isAuth && userDetails) {
+    if (isAuth) {
       if (isFavorite || !contentId) return;
       API.addUserFavorite({ dispositifId: contentId.toString() }).then(successCallback);
     }
-  }, [userDetails, contentId, isFavorite, successCallback, isAuth]);
+  }, [contentId, isFavorite, successCallback, isAuth]);
 
   const deleteFromFavorites = useCallback(() => {
-    if (isAuth && userDetails) {
+    if (isAuth) {
       if (!isFavorite || !contentId) return;
       API.deleteUserFavorites({ dispositifId: contentId.toString() }).then(successCallback);
     }
-  }, [userDetails, contentId, isFavorite, successCallback, isAuth]);
+  }, [contentId, isFavorite, successCallback, isAuth]);
 
   return { isFavorite, addToFavorites, deleteFromFavorites };
 };

--- a/apps/client/src/hooks/useFavorites.ts
+++ b/apps/client/src/hooks/useFavorites.ts
@@ -1,6 +1,6 @@
 import { GetUserInfoResponse, Id } from "@refugies-info/api-types";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { fetchUserActionCreator } from "~/services/User/user.actions";
 import { userDetailsSelector } from "~/services/User/user.selectors";
@@ -22,11 +22,7 @@ const useFavorites = (contentId: Id | null) => {
   const dispatch = useDispatch();
   const { isAuth } = useAuth();
 
-  const [isFavorite, setIsFavorite] = useState(isContentFavorite(userDetails, contentId));
-
-  useEffect(() => {
-    setIsFavorite(isContentFavorite(userDetails, contentId));
-  }, [userDetails, contentId]);
+  const isFavorite = useMemo(() => isContentFavorite(userDetails, contentId), [userDetails, contentId]);
 
   const successCallback = useCallback(() => {
     dispatch(fetchUserActionCreator());


### PR DESCRIPTION
Reprendre le useFavorites hook pour:
- éviter d'utiliser un état local
- ne pas déclencher le raffraichiseement de l'état utilisateur
- initializer l'état des favorites
- mise à jour des autres usages