### PR TITLE
fix(client): :bug: Exclude online content from dispositif tabs

### DIFF
--- a/apps/client/src/lib/recherche/filterContents.ts
+++ b/apps/client/src/lib/recherche/filterContents.ts
@@ -190,7 +190,8 @@ export const filterByType = ({ typeContenu, metadatas }: SimpleDispositif, type:
     case "demarche":
       return typeContenu === "demarche";
     case "dispositif":
-      return typeContenu === "dispositif";
+      // Exclude online resources from dispositif tab
+      return typeContenu === "dispositif" && metadatas?.location !== "online";
     case "ressource":
       return metadatas?.location === "online";
   }


### PR DESCRIPTION
# Remove Online Resources from Dispositifs Tab

## Changes Made
- Modified the [filterByType](cci:1://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/lib/recherche/filterContents.ts:185:0-197:2) function in [filterContents.ts](cci:7://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/lib/recherche/filterContents.ts:0:0-0:0) to exclude online resources from the "Dispositifs" tab
- Added condition `metadatas?.location !== "online"` to the "dispositif" case
- Maintained existing functionality for other tabs (Online Resources, All Cards)

## Technical Details
The filtering logic now works as follows:
- "all" tab: Shows all content types (unchanged)
- "demarche" tab: Shows only démarches (unchanged)
- "dispositif" tab: Shows only dispositifs that are NOT online resources (modified)
- "ressource" tab: Shows only online resources (unchanged)

## Testing
The changes can be verified by:
1. Checking that online resources are not visible in the Dispositifs tab
2. Verifying that online resources still appear in the Online Resources tab
3. Confirming that online resources are visible in the All Cards tab

## Related Issue
Closes RI-435