### PR TITLE
RI-424: fix(client): :bug: Ne pas effacer le mot clé de recherche

### DIFF
--- a/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
@@ -15,7 +15,7 @@ import DispositifCard from "~/components/UI/DispositifCard";
 import { useWindowSize } from "~/hooks";
 import { filterByType } from "~/lib/recherche/filterContents";
 import { getDisplayRuleForQuery } from "~/lib/recherche/queryContents";
-import { resetQueryActionCreator } from "~/services/SearchResults/searchResults.actions";
+import { resetFiltersActionCreator } from "~/services/SearchResults/searchResults.actions";
 import styles from "./SearchResults.module.scss";
 
 export const MATCHES_PER_PAGE = 24;
@@ -93,7 +93,7 @@ const SearchResults = (props: Props) => {
 
               <Button
                 priority="tertiary"
-                onClick={() => dispatch(resetQueryActionCreator())}
+                onClick={() => dispatch(resetFiltersActionCreator())}
                 iconId="ri-eraser-line"
                 iconPosition="right"
               >

--- a/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
@@ -93,7 +93,7 @@ const SearchResults = (props: Props) => {
 
               <Button
                 priority="tertiary"
-                onClick={() => dispatch(resetFiltersActionCreator())}
+                onClick={() => dispatch(resetFiltersActionCreator(query.search))}
                 iconId="ri-eraser-line"
                 iconPosition="right"
               >

--- a/apps/client/src/services/SearchResults/searchResults.actions.ts
+++ b/apps/client/src/services/SearchResults/searchResults.actions.ts
@@ -21,6 +21,25 @@ export const resetQueryActionCreator = () =>
     type: "all",
   });
 
-const actions = { setSearchResultsActionCreator, setNoResultsActionCreator, addToQueryActionCreator };
+export const resetFiltersActionCreator = () =>
+  action(ADD_TO_QUERY, {
+    departments: [],
+    themes: [],
+    needs: [],
+    age: [],
+    frenchLevel: [],
+    language: [],
+    public: [],
+    status: [],
+    sort: "default",
+    type: "all",
+  });
+
+const actions = {
+  setSearchResultsActionCreator,
+  setNoResultsActionCreator,
+  addToQueryActionCreator,
+  resetFiltersActionCreator,
+};
 
 export type SearchResultsActions = ActionType<typeof actions>;

--- a/apps/client/src/services/SearchResults/searchResults.actions.ts
+++ b/apps/client/src/services/SearchResults/searchResults.actions.ts
@@ -21,8 +21,9 @@ export const resetQueryActionCreator = () =>
     type: "all",
   });
 
-export const resetFiltersActionCreator = () =>
+export const resetFiltersActionCreator = (search: string) =>
   action(ADD_TO_QUERY, {
+    search,
     departments: [],
     themes: [],
     needs: [],

--- a/apps/client/src/services/SearchResults/searchResults.actions.ts
+++ b/apps/client/src/services/SearchResults/searchResults.actions.ts
@@ -6,20 +6,6 @@ import { Results, SearchQuery } from "./searchResults.reducer";
 export const setSearchResultsActionCreator = (results: Results) => action(SET_RESULTS, results);
 export const setNoResultsActionCreator = (results: SimpleDispositif[]) => action(SET_NO_RESULTS, results);
 export const addToQueryActionCreator = (query: Partial<SearchQuery>) => action(ADD_TO_QUERY, query);
-export const resetQueryActionCreator = () =>
-  action(ADD_TO_QUERY, {
-    search: "",
-    departments: [],
-    themes: [],
-    needs: [],
-    age: [],
-    frenchLevel: [],
-    language: [],
-    public: [],
-    status: [],
-    sort: "default",
-    type: "all",
-  });
 
 export const resetFiltersActionCreator = (search: string) =>
   action(ADD_TO_QUERY, {

--- a/apps/client/src/services/SearchResults/searchResults.actions.ts
+++ b/apps/client/src/services/SearchResults/searchResults.actions.ts
@@ -20,7 +20,7 @@ export const resetFiltersActionCreator = (search: string) =>
     status: [],
     sort: "default",
     type: "all",
-  });
+  } as SearchQuery);
 
 const actions = {
   setSearchResultsActionCreator,


### PR DESCRIPTION
# 🔍 Correction du comportement du bouton "Effacer les filtres"

## Problème
Actuellement, lorsqu'un utilisateur clique sur le bouton "Effacer les filtres" dans la page de recherche sans résultats, le bouton efface non seulement les filtres mais aussi le mot-clé de recherche. Ce comportement n'est pas optimal pour l'expérience utilisateur.

## Solution
- Création d'une nouvelle action [resetFiltersActionCreator](cci:1://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/services/SearchResults/searchResults.actions.ts:24:0-36:5) qui prend en paramètre le mot-clé de recherche actuel
- L'action réinitialise tous les filtres tout en préservant le mot-clé de recherche passé en paramètre
- Mise à jour du composant SearchResults pour passer le mot-clé de recherche actuel lors de la réinitialisation des filtres

## Impact
Les utilisateurs pourront maintenant effacer leurs filtres tout en conservant leur mot-clé de recherche, ce qui améliore l'expérience de recherche sur la plateforme.
