### PR TITLE
RI-436: fix(client): :lipstick: Amélioration des marges dans le menu des thèmes sur mobile

### DIFF
--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.mobile.module.scss
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.mobile.module.scss
@@ -11,7 +11,7 @@
     transition: background-color 0.1s ease-out;
     will-change: background-color;
     background-color: var(--accordion-color);
-    padding: u(2) 0;
+    padding: u(2) u(4);
 
     &:hover {
       background-color: var(--accordion-color) !important;
@@ -69,6 +69,7 @@
   .content {
     overflow: hidden;
     padding-block: u(2);
+    padding-inline: u(4);
     position: relative;
 
     &[data-state="open"] {


### PR DESCRIPTION
# Amélioration des marges dans le menu des thèmes sur mobile

## Problème
Le texte dans le menu des thèmes était trop proche des bords de l'écran sur mobile, ce qui nuisait à la lisibilité.

## Solution
Ajout de marges horizontales dans le menu accordéon :
- Padding horizontal de u(4) sur le bouton trigger
- Padding horizontal de u(4) sur le contenu

## Impact
- Meilleure lisibilité du texte
- Cohérence visuelle entre le trigger et le contenu
- Respect des standards de design mobile

## Tests
- ✅ Affichage sur différentes tailles d'écran mobile
- ✅ Interaction avec le menu accordéon
- ✅ Cohérence avec le design system