### PR TITLE
fix(server): :bug: prevent error when getRegionName parameter undefined

### DIFF
--- a/apps/server/src/modules/dispositif/dispositif.adapter.ts
+++ b/apps/server/src/modules/dispositif/dispositif.adapter.ts
@@ -106,7 +106,7 @@ interface Result {
   region: string | null;
 }
 
-const getRegionName = (regionData: RegionData | undefined, department: string) => {
+const getRegionName = (regionData: RegionData, department: string) => {
   if (department === "All") return "France";
   return regionData.region || null;
 };
@@ -126,12 +126,14 @@ export const adaptDispositifDepartement = (dispositifs: Dispositif[]): Result[] 
     } else {
       for (const department of departments) {
         const regionData = departmentRegionCorrespondency.find((data) => data.department === department);
-        const region = getRegionName(regionData, department);
-        result.push({
-          _id: dispositif._id,
-          department,
-          region,
-        });
+        if (regionData) {
+          const region = getRegionName(regionData, department);
+          result.push({
+            _id: dispositif._id,
+            department,
+            region,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
Correction du bug un peu à l'aveugle car je ne reproduis pas en dev. En staging, je vois une erreur [dans les logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.configuration_name%3D%22backend-stag%22%0Aresource.labels.revision_name%3D%22backend-stag-00490-nnr%22%0Aresource.labels.project_id%3D%22refugies-info%22%0Aresource.labels.service_name%3D%22backend-stag%22%0Aresource.labels.location%3D%22europe-west1%22;pinnedLogId=2024-11-20T08:35:18.390336Z%2F673d9f460005f4c076f96e1e;summaryFields=:false:32:beginning;cursorTimestamp=2024-11-20T08:11:29.760595Z;duration=PT1H?referrer=search&project=refugies-info&inv=1&invt=Abh-ZQ) : 
`TypeError: Cannot read properties of undefined (reading 'region') at getRegionName`

J'en déduis que la fonction qui matche un département avec une région ne retourne aucun résultat. 

Xavier à récemment remonté un problème de plusieurs utilisateurs qui arrivent à saisir un département non formaté par nous, ce qui peut être la cause du problème. 

En attendant, j'ai corrigé le bug pour ne plus avoir le point d'API qui plante. À tester sur staging