### PR TITLE
Luis/ri 421 rr affichage des fiches de themes secondaires dans les

### DIFF
--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
@@ -1,21 +1,18 @@
-import { Id, SimpleDispositif } from "@refugies-info/api-types";
-import _ from "lodash";
-import debounce from "lodash/debounce";
+import { Id } from "@refugies-info/api-types";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
+import { useDispositifCounts } from "~/components/Pages/recherche/ThemeMenu/useDispositifCounts";
 import SearchButton from "~/components/UI/SearchButton";
 import { useSearchEventName, useWindowSize } from "~/hooks";
 import { cls } from "~/lib/classname";
-import { filterDispositifs, queryDispositifsWithoutThemes } from "~/lib/recherche/queryContents";
+import { filterDispositifs } from "~/lib/recherche/queryContents";
 import { sortThemes } from "~/lib/sortThemes";
 import { Event } from "~/lib/tracking";
 import { fetchActiveDispositifsActionsCreator } from "~/services/ActiveDispositifs/activeDispositifs.actions";
 import { activeDispositifsSelector } from "~/services/ActiveDispositifs/activeDispositifs.selector";
-import { languei18nSelector } from "~/services/Langue/langue.selectors";
 import { LoadingStatusKey } from "~/services/LoadingStatus/loadingStatus.actions";
 import { hasErroredSelector, isLoadingSelector } from "~/services/LoadingStatus/loadingStatus.selectors";
 import { needsSelector } from "~/services/Needs/needs.selectors";
-import { SearchQuery } from "~/services/SearchResults/searchResults.reducer";
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
 import { themesSelector } from "~/services/Themes/themes.selectors";
 import { getInitialTheme } from "./functions";
@@ -30,18 +27,6 @@ interface Props {
   isOpen: boolean;
   className?: string;
 }
-
-const debouncedQuery = debounce(
-  (
-    query: SearchQuery,
-    dispositifs: SimpleDispositif[],
-    locale: string,
-    callback: (res: SimpleDispositif[]) => void,
-  ) => {
-    return queryDispositifsWithoutThemes(query, dispositifs, locale).then((res) => callback(res));
-  },
-  500,
-);
 
 const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
   const dispatch = useDispatch();
@@ -94,29 +79,8 @@ const ThemeMenu = ({ mobile, isOpen, className, ...props }: Props) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
 
-  const [nbDispositifsByNeed, setNbDispositifsByNeed] = useState<Record<string, number>>({});
-  const [nbDispositifsByTheme, setNbDispositifsByTheme] = useState<Record<string, number>>({});
-
   // count dispositifs by need and theme
-  const languei18nCode = useSelector(languei18nSelector);
-  useEffect(() => {
-    if (isOpen) {
-      debouncedQuery(query, matches, languei18nCode, (dispositifs) => {
-        const nbDispositifsByTheme = _(dispositifs)
-          .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
-          .countBy((dispositif) => dispositif.theme?.toString())
-          .value();
-
-        const nbDispositifsByNeed = _(dispositifs)
-          .flatMap((dispositif) => dispositif.needs || [])
-          .countBy()
-          .value();
-
-        setNbDispositifsByTheme(nbDispositifsByTheme);
-        setNbDispositifsByNeed(nbDispositifsByNeed);
-      });
-    }
-  }, [query, matches, needs, sortedThemes, mobile, languei18nCode, isOpen]);
+  const { nbDispositifsByNeed, nbDispositifsByTheme } = useDispositifCounts(isOpen);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts
@@ -8,6 +8,23 @@ import { activeDispositifsSelector } from "~/services/ActiveDispositifs/activeDi
 import { needsSelector } from "~/services/Needs/needs.selectors";
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
 
+/**
+ * Custom hook that manages the counting of dispositifs by theme and need.
+ * The hook handles:
+ * 1. Text search through Algolia
+ * 2. Filtering of results based on query parameters
+ * 3. Counting of filtered dispositifs by theme and need
+ *
+ * The counting process ensures that:
+ * - Only active dispositifs are counted
+ * - Only needs that belong to the same theme as the dispositif are counted
+ * - Dispositifs without a theme are excluded
+ *
+ * @param isOpen - Whether the theme menu is open. Controls when searches and updates occur
+ * @returns An object containing:
+ *  - nbDispositifsByTheme: Count of dispositifs per theme
+ *  - nbDispositifsByNeed: Count of dispositifs per need (filtered by theme)
+ */
 export const useDispositifCounts = (isOpen: boolean) => {
   const query = useSelector(searchQuerySelector);
   const dispositifs = useSelector(activeDispositifsSelector);
@@ -16,12 +33,14 @@ export const useDispositifCounts = (isOpen: boolean) => {
 
   const [searchResults, setSearchResults] = useState<SimpleDispositif[]>(dispositifs);
   const [filteredDispositifs, setFilteredDispositifs] = useState<SimpleDispositif[]>([]);
+
+  // Create a map of need ID to theme ID for efficient lookups
   const needsToThemeMap = useMemo(
     () => allNeeds.reduce<Map<Id, Id>>((map, need) => map.set(need._id, need.theme._id), new Map()),
     [allNeeds],
   );
 
-  // Handle Algolia search
+  // Step 1: Handle text search through Algolia
   useEffect(() => {
     const performSearch = async () => {
       setSearchResults(query.search !== "" ? await queryAlgolia(query.search, dispositifs, locale) : dispositifs);
@@ -29,18 +48,20 @@ export const useDispositifCounts = (isOpen: boolean) => {
     if (isOpen) performSearch();
   }, [query.search, dispositifs, locale, isOpen]);
 
-  // Handle filtering
+  // Step 2: Apply filters to search results
   useEffect(() => {
     if (!isOpen) return;
     const filtered = filterDispositifs(query, searchResults, false, "theme");
     setFilteredDispositifs(filtered);
   }, [query, searchResults, allNeeds, isOpen]);
 
+  // Step 3: Count dispositifs by theme
   const nbDispositifsByTheme = _(filteredDispositifs)
     .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
     .countBy((dispositif) => dispositif.theme?.toString())
     .value();
 
+  // Step 4: Count dispositifs by need, ensuring needs match the dispositif's theme
   const nbDispositifsByNeed = _(filteredDispositifs)
     .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
     .flatMap((dispositif) =>

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts
@@ -57,13 +57,13 @@ export const useDispositifCounts = (isOpen: boolean) => {
 
   // Step 3: Count dispositifs by theme
   const nbDispositifsByTheme = _(filteredDispositifs)
-    .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
+    .filter((dispositif) => dispositif.theme !== null)
     .countBy((dispositif) => dispositif.theme?.toString())
     .value();
 
   // Step 4: Count dispositifs by need, ensuring needs match the dispositif's theme
   const nbDispositifsByNeed = _(filteredDispositifs)
-    .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
+    .filter((dispositif) => dispositif.theme !== null)
     .flatMap((dispositif) =>
       _(dispositif.needs)
         .filter((id) => {

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts
@@ -1,0 +1,60 @@
+import { Id, SimpleDispositif } from "@refugies-info/api-types";
+import _ from "lodash";
+import { useEffect, useMemo, useState } from "react";
+import { useSelector } from "react-redux";
+import { useLocale } from "~/hooks";
+import { filterDispositifs, queryAlgolia } from "~/lib/recherche/queryContents";
+import { activeDispositifsSelector } from "~/services/ActiveDispositifs/activeDispositifs.selector";
+import { needsSelector } from "~/services/Needs/needs.selectors";
+import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
+
+export const useDispositifCounts = (isOpen: boolean) => {
+  const query = useSelector(searchQuerySelector);
+  const dispositifs = useSelector(activeDispositifsSelector);
+  const allNeeds = useSelector(needsSelector);
+  const locale = useLocale();
+
+  const [searchResults, setSearchResults] = useState<SimpleDispositif[]>(dispositifs);
+  const [filteredDispositifs, setFilteredDispositifs] = useState<SimpleDispositif[]>([]);
+  const needsToThemeMap = useMemo(
+    () => allNeeds.reduce<Map<Id, Id>>((map, need) => map.set(need._id, need.theme._id), new Map()),
+    [allNeeds],
+  );
+
+  // Handle Algolia search
+  useEffect(() => {
+    const performSearch = async () => {
+      setSearchResults(query.search !== "" ? await queryAlgolia(query.search, dispositifs, locale) : dispositifs);
+    };
+    if (isOpen) performSearch();
+  }, [query.search, dispositifs, locale, isOpen]);
+
+  // Handle filtering
+  useEffect(() => {
+    if (!isOpen) return;
+    const filtered = filterDispositifs(query, searchResults, false, "theme");
+    setFilteredDispositifs(filtered);
+  }, [query, searchResults, allNeeds, isOpen]);
+
+  const nbDispositifsByTheme = _(filteredDispositifs)
+    .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
+    .countBy((dispositif) => dispositif.theme?.toString())
+    .value();
+
+  const nbDispositifsByNeed = _(filteredDispositifs)
+    .filter((dispositif) => dispositif.theme !== null && dispositif.status === "Actif")
+    .flatMap((dispositif) =>
+      _(dispositif.needs)
+        .filter((id) => {
+          return needsToThemeMap.get(id) === dispositif.theme;
+        })
+        .value(),
+    )
+    .countBy()
+    .value();
+
+  return {
+    nbDispositifsByTheme,
+    nbDispositifsByNeed,
+  };
+};

--- a/apps/client/src/lib/recherche/queryContents.ts
+++ b/apps/client/src/lib/recherche/queryContents.ts
@@ -151,7 +151,7 @@ const filterSuggestions = (
 let searchCache = "";
 let searchCacheResults: SimpleDispositif[] = [];
 
-const queryOnAlgolia = async (search: string, dispositifs: SimpleDispositif[], locale: string) => {
+export const queryAlgolia = async (search: string, dispositifs: SimpleDispositif[], locale: string) => {
   let filteredDispositifsByAlgolia: SimpleDispositif[] = [...dispositifs];
   if (search) {
     if (search !== searchCache) {
@@ -261,27 +261,6 @@ export const queryDispositifsWithAlgolia = async (
   locale: string,
   allNeeds: GetNeedResponse[],
 ): Promise<Results> => {
-  const filteredDispositifsByAlgolia = await queryOnAlgolia(query.search, dispositifs, locale);
+  const filteredDispositifsByAlgolia = await queryAlgolia(query.search, dispositifs, locale);
   return { ...queryDispositifs(query, filteredDispositifsByAlgolia, allNeeds), algolia: filteredDispositifsByAlgolia };
-};
-
-/**
- * Query the dispositifs with all filters except themes or needs. Useful for the theme dropdown popup.
- * @async
- * @param query - search query
- * @param dispositifs - list of dispositifs
- * @param locale - language to use for Algolia
- * @returns - results
- */
-export const queryDispositifsWithoutThemes = async (
-  query: SearchQuery,
-  dispositifs: SimpleDispositif[],
-  locale: string,
-): Promise<SimpleDispositif[]> => {
-  const filteredDispositifsByAlgolia = await queryOnAlgolia(query.search, dispositifs, locale);
-  return [...filteredDispositifsByAlgolia]
-    .filter((dispositif) => filterByLocations(dispositif, query.departments))
-    .filter((dispositif) => filterByAge(dispositif, query.age))
-    .filter((dispositif) => filterByFrenchLevel(dispositif, query.frenchLevel))
-    .filter((dispositif) => filterByLanguage(dispositif, query.language));
 };


### PR DESCRIPTION
# Refactorisation du comptage des dispositifs dans le ThemeMenu

## Changements
- Création d'un nouveau hook personnalisé [useDispositifCounts](cci:1://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/components/Pages/recherche/ThemeMenu/useDispositifCounts.ts:32:0-64:2) pour gérer la logique de comptage des dispositifs
- Séparation du flux de données en étapes distinctes :
  1. Recherche textuelle via Algolia
  2. Filtrage basé sur les paramètres de recherche
  3. Comptage des dispositifs par thème et besoin
- Amélioration du comptage des besoins pour ne prendre en compte que les besoins appartenant au même thème que le dispositif
- Suppression de la gestion d'état locale inutile dans le composant ThemeMenu

## Détails Techniques
- Création d'une `Map` (`needsToThemeMap`) pour optimiser la recherche des thèmes associés aux besoins
- Séparation des opérations asynchrones (recherche Algolia) des opérations synchrones (filtrage et comptage)
- Ajout d'une documentation complète expliquant le fonctionnement du hook et les règles métier
- Simplification des dépendances dans les hooks useEffect pour éviter les re-rendus inutiles

## Avantages
- Meilleure séparation des responsabilités : la logique de comptage est maintenant isolée et réutilisable
- Amélioration des performances grâce à :
  - L'utilisation de la mémorisation pour les calculs coûteux
  - La prévention des re-rendus inutiles
  - L'utilisation de structures de données efficaces pour les recherches
- Code plus maintenable avec une documentation claire et une responsabilité unique
- Meilleure sécurité des types avec un typage explicite

## Tests à effectuer
- [ ] Vérifier que les comptages par thème sont exacts
- [ ] Vérifier que les comptages de besoins n'incluent que les besoins du même thème
- [ ] Tester les performances avec des grands jeux de données
- [ ] S'assurer du bon comportement lors de l'ouverture/fermeture du menu