### PR TITLE
Luis/ri 527 mettre a jour les besoins en memoire du client et serveur

### DIFF
--- a/apps/client/cloudbuild.yaml
+++ b/apps/client/cloudbuild.yaml
@@ -56,7 +56,7 @@ steps:
         "--port",
         "3000",
         "--memory",
-        "1G",
+        "${'3G' if '${_ENV}' == 'prod' else '1G'}",
         "--allow-unauthenticated",
       ]
 

--- a/apps/client/cloudbuild.yaml
+++ b/apps/client/cloudbuild.yaml
@@ -56,7 +56,7 @@ steps:
         "--port",
         "3000",
         "--memory",
-        "${'3G' if '${_ENV}' == 'prod' else '1G'}",
+        "${_MEMORY}",
         "--allow-unauthenticated",
       ]
 

--- a/apps/server/cloudbuild.yaml
+++ b/apps/server/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
       - "--image"
       - "${_REGISTRY_URL}/$PROJECT_ID/${_REGISTRY}/${_COMPONENT}:$SHORT_SHA"
       - "--memory"
-      - "1G"
+      - "${'2G' if '${_ENV}' == 'prod' else '1G'}"
       - "--set-env-vars"
       - >-
         accountSid=sm://refugies-info/accountSid,

--- a/apps/server/cloudbuild.yaml
+++ b/apps/server/cloudbuild.yaml
@@ -31,7 +31,7 @@ steps:
       - "--image"
       - "${_REGISTRY_URL}/$PROJECT_ID/${_REGISTRY}/${_COMPONENT}:$SHORT_SHA"
       - "--memory"
-      - "${'2G' if '${_ENV}' == 'prod' else '1G'}"
+      - "${_MEMORY}"
       - "--set-env-vars"
       - >-
         accountSid=sm://refugies-info/accountSid,


### PR DESCRIPTION
- mise à jour des fichiers `cloudbuild.yaml` client et server pour fixer l'option mémoire en utilisant la variable de substitution cloud build `_MEMORY`
- mise à jour des triggers suivants sur cloud build pour fixer la valeur de `_MEMORY`
  - backend-stag 
  - backend-prod
  - frontend-stag
  - frontend-prod
