### PR TITLE
Luis/ri 543 ajouter des endpoint api pour la newsletter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,16 +24,22 @@
       }
     },
     {
+      "name": "Debug server",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "yarn dev:server",
+      "env": {
+        "NODE_ENV": "development"
+      },
+    },
+    {
       "type": "node",
       "request": "launch",
       "name": "Debug Current Test File",
       "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/jest",
-      "args": [
-        "--runInBand",
-        "${fileBasename}"
-      ],
+      "args": ["--runInBand", "${fileBasename}"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen",
+      "internalConsoleOptions": "neverOpen"
     }
   ]
 }

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -333,7 +333,7 @@ export class DispositifController extends Controller {
     jwt: ["newsletter"],
     fromSite: [],
   })
-  @Get("/recent-dispositifs/:departement")
+  @Get("/recent-dispositifs/{departement}")
   public async getRecentDispositifsByDepartement(
     @Path() departement: string,
   ): ResponseWithData<{ titre: string; url: string }[]> {

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -323,7 +323,7 @@ export class DispositifController extends Controller {
     jwt: ["newsletter"],
   })
   @Get("/recent-demarches")
-  public async getRecentDemarches(): ResponseWithData<{ title: string; url: string }[]> {
+  public async getRecentDemarches(): ResponseWithData<{ titre: string; url: string }[]> {
     return getRecentDemarches();
   }
 

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -322,6 +322,7 @@ export class DispositifController extends Controller {
 
   @Security({
     jwt: ["newsletter", "admin"],
+    fromSite: [],
   })
   @Get("/recent-demarches")
   public async getRecentDemarches(): ResponseWithData<{ titre: string; url: string }[]> {
@@ -330,6 +331,7 @@ export class DispositifController extends Controller {
 
   @Security({
     jwt: ["newsletter", "admin"],
+    fromSite: [],
   })
   @Get("/recent-dispositifs/:departement")
   public async getRecentDispositifsByDepartement(

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -321,7 +321,7 @@ export class DispositifController extends Controller {
   }
 
   @Security({
-    jwt: ["newsletter"],
+    jwt: ["newsletter", "admin"],
   })
   @Get("/recent-demarches")
   public async getRecentDemarches(): ResponseWithData<{ titre: string; url: string }[]> {
@@ -329,7 +329,7 @@ export class DispositifController extends Controller {
   }
 
   @Security({
-    jwt: ["newsletter"],
+    jwt: ["newsletter", "admin"],
   })
   @Get("/recent-dispositifs/:departement")
   public async getRecentDispositifsByDepartement(

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -55,6 +55,7 @@ import {
   getNbContentsForCounty,
   getNbDispositifsByRegion,
   getRecentDemarches,
+  getRecentDispositifsByDepartement,
   getStatistics,
   getUserContributions,
   modifyDispositifMainSponsor,
@@ -325,6 +326,16 @@ export class DispositifController extends Controller {
   @Get("/recent-demarches")
   public async getRecentDemarches(): ResponseWithData<{ titre: string; url: string }[]> {
     return getRecentDemarches();
+  }
+
+  @Security({
+    jwt: ["newsletter"],
+  })
+  @Get("/recent-dispositifs/:departement")
+  public async getRecentDispositifsByDepartement(
+    @Path() departement: string,
+  ): ResponseWithData<{ titre: string; url: string }[]> {
+    return getRecentDispositifsByDepartement(departement);
   }
 
   @Security({

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -54,6 +54,7 @@ import {
   getHasTextChanges,
   getNbContentsForCounty,
   getNbDispositifsByRegion,
+  getRecentDemarches,
   getStatistics,
   getUserContributions,
   modifyDispositifMainSponsor,
@@ -316,6 +317,14 @@ export class DispositifController extends Controller {
   @Delete("/{id}/suggestion/{suggestionId}")
   public async deleteSuggestion(@Path() id: string, @Path() suggestionId: string): Response {
     return deleteSuggestion(id, suggestionId);
+  }
+
+  @Security({
+    jwt: ["newsletter"],
+  })
+  @Get("/recent-demarches")
+  public async getRecentDemarches(): ResponseWithData<{ title: string; url: string }[]> {
+    return getRecentDemarches();
   }
 
   @Security({

--- a/apps/server/src/controllers/dispositifController.ts
+++ b/apps/server/src/controllers/dispositifController.ts
@@ -321,7 +321,7 @@ export class DispositifController extends Controller {
   }
 
   @Security({
-    jwt: ["newsletter", "admin"],
+    jwt: ["newsletter"],
     fromSite: [],
   })
   @Get("/recent-demarches")
@@ -330,7 +330,7 @@ export class DispositifController extends Controller {
   }
 
   @Security({
-    jwt: ["newsletter", "admin"],
+    jwt: ["newsletter"],
     fromSite: [],
   })
   @Get("/recent-dispositifs/:departement")

--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -10,6 +10,7 @@ import {
 import { omit, pick, union, uniq } from "lodash";
 import { map } from "lodash/fp";
 import { FilterQuery, ProjectionType, UpdateQuery } from "mongoose";
+import { LatestDispositifResult } from "~/modules/dispositif/types";
 import {
   Dispositif,
   DispositifDraftModel,
@@ -531,4 +532,23 @@ export const deleteNeedFromDispositifs = async (needId: string) => {
 export const cloneDispositifInDrafts = async (id: DispositifId, newData: Partial<Dispositif>) => {
   const dispositif = await DispositifModel.findById(id).lean();
   return DispositifDraftModel.create({ ...dispositif, ...newData });
+};
+
+export const getLatestDispositifs = async (
+  query: FilterQuery<Dispositif>,
+  limit: number = 3,
+  sort: any = { updatedAt: -1 },
+): Promise<LatestDispositifResult[]> => {
+  return DispositifModel.aggregate([
+    { $match: query },
+    { $sort: sort },
+    { $limit: limit },
+    {
+      $project: {
+        _id: 1,
+        typeContenu: 1,
+        titreInformatif: "$translations.fr.content.titreInformatif",
+      },
+    },
+  ]);
 };

--- a/apps/server/src/modules/dispositif/types.ts
+++ b/apps/server/src/modules/dispositif/types.ts
@@ -1,0 +1,5 @@
+export type LatestDispositifResult = {
+  _id: string;
+  typeContenu: string;
+  titreInformatif: string;
+};

--- a/apps/server/src/workflows/dispositif/getRecentDemarches/getRecentDemarches.ts
+++ b/apps/server/src/workflows/dispositif/getRecentDemarches/getRecentDemarches.ts
@@ -1,0 +1,21 @@
+import logger from "~/logger";
+import { getLatestDispositifs } from "~/modules/dispositif/dispositif.repository";
+import { ResponseWithData } from "~/types/interface";
+
+const frontUrl = process.env.FRONT_SITE_URL || "https://refugies.info";
+
+export const getRecentDemarches = async (): ResponseWithData<{ titre: string; url: string }[]> => {
+  logger.info("[getRecentDemarches] called");
+
+  const dispositifs = await getLatestDispositifs({
+    typeContenu: "demarche",
+    status: "Actif",
+  });
+
+  const result = dispositifs.map((d) => ({
+    titre: d.titreInformatif,
+    url: `${frontUrl}/fr/${d.typeContenu}/${d._id}`,
+  }));
+
+  return { text: "success", data: result };
+};

--- a/apps/server/src/workflows/dispositif/getRecentDemarches/index.ts
+++ b/apps/server/src/workflows/dispositif/getRecentDemarches/index.ts
@@ -1,0 +1,1 @@
+export { getRecentDemarches } from "./getRecentDemarches";

--- a/apps/server/src/workflows/dispositif/getRecentDispositifsByDepartement/getRecentDispositifsByDepartement.ts
+++ b/apps/server/src/workflows/dispositif/getRecentDispositifsByDepartement/getRecentDispositifsByDepartement.ts
@@ -1,0 +1,24 @@
+import logger from "~/logger";
+import { getLatestDispositifs } from "~/modules/dispositif/dispositif.repository";
+import { ResponseWithData } from "~/types/interface";
+
+const frontUrl = process.env.FRONT_SITE_URL || "https://refugies.info";
+
+export const getRecentDispositifsByDepartement = async (
+  departement: string,
+): ResponseWithData<{ titre: string; url: string }[]> => {
+  logger.info(`[getRecentDispositifsByDepartement] called for departement ${departement}`);
+
+  const dispositifs = await getLatestDispositifs({
+    "typeContenu": "dispositif",
+    "status": "Actif",
+    "metadatas.departments": { $regex: `^${departement}\\s-` },
+  });
+
+  const result = dispositifs.map((d) => ({
+    titre: d.titreInformatif,
+    url: `${frontUrl}/fr/${d.typeContenu}/${d._id}`,
+  }));
+
+  return { text: "success", data: result };
+};

--- a/apps/server/src/workflows/dispositif/getRecentDispositifsByDepartement/index.ts
+++ b/apps/server/src/workflows/dispositif/getRecentDispositifsByDepartement/index.ts
@@ -1,0 +1,1 @@
+export * from "./getRecentDispositifsByDepartement";

--- a/apps/server/src/workflows/dispositif/index.ts
+++ b/apps/server/src/workflows/dispositif/index.ts
@@ -17,6 +17,7 @@ export { getHasTextChanges } from "./getHasTextChanges";
 export { default as getNbContentsForCounty } from "./getNbContentsForCounty";
 export { getNbDispositifsByRegion } from "./getNbDispositifsByRegion";
 export { getRecentDemarches } from "./getRecentDemarches";
+export { getRecentDispositifsByDepartement } from "./getRecentDispositifsByDepartement";
 export { getStatistics } from "./getStatistics";
 export { getUserContributions } from "./getUserContributions";
 export { modifyDispositifMainSponsor } from "./modifyDispositifMainSponsor";

--- a/apps/server/src/workflows/dispositif/index.ts
+++ b/apps/server/src/workflows/dispositif/index.ts
@@ -16,6 +16,7 @@ export { getDispositifsWithTranslationAvancement } from "./getDispositifsWithTra
 export { getHasTextChanges } from "./getHasTextChanges";
 export { default as getNbContentsForCounty } from "./getNbContentsForCounty";
 export { getNbDispositifsByRegion } from "./getNbDispositifsByRegion";
+export { getRecentDemarches } from "./getRecentDemarches";
 export { getStatistics } from "./getStatistics";
 export { getUserContributions } from "./getUserContributions";
 export { modifyDispositifMainSponsor } from "./modifyDispositifMainSponsor";

--- a/migrations/1733826012000_CreateNewsletterRoleAndUser.ts
+++ b/migrations/1733826012000_CreateNewsletterRoleAndUser.ts
@@ -1,0 +1,36 @@
+import { MigrationInterface } from "mongo-migrate-ts";
+import { Db, ObjectId } from "mongodb";
+
+export class Migration1733826012000 implements MigrationInterface {
+  public async up(db: Db): Promise<void | never> {
+    // Create newsletter role
+    const newsletterRole = {
+      _id: new ObjectId(),
+      nom: "newsletter",
+      nomPublique: "Gestionnaire de newsletter",
+    };
+
+    await db.collection("roles").insertOne(newsletterRole);
+
+    // Create newsletter user
+    const newsletterUser = {
+      _id: new ObjectId(),
+      username: "newsletter",
+      email: "dev@refugies.info",
+      password: "",
+      roles: [newsletterRole._id],
+      created_at: new Date(),
+      updatedAt: new Date(),
+    };
+
+    await db.collection("users").insertOne(newsletterUser);
+  }
+
+  public async down(db: Db): Promise<void | never> {
+    // Remove newsletter user
+    await db.collection("users").deleteOne({ username: "newsletter" });
+
+    // Remove newsletter role
+    await db.collection("roles").deleteOne({ nom: "newsletter" });
+  }
+}

--- a/migrations/1733826012000_CreateNewsletterRoleAndUser.ts
+++ b/migrations/1733826012000_CreateNewsletterRoleAndUser.ts
@@ -16,7 +16,7 @@ export class Migration1733826012000 implements MigrationInterface {
     const newsletterUser = {
       _id: new ObjectId(),
       username: "newsletter",
-      email: "dev@refugies.info",
+      email: "",
       password: "",
       roles: [newsletterRole._id],
       created_at: new Date(),

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "prettier-plugin-organize-imports": "^4.1.0",
     "stylelint": "^16.10.0",
     "stylelint-config-standard-scss": "^13.1.0",
-    "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "turbo": "^2.2.3"
   },
@@ -98,6 +97,5 @@
     "*.{css,scss}": "stylelint --fix",
     "*.{js,jsx,ts,tsx}": "prettier --write"
   },
-  "resolutions": {
-  }
+  "resolutions": {}
 }

--- a/packages/api-types/src/generics.ts
+++ b/packages/api-types/src/generics.ts
@@ -33,6 +33,7 @@ export enum RoleName {
   CAREGIVER = "Aidant",
   STRUCTURE = "hasStructure",
   USER = "User",
+  NEWSLETTER = "Newsletter",
 }
 
 // Theme

--- a/scripts/generate-newsletter-token.js
+++ b/scripts/generate-newsletter-token.js
@@ -3,13 +3,21 @@ import jwt from "jsonwebtoken";
 
 config();
 
+if (process.argv.length < 3) {
+  console.error("Error: User ID is required");
+  console.log("Usage: node generate-newsletter-token.js <user_id>");
+  process.exit(1);
+}
+
+const userId = process.argv[2];
+
 // Replace this with your actual JWT secret from your environment variables
 const JWT_SECRET = process.env.JWT_SECRET || "your-jwt-secret";
 
 const payload = {
-  roles: ["Newsletter"],
-  _id: "newsletter-test-user",
-  username: "Newsletter Test User",
+  roles: ["newsletter"],
+  _id: userId,
+  username: "Gestionnaire de newsletter",
 };
 
 const token = jwt.sign(payload, JWT_SECRET);

--- a/scripts/generate-newsletter-token.js
+++ b/scripts/generate-newsletter-token.js
@@ -1,0 +1,17 @@
+import { config } from "dotenv";
+import jwt from "jsonwebtoken";
+
+config();
+
+// Replace this with your actual JWT secret from your environment variables
+const JWT_SECRET = process.env.JWT_SECRET || "your-jwt-secret";
+
+const payload = {
+  roles: ["Newsletter"],
+  _id: "newsletter-test-user",
+  username: "Newsletter Test User",
+};
+
+const token = jwt.sign(payload, JWT_SECRET, { expiresIn: "1y" });
+console.log("Generated JWT Token:");
+console.log(token);

--- a/scripts/generate-newsletter-token.js
+++ b/scripts/generate-newsletter-token.js
@@ -12,6 +12,6 @@ const payload = {
   username: "Newsletter Test User",
 };
 
-const token = jwt.sign(payload, JWT_SECRET, { expiresIn: "1y" });
+const token = jwt.sign(payload, JWT_SECRET);
 console.log("Generated JWT Token:");
 console.log(token);

--- a/scripts/generate-newsletter-token.js
+++ b/scripts/generate-newsletter-token.js
@@ -11,8 +11,13 @@ if (process.argv.length < 3) {
 
 const userId = process.argv[2];
 
-// Replace this with your actual JWT secret from your environment variables
-const JWT_SECRET = process.env.JWT_SECRET || "your-jwt-secret";
+if (!process.env.JWT_SECRET) {
+  console.error("Error: The JWT_SECRET env var is required");
+  console.log("Usage: node generate-newsletter-token.js <user_id>");
+  process.exit(1);
+}
+
+const JWT_SECRET = process.env.JWT_SECRET;
 
 const payload = {
   roles: ["newsletter"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,7 +1574,7 @@
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
-  resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
   integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
@@ -3781,7 +3781,7 @@
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
-  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
   integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
@@ -5636,22 +5636,22 @@
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.11"
-  resolved "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
   integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
 
 "@tsconfig/node12@^1.0.7":
   version "1.0.11"
-  resolved "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
   integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
 
 "@tsconfig/node14@^1.0.0":
   version "1.0.3"
-  resolved "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
   integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
 
 "@tsconfig/node16@^1.0.2":
   version "1.0.4"
-  resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@tsoa/cli@^6.5.1":
@@ -6657,20 +6657,32 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.0.2, acorn-walk@^8.1.1:
+acorn-walk@^8.0.2:
   version "8.3.2"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz"
   integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
 
 acorn@6.4.1:
   version "6.4.1"
   resolved "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
-acorn@^8.1.0, acorn@^8.4.1, acorn@^8.8.1, acorn@^8.9.0:
+acorn@^8.1.0, acorn@^8.8.1, acorn@^8.9.0:
   version "8.11.3"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz"
   integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 acorn@^8.8.2:
   version "8.12.1"
@@ -6895,7 +6907,7 @@ arg@5.0.2:
 
 arg@^4.1.0:
   version "4.1.3"
-  resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
@@ -8354,7 +8366,7 @@ create-jest@^29.7.0:
 
 create-require@^1.1.0:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-env@^3.1.3:
@@ -8864,7 +8876,7 @@ diff-sequences@^29.6.3:
 
 diff@^4.0.1:
   version "4.0.2"
-  resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^3.0.1:
@@ -18415,7 +18427,7 @@ uuid@^9.0.0, uuid@^9.0.1:
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
-  resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^9.0.1:
@@ -19035,7 +19047,7 @@ yargs@^6.5.0:
 
 yn@3.1.1:
   version "3.1.1"
-  resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:


### PR DESCRIPTION
- migration pour nouveau role "newsletter" et  nouvel utilisateur "newsletter" qui ne peut pas se connecter au site pour l'authentification du job
- nouveaux endpoints `/dispositifs/recent-demarches` et `/dispositifs/recent-dispositifs`
- configuration de launch pour debug du back end
- script pour generer un jwt pour l'utilisateur "newsletter"
- suppression de la dépendance sur `ts-node` car on aussi `tsx` qui est plus moderne