### PR TITLE
fix(server): :bug: remove administrationName from added sections if null

### DIFF
--- a/apps/server/src/typegoose/Traductions.test.ts
+++ b/apps/server/src/typegoose/Traductions.test.ts
@@ -120,6 +120,25 @@ const trad_avancement: RecursivePartial<TranslationContent> = {
   validatorId: new ObjectId("656076dbaf8df7a3f7bceeb4"),
 };
 
+const trad_added_adminName: TranslationContent = {
+  //@ts-ignore
+  content: {
+    titreInformatif: "abc",
+    titreMarque: "def",
+    abstract: "tyui",
+    what: "WHAT",
+    how: { "my-uuid-v4-key": { title: "title", text: "text" } },
+    next: {
+      "my-uuid-v4-key": { title: "title", text: "text" },
+      "my-uuid-v4-key-2": { title: "title", text: "text" },
+      "my-uuid-v4-key-3": { title: "title", text: "text" },
+    },
+  },
+
+  created_at: new Date(),
+  validatorId: new ObjectId("656076dbaf8df7a3f7bceeb4"),
+};
+
 describe("Traductions", () => {
   describe("diff", () => {
     it("should return empty array", () => {
@@ -151,6 +170,15 @@ describe("Traductions", () => {
         modified: ["content.titreMarque", "content.next.my-uuid-v4-key-2.title", "content.next.my-uuid-v4-key-2.text"],
         added: ["content.how.my-uuid-v4-key-2.title", "content.how.my-uuid-v4-key-2.text"],
         removed: ["content.next.my-uuid-v4-key.title", "content.next.my-uuid-v4-key.text"],
+      });
+    });
+    it("should not return administrationName ", () => {
+      const newTradAdded = JSON.parse(JSON.stringify(trad_added_adminName));
+      newTradAdded.content = { ...newTradAdded.content, administrationName: null };
+      expect(Traductions.diff(trad_added_adminName, newTradAdded)).toEqual({
+        modified: [],
+        added: [],
+        removed: [],
       });
     });
   });

--- a/apps/server/src/typegoose/Traductions.ts
+++ b/apps/server/src/typegoose/Traductions.ts
@@ -122,7 +122,9 @@ export class Traductions extends Base {
     const originKeys = keys(origin);
     const compareToKeys = keys(compareTo);
     // ces champs devront être traduits impérativement => to review
-    const added = difference(compareToKeys, originKeys);
+    const added = difference(compareToKeys, originKeys).filter(
+      (key: keyof TranslationContent) => get(compareTo, key) !== null,
+    );
     // les champs supprimés peuvent être traités automatiquement sans re-traduction
     const removed = difference(originKeys, compareToKeys);
 

--- a/migrations/1733826190794_RemoveStuckedToReview.ts
+++ b/migrations/1733826190794_RemoveStuckedToReview.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface } from "mongo-migrate-ts";
+import { Db } from "mongodb";
+
+export class Migration1733826190794 implements MigrationInterface {
+  public async up(db: Db): Promise<void | never> {
+    const trads = await db.collection("traductions").find({ toReview: "content.administrationName" }).toArray();
+    for (const trad of trads) {
+      const dispositif = await db.collection("dispositifs").findOne({ _id: trad.dispositifId });
+      if (dispositif && dispositif.translations.fr.content.administrationName === null) {
+        //@ts-ignore
+        await db
+          .collection("traductions")
+          .updateOne(
+            { _id: trad._id },
+            { $pull: { toReview: "content.administrationName", toReviewCache: "content.administrationName" } },
+          );
+      }
+    }
+  }
+
+  public async down(db: Db): Promise<void | never> {}
+}


### PR DESCRIPTION
## Contexte 

Une fonctionnalité a été ajoutée récemment, un champ `administrationName` peut être défini sur les démarches (optionnel).

Toutes les démarches créées avant l’ajout de cette fonctionnalité n’ont pas ce champ en base.

## Description du problème

Lors de la modification d’une démarche, certaines manipulation peuvent créer le champ à `null` (par exemple, j’ouvre la modal de l’administration puis la ferme sans rien changer). 

Lorsque la nouvelle version est publiée, un calcul est effectué pour trouver la différence avec l’ancienne version. En ce qui concerne les éléments ajoutés, on compare simplement la liste des clés de la version originale avec la version actuelle. 

Cas problématique → `administrationName` présent dans la nouvelle (à `null`) et pas dans l’ancienne. Le système ajoute donc cet élément “à revoir”. La traduction ne peut pas être publié tant qu’il n’est pas revu. L’élément ne peut pas être revu car étant `null`, il est masqué dans l’interface de traduction. 

## Solution proposée

1. Améliorer la méthode de détection des ajouts d’éléments entre versions : si l’élément ajouté est `null`, on ne le compte pas
2. Créer une migration qui va retirer l’ `administrationName` des éléments à revoir s’il est `null` dans la version originale