### PR TITLE
Feature(accessibility): add the skip links navigation

### DIFF
--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -213,7 +213,7 @@ const Layout = (props: Props) => {
     <div dir={isRTL ? "rtl" : "ltr"} onMouseOver={toggleHover} onTouchStart={toggleHover}>
       <DownloadAppBanner />
       <Navbar />
-      <div className={styles.main}>
+      <div id="contenu" className={styles.main}>
         <main className={styles.content}>{props.children}</main>
       </div>
       <Footer />

--- a/apps/client/src/components/UI/SkipLinksNavigation/SkipLinksNavigation.tsx
+++ b/apps/client/src/components/UI/SkipLinksNavigation/SkipLinksNavigation.tsx
@@ -1,0 +1,26 @@
+import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks";
+import { useTranslation } from "react-i18next";
+
+const SkipLinksNavigation = () => {
+  const { t } = useTranslation();
+  return (
+    <SkipLinks
+      links={[
+        {
+          anchor: "#contenu",
+          label: t("SkipLinks.Contenu", "Contenu"),
+        },
+        {
+          anchor: "#fr-header-main-navigation",
+          label: t("SkipLinks.Menu", "Menu"),
+        },
+        {
+          anchor: "#fr-footer",
+          label: t("SkipLinks.PiedDePage", "Pied de page"),
+        },
+      ]}
+    />
+  );
+};
+
+export default SkipLinksNavigation;

--- a/apps/client/src/locales/fr/common.json
+++ b/apps/client/src/locales/fr/common.json
@@ -749,5 +749,10 @@
     "Russe": "Russe",
     "Tigrinya": "Tigrinya",
     "Ukrainien": "Ukrainien"
+  },
+  "SkipLinks": {
+    "PiedDePage": "Pied de page",
+    "Menu": "Menu",
+    "Contenu": "Contenu"
   }
 }

--- a/apps/client/src/pages/_document.tsx
+++ b/apps/client/src/pages/_document.tsx
@@ -1,4 +1,5 @@
 import { DocumentProps, Head, Html, Main, NextScript } from "next/document";
+import SkipLinksNavigation from "~/components/UI/SkipLinksNavigation/SkipLinksNavigation";
 import { dsfrDocumentApi } from "./_app";
 
 const { getColorSchemeHtmlAttributes, augmentDocumentForDsfr } = dsfrDocumentApi;
@@ -14,6 +15,7 @@ export default function Document(props: DocumentProps) {
         <script defer data-domain="refugies.info" src="https://plausible.io/js/script.tagged-events.js"></script>
       </Head>
       <body>
+        <SkipLinksNavigation />
         <Main />
         <NextScript />
       </body>


### PR DESCRIPTION
@kaaloo the skip links from the react DSRF library are plugged above the header 🥳

__To test it :__
- load the page
- don't click anywhere
- press tab once

__Or :__
- interact with the page 
- press shift + tab until you reach the top of the page, it should appear.