### PR TITLE
fix(mobile): :construction_worker: Use a simple semver pnpm version in eas.json

### DIFF
--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -6,7 +6,7 @@
         "image": "latest"
       },
       "node": "20.13.1",
-      "pnpm": "9.14.4+sha512.c8180b3fbe4e4bca02c94234717896b5529740a6cbadf19fa78254270403ea2f27d4e1d46a08a0f56c89b63dc8ebfd3ee53326da720273794e6200fcf0d184ab"
+      "pnpm": "9.14.4"
     },
     "production": {
       "extends": "base",


### PR DESCRIPTION
- eas build does not seem to support the trailing hash which was added by volta