### PR TITLE
fix: :package: Add node-linker statement for expo

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -73,6 +73,7 @@
     "redux": "^5.0.0",
     "redux-devtools-extension": "^2.13.9",
     "redux-saga": "^1.2.3",
+    "reselect": "^5.1.1",
     "sanitize-html": "^2.13.1",
     "search-insights": "^2.17.2",
     "sharp": "^0.33.4",

--- a/apps/mobile/src/services/redux/User/user.selectors.ts
+++ b/apps/mobile/src/services/redux/User/user.selectors.ts
@@ -1,4 +1,5 @@
 import { Languages } from "@refugies-info/api-types";
+import { createSelector } from "reselect";
 import { RootState } from "../reducers";
 
 export const hasUserSeenOnboardingSelector = (state: RootState) => state.user.hasUserSeenOnboarding;
@@ -9,10 +10,12 @@ export const selectedI18nCodeSelector = (state: RootState): Languages | null => 
 
 export const currentI18nCodeSelector = (state: RootState): Languages | null => state.user.currentLanguagei18nCode;
 
-export const userLocationSelector = (state: RootState) => ({
-  city: state.user.city,
-  department: state.user.department,
-});
+const selectUser = (state: RootState) => state.user;
+
+export const userLocationSelector = createSelector([selectUser], (user) => ({
+  city: user.city,
+  department: user.department,
+}));
 
 export const userAgeSelector = (state: RootState) => state.user.age;
 export const userFrenchLevelSelector = (state: RootState) => state.user.frenchLevel;

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "mongo-migrate-ts": "^1.6.2",
     "mongodb": "^6.10.0",
     "patch-package": "^8.0.0",
-    "postinstall-postinstall": "^2.1.0",
     "prettier": "^3.3.3",
     "prettier-plugin-organize-imports": "^4.1.0",
     "stylelint": "^16.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -630,6 +630,9 @@ importers:
       redux-saga:
         specifier: ^1.2.3
         version: 1.3.0
+      reselect:
+        specifier: ^5.1.1
+        version: 5.1.1
       sanitize-html:
         specifier: ^2.13.1
         version: 2.13.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       patch-package:
         specifier: ^8.0.0
         version: 8.0.0
-      postinstall-postinstall:
-        specifier: ^2.1.0
-        version: 2.1.0
       prettier:
         specifier: ^3.3.3
         version: 3.4.1
@@ -675,7 +672,7 @@ importers:
         version: 14.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/react-native':
         specifier: ^12.4.3
-        version: 12.5.3(jest@29.7.0(@types/node@22.10.1))(react-native@0.73.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)
+        version: 12.5.3(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(react-native@0.73.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -726,7 +723,7 @@ importers:
         version: 29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))
       jest-expo:
         specifier: 50.0.4
-        version: 50.0.4(@babel/core@7.26.0)(jest@29.7.0(@types/node@22.10.1))(react@18.3.1)
+        version: 50.0.4(@babel/core@7.26.0)(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(react@18.3.1)
       papaparse:
         specifier: ^5.3.2
         version: 5.4.1
@@ -9781,9 +9778,6 @@ packages:
     resolution: {integrity: sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postinstall-postinstall@2.1.0:
-    resolution: {integrity: sha512-7hQX6ZlZXIoRiWNrbMQaLzUUfH+sSx39u8EJ9HYuDc1kLo9IXKWjM5RSquZN1ad5GnH8CGFM78fsAAQi3OKEEQ==}
-
   preact@10.25.1:
     resolution: {integrity: sha512-frxeZV2vhQSohQwJ7FvlqC40ze89+8friponWUFeVEkaCfhC6Eu4V0iND5C9CXz8JLndV07QRDeXzH1+Anz5Og==}
 
@@ -16796,7 +16790,7 @@ snapshots:
       lodash: 4.17.21
       redent: 3.0.0
 
-  '@testing-library/react-native@12.5.3(jest@29.7.0(@types/node@22.10.1))(react-native@0.73.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)':
+  '@testing-library/react-native@12.5.3(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(react-native@0.73.6(@babel/core@7.26.0)(@babel/preset-env@7.26.0(@babel/core@7.26.0))(react@18.3.1))(react-test-renderer@18.2.0(react@18.3.1))(react@18.3.1)':
     dependencies:
       jest-matcher-utils: 29.7.0
       pretty-format: 29.7.0
@@ -21406,7 +21400,7 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  jest-expo@50.0.4(@babel/core@7.26.0)(jest@29.7.0(@types/node@22.10.1))(react@18.3.1):
+  jest-expo@50.0.4(@babel/core@7.26.0)(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))(react@18.3.1):
     dependencies:
       '@expo/config': 8.5.6
       '@expo/json-file': 8.3.3
@@ -21415,7 +21409,7 @@ snapshots:
       find-up: 5.0.0
       jest-environment-jsdom: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.10.1))
+      jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2)))
       json5: 2.2.3
       lodash: 4.17.21
       react-test-renderer: 18.2.0(react@18.3.1)
@@ -21621,7 +21615,7 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.10.1)):
+  jest-watch-typeahead@2.2.1(jest@29.7.0(@types/node@22.10.1)(ts-node@10.9.2(@types/node@22.10.1)(typescript@5.7.2))):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 4.1.2
@@ -23402,8 +23396,6 @@ snapshots:
       nanoid: 3.3.8
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  postinstall-postinstall@2.1.0: {}
 
   preact@10.25.1: {}
 


### PR DESCRIPTION
- using pnpm with expo requires [setting up hoisted dependencies](https://docs.expo.dev/more/create-expo/#pnpm)

some weird stuff:

- removed postinstall-postinstall package that is no longer needed with pnpm
- mobile tests started failing
- fix selector optimization warning during test