### PR TITLE
fix(client): :bug: fix render fewer hooks

### DIFF
--- a/apps/client/src/components/Navigation/Navbar/Navbar.tsx
+++ b/apps/client/src/components/Navigation/Navbar/Navbar.tsx
@@ -137,6 +137,8 @@ const Navbar = () => {
     ].filter((n) => n !== null) as MainNavigationProps.Item[];
   }, [router.locale, router.pathname, backendNavigation, t]);
 
+  const quickAccessMenu = QuickAccessMenu();
+
   if (isEditionMode) return null;
   return (
     <>
@@ -153,7 +155,7 @@ const Navbar = () => {
         }}
         serviceTitle={t("Header.serviceName", "Réfugiés.info")}
         serviceTagline={t("Header.serviceTagline", "L’information pour les étrangers en France")}
-        quickAccessItems={QuickAccessMenu()}
+        quickAccessItems={quickAccessMenu}
         navigation={navigationItems}
       />
     </>


### PR DESCRIPTION
Reproduction du bug : 
- aller sur l'écran de "liste des trads" ou sur "mes fiches" sur le middle office 
- cliquer sur une fiche

-> "Rendered fewer hooks than expected. This may be caused by an accidental early return statement."

Cause du bug :  
Le composant `QuickAccessMenu` est appelé tout en bas du composant `Navbar` de la manière suivante : 
```
...
quickAccessItems={QuickAccessMenu()}
...
```

Ce composant est considéré comme un hook car il utilise `useTranslations` et renvoie un tableau d'éléments. 

Or dans le cas de l'interface d'édition, on renvoie `null` dans le composant `Navbar`, donc ce hook n'est pas appelé. 

Lorsque l'on passe d'une interface avec Navbar à une interface sans, on a donc bien un hook en moins d'appelé, d'où l'erreur. 