### PR TITLE
fix(client): :lipstick: RI-436: Make sure Theme Menu takes full height on mobile

### DIFF
--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.module.scss
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.module.scss
@@ -6,6 +6,17 @@
   min-width: min(52rem, 100vw);
   max-height: min(32rem, 80vh);
   overflow-y: auto;
+
+  /* stylelint-disable-next-line media-feature-range-notation */
+  @media (max-width: 48em) { // Mobile styles
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100vh;
+    max-height: none;
+    z-index: 1050; // Higher than Bootstrap's default modal z-index
+  }
 }
 
 .main {


### PR DESCRIPTION
To test on a mobile device first find your ip address:

```bash
ifconfig | grep "inet " | grep -v 127.0.0.1
```

Then on the mobile browser type the following in the address bar:

`http://YOUR_IP_ADDRESS:3000`

Go the the search screen and open the theme filter.