### PR TITLE
fix(server): :bug: fix computeFinished function

### DIFF
--- a/apps/server/src/typegoose/Traductions.test.ts
+++ b/apps/server/src/typegoose/Traductions.test.ts
@@ -231,9 +231,9 @@ describe("Traductions", () => {
       ).toEqual(false);
     });
     it("should return true", () => {
-      // @ts-ignore because we inject a partial Dispositif & partial Traductions
       expect(
         Traductions.computeFinished(
+          // @ts-ignore because we inject a partial Dispositif & partial Traductions
           { translations: { fr: trad_adminNameNull } },
           { translated: trad_adminNameNull_en },
         ),

--- a/apps/server/src/typegoose/Traductions.test.ts
+++ b/apps/server/src/typegoose/Traductions.test.ts
@@ -139,6 +139,36 @@ const trad_added_adminName: TranslationContent = {
   validatorId: new ObjectId("656076dbaf8df7a3f7bceeb4"),
 };
 
+const trad_adminNameNull: TranslationContent = {
+  content: {
+    titreInformatif: "abc",
+    titreMarque: "def",
+    abstract: "tyui",
+    what: "WHAT",
+    how: { "my-uuid-v4-key": { title: "title", text: "text" } },
+    next: { "my-uuid-v4-key": { title: "title", text: "text" }, "my-uuid-v4-key-2": { title: "title", text: "text" } },
+    administrationName: null,
+  },
+
+  created_at: new Date(),
+  validatorId: new ObjectId("656076dbaf8df7a3f7bceeb4"),
+};
+
+const trad_adminNameNull_en: TranslationContent = {
+  content: {
+    titreInformatif: "abc",
+    titreMarque: "def",
+    abstract: "tyui",
+    what: "WHAT",
+    why: {},
+    how: { "my-uuid-v4-key": { title: "title", text: "text" } },
+    next: { "my-uuid-v4-key": { title: "title", text: "text" }, "my-uuid-v4-key-2": { title: "title", text: "text" } },
+  },
+
+  created_at: new Date(),
+  validatorId: new ObjectId("656076dbaf8df7a3f7bceeb4"),
+};
+
 describe("Traductions", () => {
   describe("diff", () => {
     it("should return empty array", () => {
@@ -199,6 +229,15 @@ describe("Traductions", () => {
         // @ts-ignore because we inject a partial Dispositif & partial Traductions
         Traductions.computeFinished({ translations: { fr: trad_complete } }, { translated: trad_avancement }),
       ).toEqual(false);
+    });
+    it("should return true", () => {
+      // @ts-ignore because we inject a partial Dispositif & partial Traductions
+      expect(
+        Traductions.computeFinished(
+          { translations: { fr: trad_adminNameNull } },
+          { translated: trad_adminNameNull_en },
+        ),
+      ).toEqual(true);
     });
   });
 });

--- a/apps/server/src/typegoose/Traductions.ts
+++ b/apps/server/src/typegoose/Traductions.ts
@@ -38,6 +38,10 @@ const keysForSubSection = (prefix: string, translated: any) =>
     }),
   );
 
+const removeNullValues = (keys: (keyof TranslationContent)[], translationObject: Partial<TranslationContent>) => {
+  return keys.filter((key: keyof TranslationContent) => get(translationObject, key) !== null);
+};
+
 /**
  * Cette fonction permet de récupérer l'ensemble des sections
  * du langue du dispositif ou d'une traduction.
@@ -119,12 +123,10 @@ export class Traductions extends Base {
   }
 
   public static diff(origin: TranslationContent, compareTo: TranslationContent): TraductionDiff {
-    const originKeys = keys(origin);
-    const compareToKeys = keys(compareTo);
+    const originKeys = keys(origin) as (keyof TranslationContent)[];
+    const compareToKeys = keys(compareTo) as (keyof TranslationContent)[];
     // ces champs devront être traduits impérativement => to review
-    const added = difference(compareToKeys, originKeys).filter(
-      (key: keyof TranslationContent) => get(compareTo, key) !== null,
-    );
+    const added = removeNullValues(difference(compareToKeys, originKeys), compareTo);
     // les champs supprimés peuvent être traités automatiquement sans re-traduction
     const removed = difference(originKeys, compareToKeys);
 
@@ -136,8 +138,14 @@ export class Traductions extends Base {
   }
 
   public static computeFinished(dispositif: Dispositif, translation: Traductions): boolean {
-    const dispositifSectionsCounter = keys(dispositif.translations.fr).length;
-    const translationSectionsCounter = keys(translation.translated).length;
+    const dispositifSectionsCounter = removeNullValues(
+      keys(dispositif.translations.fr) as (keyof TranslationContent)[],
+      dispositif.translations.fr,
+    ).length;
+    const translationSectionsCounter = removeNullValues(
+      keys(translation.translated) as (keyof TranslationContent)[],
+      translation.translated,
+    ).length;
     const notFinished = [...new Set([...(translation.toFinish || []), ...(translation.toReview || [])])].length;
     return (translationSectionsCounter - notFinished) / dispositifSectionsCounter >= 1;
   }


### PR DESCRIPTION
J'ai trouvé le bug lié aux traductions qui ne se publient pas. Il s'applique aux fiches démarches créées avant l'ajout de la feature `administrationName`. Pour celles-ci : 
- lors de la modification de la fiche en FR, le champ `administrationName` passe à `null` si non renseigné (mais reste absent dans les autres langues car elles ne sont pas modifiées)
- lorsque l'on modifie la traduction dans une langue, le texte initial de cette langue est copié pour être modifié
- une fois la traduction modifié, on vérifie si elle est complète ou pas en comparant le nombre de clés en FR et en version traduite 
- -> dans ce cas, on aura 1 clé de plus en FR (`administrationName` à null), la traduction reste en  `finished = false` et ne se publie pas

Le correctif : j'ai utilisé la même fonction que lors du calcul de différence, pour retirer les champs `null` de ce calcul. De cette manière, on arrive bien au même nombre de clés entre la version FR et la version traduite

Une fois le correctif appliqué, il faudra : 
- aller sur la traduction dans chaque langue, et provoquer une sauvegarde (ajout / suppression d'un espace dans le texte par exemple)
- publier la traduction -> ça devrait être bon  