### PR TITLE
RI-583 soucis de visuels sur staging pas bloquants pour la mep

### DIFF
--- a/apps/client/src/components/Backend/screens/Admin/Admin.tsx
+++ b/apps/client/src/components/Backend/screens/Admin/Admin.tsx
@@ -121,9 +121,9 @@ export const Admin = (props: Props) => {
 
   return (
     <div className={styles.admin + " animated fadeIn"}>
-      <Nav>
-        <NavItem>
-          <NavLink active={activeTab === "contenus"} onClick={() => toggleTab("contenus")}>
+      <Nav className="flex p-0 pl-4 m-0 list-none">
+        <NavItem className="list-none">
+          <NavLink className="p-0 mr-4" active={activeTab === "contenus"} onClick={() => toggleTab("contenus")}>
             <Onglet
               iconSelected="file-add"
               iconNotSelected="file-add-outline"
@@ -132,8 +132,8 @@ export const Admin = (props: Props) => {
             />
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink active={activeTab === "structures"} onClick={() => toggleTab("structures")}>
+        <NavItem className="list-none">
+          <NavLink className="p-0 mr-4" active={activeTab === "structures"} onClick={() => toggleTab("structures")}>
             <Onglet
               iconSelected="shopping-bag"
               iconNotSelected="shopping-bag-outline"
@@ -142,8 +142,8 @@ export const Admin = (props: Props) => {
             />
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink active={activeTab === "utilisateurs"} onClick={() => toggleTab("utilisateurs")}>
+        <NavItem className="list-none">
+          <NavLink className="p-0 mr-4" active={activeTab === "utilisateurs"} onClick={() => toggleTab("utilisateurs")}>
             <Onglet
               iconSelected="person"
               iconNotSelected="person-outline"
@@ -152,8 +152,8 @@ export const Admin = (props: Props) => {
             />
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink active={activeTab === "categories"} onClick={() => toggleTab("categories")}>
+        <NavItem className="list-none">
+          <NavLink className="p-0 mr-4" active={activeTab === "categories"} onClick={() => toggleTab("categories")}>
             <Onglet
               iconSelected="settings-2"
               iconNotSelected="settings-2-outline"
@@ -162,8 +162,8 @@ export const Admin = (props: Props) => {
             />
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink active={activeTab === "divers"} onClick={() => toggleTab("divers")}>
+        <NavItem className="list-none">
+          <NavLink className="p-0 mr-4" active={activeTab === "divers"} onClick={() => toggleTab("divers")}>
             <Onglet
               iconSelected="pie-chart"
               iconNotSelected="pie-chart-outline"
@@ -172,8 +172,8 @@ export const Admin = (props: Props) => {
             />
           </NavLink>
         </NavItem>
-        <NavItem>
-          <NavLink active={activeTab === "widgets"} onClick={() => toggleTab("widgets")}>
+        <NavItem className="list-none">
+          <NavLink className="p-0 mr-4" active={activeTab === "widgets"} onClick={() => toggleTab("widgets")}>
             <Onglet
               iconSelected="code"
               iconNotSelected="code-outline"

--- a/apps/client/src/components/UI/RichTextInput/ToolbarPlugin/ToolbarDropdown/ToolbarDropdown.tsx
+++ b/apps/client/src/components/UI/RichTextInput/ToolbarPlugin/ToolbarDropdown/ToolbarDropdown.tsx
@@ -31,7 +31,7 @@ const ToolbarDropdown = (props: Props) => {
       <DropdownToggle disabled={props.disabled} title={props.title} className={styles.toggle}>
         {props.toggleElement}
       </DropdownToggle>
-      <DropdownMenu id={props.name} className={styles.menu}>
+      <DropdownMenu id={props.name} className={`${styles.menu} bg-white`}>
         {props.items.map((item, i) => (
           <ToolbarButton
             key={i}
@@ -43,7 +43,7 @@ const ToolbarDropdown = (props: Props) => {
             hasSelectedIcon={true}
             icon={item.icon}
             text={item.text}
-            className={"w-full mb-1"}
+            className={"mb-1 w-full"}
           ></ToolbarButton>
         ))}
       </DropdownMenu>


### PR DESCRIPTION
# Description

This PR includes two UI fixes:
1. Removed unwanted dots in the admin navigation bar
2. Fixed missing white background in rich text editor's "+ Insérer" dropdown menu

## Changes

### Admin Navigation
- Removed dots that were appearing in the admin navbar

### Rich Text Editor
- Added `bg-white` Tailwind CSS class to the DropdownMenu component in the rich text editor's toolbar dropdown
- Follows project convention of using Tailwind CSS for styling when possible

## Visual Changes

### Admin Navigation
Before: Navigation bar displayed unwanted dots
After: Clean navigation bar without dots

### Rich Text Editor
Before: Dropdown menu had a transparent background
After: Dropdown menu has a white background, improving visibility and consistency with the UI

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing

- Verified that the admin navigation bar no longer shows unwanted dots
- Verified that the "+ Insérer" dropdown menu now displays with a proper white background