### PR TITLE
fix(client): :bug: RI-577 Don't count NextJS prerendering

### DIFF
--- a/apps/client/src/pages/demarche/[id]/index.tsx
+++ b/apps/client/src/pages/demarche/[id]/index.tsx
@@ -44,7 +44,11 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     return { notFound: true };
   }
 
-  await updateNbViews(dispositif);
+  const isPrefetch = req.headers["purpose"] === "prefetch";
+
+  if (!isPrefetch) {
+    await updateNbViews(dispositif);
+  }
 
   // 200
   return {

--- a/apps/client/src/pages/dispositif/[id]/index.tsx
+++ b/apps/client/src/pages/dispositif/[id]/index.tsx
@@ -43,7 +43,11 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     return { notFound: true };
   }
 
-  await updateNbViews(dispositif);
+  const isPrefetch = req.headers["purpose"] === "prefetch";
+
+  if (!isPrefetch) {
+    await updateNbViews(dispositif);
+  }
 
   // 200
   return {


### PR DESCRIPTION
## Skip `updateNbViews` during prefetch requests

### Description
This PR modifies the `getServerSideProps` function to skip the `updateNbViews` call when the page is being prefetched.

The change uses the `Purpose` HTTP header with the value `"prefetch"` to detect prefetch requests, as implemented in Next.js. This is a more reliable approach than previous attempts using `x-nextjs-data`.

### Changes
- Added a check for `req.headers['purpose'] === 'prefetch'`
- Only call `updateNbViews(dispositif)` when not in prefetch mode

### References
1. [HTTP Purpose Header Specification](https://http.dev/purpose) - Documents the standard `Purpose` header
2. [Next.js Router Implementation](https://github.com/vercel/next.js/blob/58e1bd29a1563032244ee6d3ca689eb255756e0d/packages/next/src/shared/lib/router/router.ts#L500) - Shows Next.js's use of the `Purpose` header for prefetch detection

### Impact
- Prevents unnecessary view count updates during page prefetching
- Maintains accurate view counts for actual page visits
- Follows Next.js best practices for handling prefetch requests