### PR TITLE
RI-611: fix: :green_heart: Don't use turbo for start scripts

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -18,8 +18,7 @@
     "pr:prod": "gh pr create -B master-backend -H staging-backend -l release -t '[PROD-BACK] Release' -b ''",
     "pr:stg": "gh pr create -B staging-backend -H dev -l release -t '[STG-BACK] Release' -b ''",
     "start": "node dist/index.js",
-    "test": "jest --runInBand",
-    "print-env": "node src/scripts/print-env.js"
+    "test": "jest --runInBand"
   },
   "dependencies": {
     "@azure/msal-node": "^2.16.1",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,9 @@
     "dev:server": "turbo dev --filter=@refugies-info/server",
     "dev:mobile": "turbo dev --filter=@refugies-info/mobile",
     "update-icons": "react-dsfr update-icons --silent --projectDir ./apps/client",
-    "start": "turbo start",
-    "start:client": "turbo --filter @refugies-info/client start",
-    "start:server": "turbo --filter @refugies-info/server start",
-    "start:mobile": "turbo --filter @refugies-info/mobile start",
+    "start:client": "pnpm --filter @refugies-info/client start",
+    "start:server": "pnpm --filter @refugies-info/server start",
+    "start:mobile": "pnpm --filter @refugies-info/mobile start",
     "test": "turbo test",
     "test:client": "turbo test --filter=@refugies-info/client -- $*",
     "test:server": "turbo test --filter=@refugies-info/server -- $*",
@@ -81,8 +80,7 @@
     "migrate": "tsx migrations/cli.ts",
     "storybook": "pnpm --filter @refugies-info/storybook storybook",
     "storybook:publish": "pnpm --filter @refugies-info/storybook storybook:publish",
-    "knip": "knip",
-    "print-env": "turbo --filter @refugies-info/server print-env"
+    "knip": "knip"
   },
   "engines": {
     "node": "22.13.1"

--- a/turbo.json
+++ b/turbo.json
@@ -79,12 +79,6 @@
       "cache": false,
       "inputs": ["$TURBO_DEFAULT$", ".env"]
     },
-    "start": {
-      "persistent": true,
-      "cache": false,
-      "dependsOn": ["^start"],
-      "inputs": ["$TURBO_DEFAULT$", ".env"]
-    },
     "test": {
       "cache": false,
       "dependsOn": ["@refugies-info/ui#build", "^test"]
@@ -94,9 +88,6 @@
     },
     "lint:fix": {
       "dependsOn": ["^lint:fix"]
-    },
-    "print-env": {
-      "dependsOn": ["^print-env"]
     }
   }
 }


### PR DESCRIPTION
Turbo will ignore env vars for tasks unless explicitly mentionned in globalEnv or the env section of a task.  Since this mechanism is only for controlling caching behavior it's not needed outside of build time.  Just use pnpm directly.