### PR TITLE
RI-613: fix(client): :construction_worker: Rework secrets mechanism

### DIFF
--- a/apps/client/.dockerignore
+++ b/apps/client/.dockerignore
@@ -1,2 +1,0 @@
-Dockerfile
-.dockerignore

--- a/apps/client/Dockerfile
+++ b/apps/client/Dockerfile
@@ -24,6 +24,9 @@ RUN mkdir -p "$PNPM_HOME" && \
 # Copy workspace
 COPY . .
 
+# Rename apps/client/env.cloudbuild to .env (see cloudbuild.yaml)
+RUN mv apps/client/env.cloudbuild apps/client/.env 2>/dev/null || true
+
 # Generate a partial monorepo with a pruned lockfile for a target workspace.
 RUN turbo prune @refugies-info/client --docker
 

--- a/apps/client/cloudbuild.yaml
+++ b/apps/client/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     args:
       [
         "-c",
-        'for secret in $(gcloud secrets list --filter=REACT --format=''value(NAME)''); do echo NEXT_PUBLIC_$secret="$(gcloud secrets versions access --secret=$secret latest)" >> .env; done',
+        'for secret in $(gcloud secrets list --filter=REACT --format=''value(NAME)''); do echo NEXT_PUBLIC_$secret="$(gcloud secrets versions access --secret=$secret latest)" >> env.cloudbuild; done',
       ]
     dir: apps/client
 


### PR DESCRIPTION
Since .env files are now in .dockerignores, use new file name and rename to .env during the build