### PR TITLE
feat(client): :chart_with_upwards_trend: update matomo tag for beta.gouv

### DIFF
--- a/apps/client/src/lib/tracking.ts
+++ b/apps/client/src/lib/tracking.ts
@@ -75,7 +75,7 @@ const initMatomo = () => {
     g = d.createElement("script"),
     s = d.getElementsByTagName("script")[0];
   g.async = true;
-  g.src = "https://cdn.matomo.cloud/refugies.matomo.cloud/container_ZxAXaEFC.js";
+  g.src = "https://stats.beta.gouv.fr/js/container_DTJPTlF7.js";
   s.parentNode?.insertBefore(g, s);
 };
 


### PR DESCRIPTION
ATTENTION : ne pas tester avant de faire l'import GA4 dans Matomo. Si des données arrivent dans Matomo avant, l'import n'est plus possible.

[Documentation de l'import ici](https://matomo.org/faq/general/set-up-google-analytics-import/)
- j'ai déjà créé le Google OAuth Client Config
- je suis bloqué à "Authorizing Matomo", il faut être Super User pour le faire. Je n'ai pas les droits
- j'ai uploadé le JSON des OAuth Credentials dans le ticket Linear