### PR TITLE
feat(server): :sparkles: replicate draft process of published dispositifs for archived dispositifs

### DIFF
--- a/apps/server/src/workflows/dispositif/publishDispositif/publishDispositif.ts
+++ b/apps/server/src/workflows/dispositif/publishDispositif/publishDispositif.ts
@@ -102,7 +102,7 @@ export const publishDispositif = async (id: string, body: PublishDispositifReque
   const editedDispositif: Partial<Dispositif> = {};
 
   // if dispositif already published...
-  if (oldDispositif.status === DispositifStatus.ACTIVE) {
+  if ([DispositifStatus.ACTIVE, DispositifStatus.ARCHIVED].includes(oldDispositif.status)) {
     if (oldDispositif.hasDraftVersion) {
       // with a draft version => publish
       const isAdmin = user.isAdmin();

--- a/apps/server/src/workflows/dispositif/updateDispositif/updateDispositif.ts
+++ b/apps/server/src/workflows/dispositif/updateDispositif/updateDispositif.ts
@@ -110,7 +110,8 @@ export const updateDispositif = async (
 
   // if published and not draft version yet, create draft version
   let newDispositif: Dispositif | null = null;
-  const needsDraftVersion = oldDispositif.status === DispositifStatus.ACTIVE && !draftOldDispositif;
+  const needsDraftVersion =
+    [DispositifStatus.ACTIVE, DispositifStatus.ARCHIVED].includes(oldDispositif.status) && !draftOldDispositif;
   if (needsDraftVersion) {
     newDispositif = await cloneDispositifInDrafts(id, {
       ...editedDispositif,


### PR DESCRIPTION
Nécessite d'être bien testé pour vérifier que le comportement est correct