### PR TITLE
RI-654: Le site ne peut pas etre indexe par crisp

### DIFF
--- a/apps/client/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -318,7 +318,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/6392ff59bcd2075a379203a9"
+                        href="/demarche/6392ff59bcd2075a379203a9"
                       >
                         <span
                           class="title three_lines"
@@ -468,7 +468,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/63972dcb98b670cc4bae76e6"
+                        href="/demarche/63972dcb98b670cc4bae76e6"
                       >
                         <span
                           class="title three_lines"
@@ -618,7 +618,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/5e1c8c0e0742580052a33972"
+                        href="/demarche/5e1c8c0e0742580052a33972"
                       >
                         <span
                           class="title three_lines"
@@ -768,7 +768,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/637781c6896812af208f3495"
+                        href="/demarche/637781c6896812af208f3495"
                       >
                         <span
                           class="title three_lines"
@@ -913,7 +913,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/6123a82c6bf6bc00148a5176"
+                        href="/demarche/6123a82c6bf6bc00148a5176"
                       >
                         <span
                           class="title three_lines"
@@ -1063,7 +1063,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/5dd7c4b06f0ac0004c87c88d"
+                        href="/demarche/5dd7c4b06f0ac0004c87c88d"
                       >
                         <span
                           class="title three_lines"
@@ -1208,7 +1208,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/63528e00976acb4f7bcd37ad"
+                        href="/demarche/63528e00976acb4f7bcd37ad"
                       >
                         <span
                           class="title three_lines"
@@ -1358,7 +1358,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/63401d8783f485a025e88388"
+                        href="/demarche/63401d8783f485a025e88388"
                       >
                         <span
                           class="title three_lines"
@@ -1503,7 +1503,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/630337ddf2087e2b25ac7609"
+                        href="/demarche/630337ddf2087e2b25ac7609"
                       >
                         <span
                           class="title three_lines"
@@ -1648,7 +1648,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/62f265d81119eede87fb1ae2"
+                        href="/demarche/62f265d81119eede87fb1ae2"
                       >
                         <span
                           class="title three_lines"
@@ -1798,7 +1798,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/62b9809b796009107a932cbc"
+                        href="/demarche/62b9809b796009107a932cbc"
                       >
                         <span
                           class="title three_lines"
@@ -1943,7 +1943,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/62bab2e7b47f6b02fa9783f2"
+                        href="/demarche/62bab2e7b47f6b02fa9783f2"
                       >
                         <span
                           class="title three_lines"
@@ -2093,7 +2093,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/62b5cc16092a73346b4a9a11"
+                        href="/demarche/62b5cc16092a73346b4a9a11"
                       >
                         <span
                           class="title three_lines"
@@ -2238,7 +2238,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/62a897aceece9a373f34ee49"
+                        href="/demarche/62a897aceece9a373f34ee49"
                       >
                         <span
                           class="title three_lines"
@@ -2383,7 +2383,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/procedure/62a8ae34eece9a373f350351"
+                        href="/demarche/62a8ae34eece9a373f350351"
                       >
                         <span
                           class="title three_lines"
@@ -2576,7 +2576,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/6317279072a7091286cfaf24"
+                        href="/dispositif/6317279072a7091286cfaf24"
                       >
                         <span
                           class="title three_lines"
@@ -2715,7 +2715,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/638dcbbaf0b1a31177cf9602"
+                        href="/dispositif/638dcbbaf0b1a31177cf9602"
                       >
                         <span
                           class="title three_lines"
@@ -2854,7 +2854,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/638613c54730d143903ca9ca"
+                        href="/dispositif/638613c54730d143903ca9ca"
                       >
                         <span
                           class="title three_lines"
@@ -2988,7 +2988,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/63873a586fd089c3dad298f2"
+                        href="/dispositif/63873a586fd089c3dad298f2"
                       >
                         <span
                           class="title three_lines"
@@ -3127,7 +3127,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/635a71c8d43c4d1a3f25227f"
+                        href="/dispositif/635a71c8d43c4d1a3f25227f"
                       >
                         <span
                           class="title three_lines"
@@ -3266,7 +3266,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/6376470705f74970c5342371"
+                        href="/dispositif/6376470705f74970c5342371"
                       >
                         <span
                           class="title three_lines"
@@ -3400,7 +3400,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/634d28bd9d3bda3be5cfd979"
+                        href="/dispositif/634d28bd9d3bda3be5cfd979"
                       >
                         <span
                           class="title three_lines"
@@ -3539,7 +3539,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/6332c0e6a36f411314ba4ca3"
+                        href="/dispositif/6332c0e6a36f411314ba4ca3"
                       >
                         <span
                           class="title three_lines"
@@ -3673,7 +3673,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/636cd4572c725bfbf72d6302"
+                        href="/dispositif/636cd4572c725bfbf72d6302"
                       >
                         <span
                           class="title three_lines"
@@ -3812,7 +3812,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/63231e68d585c0849a9bb2b1"
+                        href="/dispositif/63231e68d585c0849a9bb2b1"
                       >
                         <span
                           class="title three_lines"
@@ -3951,7 +3951,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/634e7269313f6183f3510709"
+                        href="/dispositif/634e7269313f6183f3510709"
                       >
                         <span
                           class="title three_lines"
@@ -4090,7 +4090,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/634fba2814dbd7acb5c4f759"
+                        href="/dispositif/634fba2814dbd7acb5c4f759"
                       >
                         <span
                           class="title three_lines"
@@ -4224,7 +4224,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/6317495572a7091286cfbd68"
+                        href="/dispositif/6317495572a7091286cfbd68"
                       >
                         <span
                           class="title three_lines"
@@ -4363,7 +4363,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/6336f551bf68aaed7fe0f8b4"
+                        href="/dispositif/6336f551bf68aaed7fe0f8b4"
                       >
                         <span
                           class="title three_lines"
@@ -4497,7 +4497,7 @@ exports[`homepage renders homepage 1`] = `
                       class="fr-card__title"
                     >
                       <a
-                        href="/program/63623b16a2a5bf7006723347"
+                        href="/dispositif/63623b16a2a5bf7006723347"
                       >
                         <span
                           class="title three_lines"

--- a/apps/client/src/components/Backend/screens/UserFavorites/UserFavorites.tsx
+++ b/apps/client/src/components/Backend/screens/UserFavorites/UserFavorites.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import { useEffect, useMemo, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import TitleWithNumber from "~/components/Backend/TitleWithNumber";
@@ -7,6 +6,7 @@ import { FrameModal } from "~/components/Modals";
 import DispositifCard from "~/components/UI/DispositifCard";
 import FButton from "~/components/UI/FButton/FButton";
 import Toast from "~/components/UI/Toast";
+import { useLocale } from "~/hooks";
 import { LoadingStatusKey } from "~/services/LoadingStatus/loadingStatus.actions";
 import { isLoadingSelector } from "~/services/LoadingStatus/loadingStatus.selectors";
 import {
@@ -27,9 +27,8 @@ const UserFavorites = (props: Props) => {
   const [showTutoModal, setShowTutoModal] = useState(false);
   const toggleTutoModal = () => setShowTutoModal(!showTutoModal);
 
-  const router = useRouter();
   const dispatch = useDispatch();
-  const locale = router.locale || "fr";
+  const locale = useLocale();
 
   useEffect(() => {
     document.title = props.title;

--- a/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
@@ -448,7 +448,7 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                     class="fr-card__title"
                   >
                     <a
-                      href="/program/id1"
+                      href="/dispositif/id1"
                     >
                       <span
                         class="title three_lines"
@@ -572,7 +572,7 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                     class="fr-card__title"
                   >
                     <a
-                      href="/program/id2"
+                      href="/dispositif/id2"
                     >
                       <span
                         class="title three_lines"
@@ -696,7 +696,7 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                     class="fr-card__title"
                   >
                     <a
-                      href="/procedure/id3"
+                      href="/demarche/id3"
                     >
                       <span
                         class="title three_lines"

--- a/apps/client/src/components/Backend/screens/UserNotifications/__tests__/UserNotifications.test.tsx
+++ b/apps/client/src/components/Backend/screens/UserNotifications/__tests__/UserNotifications.test.tsx
@@ -197,7 +197,7 @@ describe("UserNotifications", () => {
       locale: "fr",
     });
     await user.click(component.getByTestId("test-notif-annuaire"));
-    expect(Router).toMatchObject({ asPath: "/directory-create" });
+    expect(Router).toMatchObject({ asPath: "/annuaire-creation" });
   });
 
   it("should delete notif reaction", () => {

--- a/apps/client/src/components/Backend/screens/UserNotifications/components/Notification.tsx
+++ b/apps/client/src/components/Backend/screens/UserNotifications/components/Notification.tsx
@@ -4,6 +4,7 @@ import { getPath } from "routes";
 import styled from "styled-components";
 import EVAIcon from "~/components/UI/EVAIcon/EVAIcon";
 import FButton from "~/components/UI/FButton/FButton";
+import { useLocale } from "~/hooks";
 import { colors } from "~/utils/colors";
 
 const Container = styled.div<{ read: boolean }>`
@@ -85,6 +86,7 @@ const getFormattedDate = (createdAt: Date) => {
 };
 export const Notification = (props: Props) => {
   const router = useRouter();
+  const locale = useLocale();
   const onNotifClick = (event: any) => {
     event.stopPropagation();
     if (props.type === "reaction") {
@@ -93,7 +95,7 @@ export const Notification = (props: Props) => {
     }
 
     if (props.type === "annuaire") {
-      return router.push(getPath("/annuaire-creation", router.locale));
+      return router.push(getPath("/annuaire-creation", locale));
     }
 
     if (props.type === "new content" && props.link) {

--- a/apps/client/src/components/Backend/screens/UserStructure/__tests__/__snapshots__/UserStructure.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserStructure/__tests__/__snapshots__/UserStructure.test.tsx.snap
@@ -172,7 +172,7 @@ exports[`UserStructure should render correctly when add member modal is open 1`]
         </div>
         <a
           class="btn dark"
-          href="/directory/structureId"
+          href="/annuaire/structureId"
         >
           <span
             class="me-2 icon"
@@ -1002,7 +1002,7 @@ exports[`UserStructure should render correctly when structure with membres when 
         </div>
         <a
           class="btn dark"
-          href="/directory/structureId"
+          href="/annuaire/structureId"
         >
           <span
             class="me-2 icon"
@@ -1488,7 +1488,7 @@ exports[`UserStructure should render correctly when structure with membres when 
         </div>
         <a
           class="btn dark"
-          href="/directory/structureId"
+          href="/annuaire/structureId"
         >
           <span
             class="me-2 icon"

--- a/apps/client/src/components/Backend/screens/UserStructure/components/UserStructureDetails.tsx
+++ b/apps/client/src/components/Backend/screens/UserStructure/components/UserStructureDetails.tsx
@@ -1,6 +1,5 @@
 import { GetStructureResponse, Id, Picture, StructureMember } from "@refugies-info/api-types";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { useState } from "react";
 import { getPath } from "routes";
 import styled from "styled-components";
@@ -8,6 +7,7 @@ import placeholder from "~/assets/no_results_alt.svg";
 import TitleWithNumber from "~/components/Backend/TitleWithNumber";
 import FButton from "~/components/UI/FButton/FButton";
 import Image from "~/components/UI/Image";
+import { useLocale } from "~/hooks";
 import AddMemberModal from "./AddMemberModal";
 import { MembresTable } from "./MembresTable";
 import { MainContainer, StructureContainer, StructurePictureContainer } from "./SubComponents";
@@ -43,7 +43,7 @@ const checkIfUserIsAuthorizedToAddMembers = (isAdmin: boolean, userWithRole: Get
 };
 
 export const UserStructureDetails = (props: Props) => {
-  const router = useRouter();
+  const locale = useLocale();
   const [showAddMemberModal, setShowAddMemberModal] = useState(false);
   const toggleAddMemberModal = () => setShowAddMemberModal(!showAddMemberModal);
 
@@ -77,7 +77,7 @@ export const UserStructureDetails = (props: Props) => {
           <Link
             legacyBehavior
             href={{
-              pathname: getPath("/annuaire/[id]", router.locale),
+              pathname: getPath("/annuaire/[id]", locale),
               query: { id: props.structureId.toString() },
             }}
             passHref

--- a/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
+++ b/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
@@ -1,10 +1,9 @@
 import { Footer as DSFRFooter, FooterProps } from "@codegouvfr/react-dsfr/Footer";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { useDispatch, useSelector } from "react-redux";
 import { getPath } from "routes";
-import { useEditionMode } from "~/hooks";
+import { useEditionMode, useLocale } from "~/hooks";
 import { FooterConsentManagementItem, FooterPersonalDataPolicyItem } from "~/hooks/useConsentContext";
 import { cn } from "~/lib/classname";
 import { Event } from "~/lib/tracking";
@@ -13,7 +12,7 @@ import { themesSelector } from "~/services/Themes/themes.selectors";
 import styles from "./FooterDSFR.module.scss";
 
 const Footer = () => {
-  const router = useRouter();
+  const locale = useLocale();
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const isEditionMode = useEditionMode();
@@ -29,7 +28,7 @@ const Footer = () => {
   return (
     <DSFRFooter
       accessibility="non compliant"
-      accessibilityLinkProps={{ href: getPath("/declaration-accessibilite", router.locale), prefetch: false }}
+      accessibilityLinkProps={{ href: getPath("/declaration-accessibilite", locale), prefetch: false }}
       brandTop="GOUVERNEMENT"
       id="footer"
       className={cn(styles.footer)}
@@ -60,12 +59,12 @@ const Footer = () => {
         </Link>,
       ]}
       termsLinkProps={{
-        href: getPath("/mentions-legales", router.locale),
+        href: getPath("/mentions-legales", locale),
         title: t("Footer.legal_terms", "Mentions légales"),
         prefetch: false,
       }}
       websiteMapLinkProps={{
-        href: getPath("/plan-du-site", router.locale),
+        href: getPath("/plan-du-site", locale),
         title: t("Footer.Plan du site", "Plan du site"),
         prefetch: false,
       }}
@@ -74,9 +73,9 @@ const Footer = () => {
           categoryName: "Chercher par thématique",
           links: themes.map((theme) => ({
             linkProps: {
-              href: `${getPath("/recherche", router.locale)}?themes=${theme._id}`,
+              href: `${getPath("/recherche", locale)}?themes=${theme._id}`,
             },
-            text: theme.short[router.locale || "fr"],
+            text: theme.short[locale || "fr"],
           })) as FooterProps.LinkList.Links,
         },
         {
@@ -84,22 +83,22 @@ const Footer = () => {
           links: [
             {
               linkProps: {
-                href: getPath("/recherche", router.locale, "?type=dispositif"),
-                hrefLang: router.locale,
+                href: getPath("/recherche", locale, "?type=dispositif"),
+                hrefLang: locale,
               },
               text: t("Footer.Les fiches actions", "Les fiches actions"),
             },
             {
               linkProps: {
-                href: getPath("/recherche", router.locale, "?type=demarche"),
-                hrefLang: router.locale,
+                href: getPath("/recherche", locale, "?type=demarche"),
+                hrefLang: locale,
               },
               text: t("Footer.procedures", "Les fiches démarches"),
             },
             {
               linkProps: {
-                href: getPath("/annuaire", router.locale),
-                hrefLang: router.locale,
+                href: getPath("/annuaire", locale),
+                hrefLang: locale,
                 prefetch: false,
               },
               text: t("Footer.directory", "L’annuaire des acteurs"),
@@ -111,14 +110,14 @@ const Footer = () => {
           links: [
             {
               linkProps: {
-                href: getPath("/publier", router.locale),
+                href: getPath("/publier", locale),
                 prefetch: false,
               },
               text: t("Footer.Recenser mon action", "Recenser mon action"),
             },
             {
               linkProps: {
-                href: getPath("/traduire", router.locale),
+                href: getPath("/traduire", locale),
                 prefetch: false,
               },
               text: t("Footer.help_translate", "Aider à traduire"),
@@ -194,7 +193,7 @@ const Footer = () => {
           links: [
             {
               linkProps: {
-                href: getPath("/mission-et-impact", router.locale),
+                href: getPath("/mission-et-impact", locale),
                 prefetch: false,
               },
               text: t("Footer.mission_impact", "Mission et impact"),

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
@@ -6,6 +6,7 @@ import { isMobile } from "react-device-detect";
 import { Col, ListGroup, ListGroupItem, Modal, ModalBody, ModalHeader, Row } from "reactstrap";
 import { getPath } from "routes";
 import { LanguageSelector } from "~/components/UI/LanguageSelector";
+import useLocale from "~/hooks/useLocale";
 import styles from "./LanguageModal.module.scss";
 
 interface Props {
@@ -20,6 +21,7 @@ interface Props {
 const LanguageModal = (props: Props) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const locale = useLocale();
 
   return (
     <Modal isOpen={props.show} toggle={props.toggle} className={styles.modal} contentClassName={styles.modal_content}>
@@ -52,7 +54,7 @@ const LanguageModal = (props: Props) => {
                       props.toggle();
                       setTimeout(() => {
                         router.push({
-                          pathname: getPath("/traduire", router.locale),
+                          pathname: getPath("/traduire", locale),
                         });
                       }, 100);
                     }}

--- a/apps/client/src/components/Modals/WriteContentModal/WriteContentModal.tsx
+++ b/apps/client/src/components/Modals/WriteContentModal/WriteContentModal.tsx
@@ -7,6 +7,7 @@ import { getPath } from "routes";
 import { assetsOnServer } from "~/assets/assetsOnServer";
 import EVAIcon from "~/components/UI/EVAIcon/EVAIcon";
 import FButton from "~/components/UI/FButton/FButton";
+import { useLocale } from "~/hooks";
 import { userSelector } from "~/services/User/user.selectors";
 import Modal from "../Modal";
 import { pseudoModal, PseudoModal } from "../PseudoModal";
@@ -20,6 +21,7 @@ interface Props {
 
 const WriteContentModal = ({ show, close }: Props) => {
   const router = useRouter();
+  const locale = useLocale();
   const user = useSelector(userSelector);
   const isPseudoModalOpen = useIsModalOpen(pseudoModal);
 
@@ -46,7 +48,7 @@ const WriteContentModal = ({ show, close }: Props) => {
 
   const navigate = () => {
     const path = selected === "dispositif" ? "/dispositif" : "/demarche";
-    router.push(getPath(path, router.locale));
+    router.push(getPath(path, locale));
   };
 
   return (

--- a/apps/client/src/components/Navigation/Navbar/Navbar.tsx
+++ b/apps/client/src/components/Navigation/Navbar/Navbar.tsx
@@ -1,6 +1,5 @@
 import { Header } from "@codegouvfr/react-dsfr/Header";
 import { MainNavigationProps } from "@codegouvfr/react-dsfr/MainNavigation";
-import { Languages } from "@refugies-info/api-types";
 import { androidStoreLink, iosStoreLink } from "data/storeLinks";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
@@ -12,7 +11,7 @@ import { assetsOnServer } from "~/assets/assetsOnServer";
 import useBackendNavigation from "~/components/Backend/Navigation/useBackendNavigation";
 import { QuickAccessMenu } from "~/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu";
 import Image from "~/components/UI/Image";
-import { useEditionMode, useWindowSize } from "~/hooks";
+import { useEditionMode, useLocale, useWindowSize } from "~/hooks";
 import isInBrowser from "~/lib/isInBrowser";
 import { Event } from "~/lib/tracking";
 import { toggleNewsletterModalAction } from "~/services/Miscellaneous/miscellaneous.actions";
@@ -21,6 +20,7 @@ import styles from "./Navbar.module.scss";
 const Navbar = () => {
   const { t } = useTranslation();
   const router = useRouter();
+  const locale = useLocale();
   const isEditionMode = useEditionMode();
   const backendNavigation = useBackendNavigation();
   const dispatch = useDispatch();
@@ -32,11 +32,10 @@ const Navbar = () => {
   }, [dispatch]);
 
   const navigationItems: MainNavigationProps.Item[] = useMemo(() => {
-    const locale: Languages = (router.locale || "fr") as Languages;
     const isCurrent = (href: string, paramCheck?: { param: string; value: string }) => {
       if (!isInBrowser()) return false;
       const currentPath = window?.location?.pathname || "";
-      const isPathMatching = currentPath === "/" + router.locale + href;
+      const isPathMatching = currentPath === "/" + locale + href;
 
       if (paramCheck) {
         const urlParams = new URLSearchParams(window?.location?.search || "");
@@ -53,36 +52,36 @@ const Navbar = () => {
     return [
       {
         linkProps: {
-          href: getPath("/recherche", router.locale, "?search=&sort=default&type=demarche"),
+          href: getPath("/recherche", locale, "?search=&sort=default&type=demarche"),
           className: styles.navLinkWithSearchIcon,
         },
         text: t("Toolbar.fichesDemarches", "Fiches démarches"),
-        isActive: isCurrent(getPath("/recherche", router.locale), {
+        isActive: isCurrent(getPath("/recherche", locale), {
           param: "type",
           value: "demarche",
         }),
       },
       {
         linkProps: {
-          href: getPath("/recherche", router.locale, "?search=&sort=default&type=dispositif"),
+          href: getPath("/recherche", locale, "?search=&sort=default&type=dispositif"),
           prefetch: false,
           className: styles.navLinkWithSearchIcon,
         },
         text: t("Toolbar.dispositifsLocaux", "Dispositifs locaux"),
-        isActive: isCurrent(getPath("/recherche", router.locale), {
+        isActive: isCurrent(getPath("/recherche", locale), {
           param: "type",
           value: "dispositif",
         }),
       },
       {
-        linkProps: { href: getPath("/agir", router.locale), prefetch: false },
+        linkProps: { href: getPath("/agir", locale), prefetch: false },
         text: t("Toolbar.agir", "AGIR"),
-        isActive: isCurrent(getPath("/agir", router.locale)),
+        isActive: isCurrent(getPath("/agir", locale)),
       },
       {
-        linkProps: { href: getPath("/mission-et-impact", router.locale), prefetch: false },
+        linkProps: { href: getPath("/mission-et-impact", locale), prefetch: false },
         text: t("Toolbar.missionImpact", "Mission et impact"),
-        isActive: isCurrent(getPath("/mission-et-impact", router.locale)),
+        isActive: isCurrent(getPath("/mission-et-impact", locale)),
       },
       {
         text: t("Toolbar.partagerProjet", "Ressources"),
@@ -110,7 +109,7 @@ const Navbar = () => {
       !isMobile
         ? {
             linkProps: {
-              href: getPath("/", router.locale, "#application"),
+              href: getPath("/", locale, "#application"),
               className: styles.navLinkWithAppIcon,
             },
             text: t("Toolbar.shareApplication", "Partager l'application"),
@@ -119,7 +118,7 @@ const Navbar = () => {
 
       {
         linkProps: {
-          href: isMobile ? "#" : getPath("/", router.locale, "#newsletter"),
+          href: isMobile ? "#" : getPath("/", locale, "#newsletter"),
           onClick: isMobile ? toggleNewsletter : undefined,
         },
         text: t("Toolbar.newsletter", "Newsletter"),
@@ -152,7 +151,7 @@ const Navbar = () => {
           }
         : null,
     ].filter((n) => n !== null) as MainNavigationProps.Item[];
-  }, [router.locale, router.pathname, backendNavigation, t, isMobile, toggleNewsletter]);
+  }, [locale, router.pathname, backendNavigation, t, isMobile, toggleNewsletter]);
 
   const quickAccessMenu = QuickAccessMenu();
 

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
@@ -1,12 +1,11 @@
 import { Accordion } from "@codegouvfr/react-dsfr/Accordion";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { useIsHeaderMenuModalOpen } from "@codegouvfr/react-dsfr/Header/useIsHeaderMenuModalOpen";
 import { activatedLanguages } from "data/activatedLanguages";
 import { useTranslation } from "next-i18next";
-import router from "next/router";
 import { useRef, useState } from "react";
 import { DropdownContent, DropdownRoot, DropdownTrigger } from "~/components/UI/DropDown/DropDown";
 import { LanguageSelector } from "~/components/UI/LanguageSelector/LanguageSelector";
+import { useLocale } from "~/hooks";
 import useStylesDisabled from "~/hooks/useStyleDisabled";
 import useWindowSize from "~/hooks/useWindowSize";
 import { cls } from "~/lib/classname";
@@ -14,9 +13,8 @@ import styles from "./LanguageMenu.module.scss";
 
 const LanguageMenu = () => {
   const [langMenuOpened, setLangMenuOpened] = useState(false);
-  const isOpen = useIsHeaderMenuModalOpen();
 
-  const locale = router.locale || "fr";
+  const locale = useLocale();
   const currentLanguage = activatedLanguages.find((lang) => lang.i18nCode === locale);
 
   const { isMobile } = useWindowSize();
@@ -58,7 +56,7 @@ const LanguageMenu = () => {
         <DropdownRoot ref={dropdownRef} key="language" onOpenChange={(open) => setLangMenuOpened(open)}>
           <DropdownTrigger asChild>
             <Button iconId="fr-icon-translate-2" priority="tertiary">
-              {router.locale?.toLocaleUpperCase()}{" "}
+              {locale?.toLocaleUpperCase()}{" "}
               <i className={cls(langMenuOpened ? "fr-icon-arrow-up-s-line" : "fr-icon-arrow-down-s-line")} />
             </Button>
           </DropdownTrigger>

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LoginButton.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LoginButton.tsx
@@ -1,14 +1,15 @@
 import Button from "@codegouvfr/react-dsfr/Button";
 import { RoleName } from "@refugies-info/api-types";
 import { useTranslation } from "next-i18next";
-import router from "next/router";
 import { memo } from "react";
 import { useSelector } from "react-redux";
+import { useLocale } from "~/hooks";
 import { getPath } from "~/routes";
 import { userSelector } from "~/services/User/user.selectors";
 import styles from "./LoginButton.module.scss";
 
 const LoginButton = () => {
+  const locale = useLocale();
   const { user } = useSelector(userSelector);
   const { t } = useTranslation();
 
@@ -45,7 +46,7 @@ const LoginButton = () => {
           key="login"
           priority="primary"
           linkProps={{
-            href: getPath("/auth", router.locale),
+            href: getPath("/auth", locale),
             prefetch: false,
           }}
           iconId="fr-icon-account-pin-circle-line"

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
@@ -1,9 +1,8 @@
 import Button from "@codegouvfr/react-dsfr/Button";
 import { useTranslation } from "next-i18next";
-import router from "next/router";
 import LanguageMenu from "~/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu";
 import LoginButton from "~/components/Navigation/Navbar/QuickAccessMenu/LoginButton";
-import { useWindowSize } from "~/hooks";
+import { useLocale, useWindowSize } from "~/hooks";
 import { getPath } from "~/routes";
 
 // This component retunrs an array of JSX items specifically for the DSFR Header component
@@ -17,12 +16,13 @@ import { getPath } from "~/routes";
 const QuickAccessMenu = () => {
   const { t } = useTranslation();
   const { isMobile } = useWindowSize();
+  const locale = useLocale();
 
   const menuItems = [
     <Button
       key="publish"
       linkProps={{
-        href: getPath("/publier", router.locale),
+        href: getPath("/publier", locale),
         prefetch: false,
       }}
       iconId="fr-icon-file-add-line"
@@ -33,7 +33,7 @@ const QuickAccessMenu = () => {
     <Button
       key="translate"
       linkProps={{
-        href: getPath("/traduire", router.locale),
+        href: getPath("/traduire", locale),
         prefetch: false,
       }}
       iconId="fr-icon-message-2-line"

--- a/apps/client/src/components/Pages/annuaire-create/Step6.tsx
+++ b/apps/client/src/components/Pages/annuaire-create/Step6.tsx
@@ -1,17 +1,17 @@
 import { Id } from "@refugies-info/api-types";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { getPath } from "routes";
 import gif from "~/assets/annuaire/GIF-annuaire.gif";
 import FButton from "~/components/UI/FButton/FButton";
 import Image from "~/components/UI/Image";
+import { useLocale } from "~/hooks";
 import styles from "./Step6.module.scss";
 
 interface Props {
   structureId: string | Id;
 }
 export const Step6 = (props: Props) => {
-  const router = useRouter();
+  const locale = useLocale();
 
   return (
     <div className="step6">
@@ -24,7 +24,7 @@ export const Step6 = (props: Props) => {
       <Link
         legacyBehavior
         href={{
-          pathname: getPath("/annuaire/[id]", router.locale),
+          pathname: getPath("/annuaire/[id]", locale),
           query: { id: props.structureId.toString() },
         }}
         passHref

--- a/apps/client/src/components/Pages/annuaire/id/LeftAnnuaireDetail.tsx
+++ b/apps/client/src/components/Pages/annuaire/id/LeftAnnuaireDetail.tsx
@@ -5,6 +5,7 @@ import { getPath, isRoute } from "routes";
 import placeholder from "~/assets/no_results_alt.svg";
 import FButton from "~/components/UI/FButton/FButton";
 import Image from "~/components/UI/Image";
+import useLocale from "~/hooks/useLocale";
 import styles from "./LeftAnnuaireDetail.module.scss";
 import { SocialsLink } from "./SocialsLink";
 import { StructureType } from "./StructureType";
@@ -18,6 +19,7 @@ interface Props {
 export const LeftAnnuaireDetail = (props: Props) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const locale = useLocale();
 
   const getSecureUrl = (picture: Picture | undefined) => {
     if (picture && picture.secure_url) return picture.secure_url;
@@ -29,7 +31,7 @@ export const LeftAnnuaireDetail = (props: Props) => {
     if (props.history[1] && isRoute(props.history[1], "/annuaire")) {
       router.push(props.history[1]);
     } else {
-      router.push(getPath("/annuaire", router.locale));
+      router.push(getPath("/annuaire", locale));
     }
   };
   if (props.structure && !props.isLoading) {

--- a/apps/client/src/components/Pages/annuaire/id/MiddleAnnuaireDetails.tsx
+++ b/apps/client/src/components/Pages/annuaire/id/MiddleAnnuaireDetails.tsx
@@ -16,6 +16,7 @@ import { activities } from "data/activities";
 import { getPath } from "routes";
 
 import { GetStructureResponse, GetThemeResponse } from "@refugies-info/api-types";
+import { useLocale } from "~/hooks";
 import { themesSelector } from "~/services/Themes/themes.selectors";
 import styles from "./MiddleAnnuaireDetails.module.scss";
 
@@ -113,6 +114,7 @@ const sortStructureActivities = (structure: GetStructureResponse | null, themes:
 export const MiddleAnnuaireDetail = (props: Props) => {
   const { t } = useTranslation();
   const router = useRouter();
+  const locale = useLocale();
   const structure = props.structure;
   const admin = useSelector(userSelector).admin;
   const themes = useSelector(themesSelector);
@@ -133,7 +135,7 @@ export const MiddleAnnuaireDetail = (props: Props) => {
           </div>
           {hasUpdatePermission && (
             <div style={{ height: "5Opx" }}>
-              <Link legacyBehavior href={getPath("/annuaire-creation", router.locale)} passHref prefetch={false}>
+              <Link legacyBehavior href={getPath("/annuaire-creation", locale)} passHref prefetch={false}>
                 <FButton tag="a" type="dark" name="edit-outline">
                   Modifier la fiche
                 </FButton>

--- a/apps/client/src/components/Pages/annuaire/index/Header.tsx
+++ b/apps/client/src/components/Pages/annuaire/index/Header.tsx
@@ -1,8 +1,8 @@
 import { GetActiveStructuresResponse } from "@refugies-info/api-types";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { getPath } from "routes";
+import { useLocale } from "~/hooks";
 import useRTL from "~/hooks/useRTL";
 import styles from "./Header.module.scss";
 import { SearchBarAnnuaire } from "./SearchBarAnnuaire";
@@ -30,7 +30,7 @@ interface Props {
 export const Header = (props: Props) => {
   const isRTL = useRTL();
   const { t } = useTranslation();
-  const router = useRouter();
+  const locale = useLocale();
 
   return (
     <>
@@ -67,7 +67,7 @@ export const Header = (props: Props) => {
                 legacyBehavior
                 href={getPath(
                   "/annuaire",
-                  router.locale,
+                  locale,
                   props.lettersClickable.includes(letter.toLocaleUpperCase()) ? "#" + letter.toUpperCase() : "",
                 )}
                 key={letter}

--- a/apps/client/src/components/Pages/annuaire/index/LetterSection.tsx
+++ b/apps/client/src/components/Pages/annuaire/index/LetterSection.tsx
@@ -1,10 +1,10 @@
 import { GetActiveStructuresResponse, Id, Picture } from "@refugies-info/api-types";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { useMemo } from "react";
 import { getPath } from "routes";
 import placeholder from "~/assets/no_results_alt.svg";
 import Image from "~/components/UI/Image";
+import { useLocale } from "~/hooks";
 import styles from "./LetterSection.module.scss";
 interface StructureCardProps {
   nom: string;
@@ -13,7 +13,7 @@ interface StructureCardProps {
   id: Id;
 }
 const StructureCard = (props: StructureCardProps) => {
-  const router = useRouter();
+  const locale = useLocale();
 
   const title = useMemo(() => {
     return props.acronyme
@@ -27,7 +27,7 @@ const StructureCard = (props: StructureCardProps) => {
     <Link
       legacyBehavior
       href={{
-        pathname: getPath("/annuaire/[id]", router.locale),
+        pathname: getPath("/annuaire/[id]", locale),
         query: { id: props.id.toString() },
       }}
       prefetch={false}

--- a/apps/client/src/components/Pages/dispositif/Banner/Banner.tsx
+++ b/apps/client/src/components/Pages/dispositif/Banner/Banner.tsx
@@ -6,7 +6,7 @@ import { useCallback, useContext, useMemo, useState } from "react";
 import { useSelector } from "react-redux";
 import { getPath } from "routes";
 import Button from "~/components/UI/Button";
-import { useLanguages } from "~/hooks";
+import { useLanguages, useLocale } from "~/hooks";
 import { cls } from "~/lib/classname";
 import { canEdit, isStatus } from "~/lib/dispositif";
 import { selectedDispositifSelector } from "~/services/SelectedDispositif/selectedDispositif.selector";
@@ -55,9 +55,10 @@ const Banner = (props: Props) => {
 
   // ln not available
   const { currentLocale } = useLanguages();
+  const locale = useLocale();
   const isNotTranslated = useMemo(() => {
-    return !(dispositif?.availableLanguages || ["fr"]).includes(router.locale || "fr");
-  }, [router.locale, dispositif]);
+    return !(dispositif?.availableLanguages || ["fr"]).includes(locale || "fr");
+  }, [locale, dispositif]);
 
   return (
     <div

--- a/apps/client/src/components/Pages/dispositif/StructureReceiveDispositif/StructureReceiveDispositif.tsx
+++ b/apps/client/src/components/Pages/dispositif/StructureReceiveDispositif/StructureReceiveDispositif.tsx
@@ -13,6 +13,7 @@ import BaseModal from "~/components/UI/BaseModal";
 import Button from "~/components/UI/Button";
 import EVAIcon from "~/components/UI/EVAIcon/EVAIcon";
 import Image from "~/components/UI/Image";
+import { useLocale } from "~/hooks";
 import { selectedDispositifSelector } from "~/services/SelectedDispositif/selectedDispositif.selector";
 import API from "~/utils/API";
 import { ChoiceButton } from "../Edition";
@@ -41,17 +42,18 @@ const StructureReceiveDispositif = () => {
   };
 
   const router = useRouter();
+  const locale = useLocale();
   const goToEdit = useCallback(() => {
     const id = dispositif?._id;
     if (!id) return;
     router.push({
       pathname:
         dispositif.typeContenu === ContentType.DEMARCHE
-          ? getPath("/demarche/[id]/edit", router.locale)
-          : getPath("/dispositif/[id]/edit", router.locale),
+          ? getPath("/demarche/[id]/edit", locale)
+          : getPath("/dispositif/[id]/edit", locale),
       query: { id: dispositif._id.toString() },
     });
-  }, [router, dispositif]);
+  }, [router, locale, dispositif]);
 
   const quit = useCallback(() => router.push("/backend/user-dash-contrib"), [router]);
 
@@ -120,7 +122,7 @@ const StructureReceiveDispositif = () => {
                 Vous êtes désormais responsable de cette fiche. Nous comptons sur vous pour maintenir ce contenu à jour
                 et répondre aux suggestions des contributeurs.
               </p>
-              <div className="text-center mb-8">
+              <div className="mb-8 text-center">
                 <Image src={ReceiveDispositif} width={224} height={160} alt="" />
               </div>
               <div className="text-end">

--- a/apps/client/src/components/Pages/embed/EmbedHeader/EmbedHeader.tsx
+++ b/apps/client/src/components/Pages/embed/EmbedHeader/EmbedHeader.tsx
@@ -1,8 +1,8 @@
 import { GetThemeResponse } from "@refugies-info/api-types";
 import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import { useSelector } from "react-redux";
 import ThemeIcon from "~/components/UI/ThemeIcon";
+import { useLocale } from "~/hooks";
 import useRTL from "~/hooks/useRTL";
 import { getThemeName } from "~/lib/getThemeName";
 import { allLanguesSelector } from "~/services/Langue/langue.selectors";
@@ -16,7 +16,7 @@ interface Props {
 
 const EmbedHeader = (props: Props) => {
   const { t } = useTranslation();
-  const router = useRouter();
+  const locale = useLocale();
   const isRTL = useRTL();
   const languages = useSelector(allLanguesSelector);
 
@@ -35,7 +35,7 @@ const EmbedHeader = (props: Props) => {
             <span className={styles.theme_icon}>
               <ThemeIcon theme={selectedTheme} size={18} />
             </span>
-            <span className="ms-2">{getThemeName(selectedTheme, router.locale, "short")}</span>
+            <span className="ms-2">{getThemeName(selectedTheme, locale, "short")}</span>
           </span>
         </>
       )}

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -2,21 +2,18 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import { AnnotationsOverlay } from "@refugies-info/ui";
 import { androidStoreLink, iosStoreLink } from "data/storeLinks";
 import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import { useMemo } from "react";
 import { isAndroid, isIOS } from "react-device-detect";
 import { assetsOnServer } from "~/assets/assetsOnServer";
 import application from "~/assets/homepage/application.png";
 import Image from "~/components/UI/Image";
-import { useWindowSize } from "~/hooks";
+import { useLocale, useWindowSize } from "~/hooks";
 import { cn } from "~/lib/classname";
-import { AvailableLanguageI18nCode } from "~/types/interface";
 import MobileAppSmsForm from "./MobileAppSmsForm";
 
 const MobileApp = () => {
   const { t } = useTranslation();
-  const router = useRouter();
-  const locale: AvailableLanguageI18nCode = (router.locale || "fr") as AvailableLanguageI18nCode;
+  const locale = useLocale();
 
   const { isMobile } = useWindowSize();
 

--- a/apps/client/src/components/Seo.tsx
+++ b/apps/client/src/components/Seo.tsx
@@ -1,6 +1,7 @@
 import Head from "next/head";
 import { NextRouter, useRouter } from "next/router";
 import { getPath, PathNames } from "routes";
+import { useLocale } from "~/hooks";
 import { getBaseUrl } from "~/lib/getBaseUrl";
 
 interface Props {
@@ -31,16 +32,17 @@ const getImagePath = (imagePath: string) => {
 const SEO = (props: Props) => {
   const prefixTitle = props.title ? `${props.title} - ` : "";
   const router = useRouter();
+  const locale = useLocale();
 
   return (
     <Head>
       <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
       <title>{prefixTitle + defaultTitle}</title>
       {props.description && <meta name="description" content={props.description} />}
-      <link rel="canonical" href={getFullPath(router, router.locale || "fr")} />
+      <link rel="canonical" href={getFullPath(router, locale)} />
 
       {/* OPENGRAPH */}
-      <meta property="og:url" content={getFullPath(router, router.locale || "fr")} />
+      <meta property="og:url" content={getFullPath(router, locale)} />
       <meta property="og:type" content="website" />
       {props.title && <meta property="og:title" content={props.title} />}
       {props.description && <meta property="og:description" content={props.description} />}
@@ -56,7 +58,7 @@ const SEO = (props: Props) => {
       {props.description && <meta property="twitter:description" content={props.description} />}
       <meta property="twitter:image" content={getImagePath(props.image || defaultImage)} />
 
-      {getAlternateLocales(router.locales, router.locale).map((ln: string, i: number) => (
+      {getAlternateLocales(router.locales, locale).map((ln: string, i: number) => (
         <link key={i} hrefLang={ln} href={getFullPath(router, ln)} rel="alternate"></link>
       ))}
     </Head>

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -2,14 +2,13 @@ import Badge from "@codegouvfr/react-dsfr/Badge";
 import { ContentType, SimpleDispositif } from "@refugies-info/api-types";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { memo, useMemo } from "react";
 import { useSelector } from "react-redux";
 import defaultStructureImage from "~/assets/recherche/default-structure-image.svg";
 import demarcheIcon from "~/assets/recherche/illu-demarche.svg";
 import FavoriteButton from "~/components/UI/FavoriteButton";
 import Image from "~/components/UI/Image";
-import { useSanitizedContent, useUtmz } from "~/hooks";
+import { useLocale, useSanitizedContent, useUtmz } from "~/hooks";
 import { useCardImageUrl } from "~/hooks/useCardImage";
 import { jsLcfirst, jsUcfirst } from "~/lib";
 import { cls } from "~/lib/classname";
@@ -31,7 +30,7 @@ interface Props {
 
 const DispositifCard = (props: Props) => {
   const { t } = useTranslation();
-  const router = useRouter();
+  const locale = useLocale();
   const themes = useSelector(themesSelector);
   const isDispositif = useMemo(
     () => props.dispositif.typeContenu === ContentType.DISPOSITIF,
@@ -85,7 +84,7 @@ const DispositifCard = (props: Props) => {
                     props.demoCard
                       ? "#"
                       : {
-                          pathname: getPath(`/${props.dispositif.typeContenu}/[id]`, router.locale),
+                          pathname: getPath(`/${props.dispositif.typeContenu}/[id]`, locale),
                           query: { id: props.dispositif._id.toString(), ...utmParams },
                         }
                   }
@@ -150,13 +149,7 @@ const DispositifCard = (props: Props) => {
                     <div className={styles.info}>
                       <span className="shrink">
                         <i className="fr-icon-time-line me-2" />
-                        <span>
-                          {getRelativeTimeString(
-                            new Date(props.dispositif.lastModificationDate),
-                            router.locale || "fr",
-                            t,
-                          )}
-                        </span>
+                        <span>{getRelativeTimeString(new Date(props.dispositif.lastModificationDate), locale, t)}</span>
                       </span>
                     </div>
                   )}

--- a/apps/client/src/components/UI/LanguageSelector/LanguageItem.tsx
+++ b/apps/client/src/components/UI/LanguageSelector/LanguageItem.tsx
@@ -2,11 +2,9 @@ import Badge from "@codegouvfr/react-dsfr/Badge";
 import { Tag } from "@codegouvfr/react-dsfr/Tag";
 import { GetLanguagesResponse } from "@refugies-info/api-types";
 import { useTranslation } from "next-i18next";
-import router from "next/router";
 import { forwardRef, memo, useCallback } from "react";
 import { useSelector } from "react-redux";
-import { useChangeLanguage } from "~/hooks";
-import useStylesDisabled from "~/hooks/useStyleDisabled";
+import { useChangeLanguage, useLocale } from "~/hooks";
 import { cls } from "~/lib/classname";
 import { Event } from "~/lib/tracking";
 import { allLanguesSelector } from "~/services/Langue/langue.selectors";
@@ -21,10 +19,9 @@ interface LanguageItemProps {
 const LanguageItem = memo(
   forwardRef<HTMLButtonElement, LanguageItemProps>(({ item, className, onChangeLang, ...props }, ref) => {
     const { t } = useTranslation();
-    const stylesDisabled = useStylesDisabled();
 
     const { changeLanguage, loading } = useChangeLanguage();
-    const currentLanguage = router.locale || "fr";
+    const currentLanguage = useLocale();
 
     const langues = useSelector(allLanguesSelector);
     const notListenableLanguages = ["er"];

--- a/apps/client/src/components/UI/ThemeButton/ThemeButton.tsx
+++ b/apps/client/src/components/UI/ThemeButton/ThemeButton.tsx
@@ -1,7 +1,6 @@
 import { GetThemeResponse } from "@refugies-info/api-types";
-import { useTranslation } from "next-i18next";
-import { useRouter } from "next/router";
 import styled from "styled-components";
+import { useLocale } from "~/hooks";
 import { getThemeName } from "~/lib/getThemeName";
 import ThemeIcon from "../ThemeIcon";
 
@@ -32,13 +31,12 @@ interface Props {
 }
 
 export const ThemeButton = (props: Props) => {
-  const { t } = useTranslation();
-  const router = useRouter();
+  const locale = useLocale();
 
   return (
     <ThemeButtonContainer color={props.theme ? props.theme.colors.color100 : ""}>
       <ThemeIcon theme={props.theme} size={14} />
-      <ThemeText mr={props.isRTL ? 8 : 0}>{getThemeName(props.theme, router.locale, "short")}</ThemeText>
+      <ThemeText mr={props.isRTL ? 8 : 0}>{getThemeName(props.theme, locale, "short")}</ThemeText>
     </ThemeButtonContainer>
   );
 };

--- a/apps/client/src/pages/_app.tsx
+++ b/apps/client/src/pages/_app.tsx
@@ -5,16 +5,15 @@ import { Caveat } from "next/font/google";
 
 import { createNextDsfrIntegrationApi } from "@codegouvfr/react-dsfr/next-pagesdir";
 import { DirectionProvider } from "@radix-ui/react-direction";
-import { ToastProvider } from "@radix-ui/react-toast";
+import { ToastProvider, ToastViewport } from "@radix-ui/react-toast";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type { NextPage } from "next";
 import { appWithTranslation } from "next-i18next";
 import type { AppProps } from "next/app";
-import dynamic from "next/dynamic";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import Script from "next/script";
-import { ReactElement, ReactNode, useCallback, useEffect, useMemo, useState } from "react";
+import { ReactElement, ReactNode, useCallback, useEffect, useState } from "react";
 import { Provider } from "react-redux";
 import { useEffectOnce } from "react-use";
 import toastStyles from "scss/components/toast.module.scss";
@@ -106,15 +105,6 @@ const App = ({ Component, ...pageProps }: AppPropsWithLayout) => {
   }, []);
 
   const isRTL = useRTL();
-
-  // These radix-ui components create hydration issues if rendered server side
-  const ToastViewport = useMemo(
-    () =>
-      dynamic(() => import("@radix-ui/react-toast").then((mod) => mod.ToastViewport), {
-        ssr: false,
-      }),
-    [],
-  );
 
   return (
     <DirectionProvider dir={isRTL ? "rtl" : "ltr"}>

--- a/apps/client/src/pages/_app.tsx
+++ b/apps/client/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { Caveat } from "next/font/google";
 
 import { createNextDsfrIntegrationApi } from "@codegouvfr/react-dsfr/next-pagesdir";
 import { DirectionProvider } from "@radix-ui/react-direction";
+import { ToastProvider } from "@radix-ui/react-toast";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type { NextPage } from "next";
 import { appWithTranslation } from "next-i18next";
@@ -110,13 +111,6 @@ const App = ({ Component, ...pageProps }: AppPropsWithLayout) => {
   const ToastViewport = useMemo(
     () =>
       dynamic(() => import("@radix-ui/react-toast").then((mod) => mod.ToastViewport), {
-        ssr: false,
-      }),
-    [],
-  );
-  const ToastProvider = useMemo(
-    () =>
-      dynamic(() => import("@radix-ui/react-toast").then((mod) => mod.ToastProvider), {
         ssr: false,
       }),
     [],

--- a/apps/client/src/pages/annuaire-creation.tsx
+++ b/apps/client/src/pages/annuaire-creation.tsx
@@ -14,6 +14,7 @@ import { Step5 } from "~/components/Pages/annuaire-create/Step5";
 import { Step6 } from "~/components/Pages/annuaire-create/Step6";
 import SEO from "~/components/Seo";
 import FButton from "~/components/UI/FButton/FButton";
+import { useLocale } from "~/hooks";
 import { defaultStaticPropsWithThemes } from "~/lib/getDefaultStaticProps";
 import styles from "~/scss/pages/annuaire-create.module.scss";
 import { LoadingStatusKey } from "~/services/LoadingStatus/loadingStatus.actions";
@@ -29,6 +30,7 @@ import {
 
 const AnnuaireCreate = () => {
   const router = useRouter();
+  const locale = useLocale();
   const [step, setStep] = useState(1);
   const [showTutoModal, setShowTutoModal] = useState(false);
   const [hasModifications, setHasModifications] = useState(false);
@@ -54,7 +56,7 @@ const AnnuaireCreate = () => {
   };
 
   const updateStructure = () => {
-    dispatch(updateSelectedStructureActionCreator({ locale: router.locale || "fr" }));
+    dispatch(updateSelectedStructureActionCreator({ locale }));
   };
 
   const setStructure = (structure: GetStructureResponse) => {

--- a/apps/client/src/pages/annuaire/[id].tsx
+++ b/apps/client/src/pages/annuaire/[id].tsx
@@ -3,23 +3,20 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { END } from "redux-saga";
-
-import { getLanguageFromLocale } from "~/lib/getLanguageFromLocale";
-
-import { LoadingStatusKey } from "~/services/LoadingStatus/loadingStatus.actions";
-import { isLoadingSelector } from "~/services/LoadingStatus/loadingStatus.selectors";
-import { fetchSelectedStructureActionCreator } from "~/services/SelectedStructure/selectedStructure.actions";
-import { selectedStructureSelector } from "~/services/SelectedStructure/selectedStructure.selector";
-import { userSelector } from "~/services/User/user.selectors";
-import { wrapper } from "~/services/configureStore";
-
 import { LeftAnnuaireDetail } from "~/components/Pages/annuaire/id/LeftAnnuaireDetail";
 import { MiddleAnnuaireDetail } from "~/components/Pages/annuaire/id/MiddleAnnuaireDetails";
 import { RightAnnuaireDetails } from "~/components/Pages/annuaire/id/RightAnnuaireDetails";
 import SEO from "~/components/Seo";
-
+import { useLocale } from "~/hooks";
+import { getLanguageFromLocale } from "~/lib/getLanguageFromLocale";
 import styles from "~/scss/pages/annuaire-id.module.scss";
+import { LoadingStatusKey } from "~/services/LoadingStatus/loadingStatus.actions";
+import { isLoadingSelector } from "~/services/LoadingStatus/loadingStatus.selectors";
+import { fetchSelectedStructureActionCreator } from "~/services/SelectedStructure/selectedStructure.actions";
+import { selectedStructureSelector } from "~/services/SelectedStructure/selectedStructure.selector";
 import { fetchThemesActionCreator } from "~/services/Themes/themes.actions";
+import { userSelector } from "~/services/User/user.selectors";
+import { wrapper } from "~/services/configureStore";
 
 interface Props {
   history: string[];
@@ -36,7 +33,7 @@ const AnnuaireDetail = (props: Props) => {
   const router = useRouter();
   const structureId = router.query.id as string;
 
-  const locale = router.locale || "fr";
+  const locale = useLocale();
   const [currentLoadedLocale, setCurrentLoadedLocale] = useState(locale);
 
   // Reload structure if locale change

--- a/apps/client/src/pages/annuaire/index.tsx
+++ b/apps/client/src/pages/annuaire/index.tsx
@@ -19,6 +19,7 @@ import { NoResult } from "~/components/Pages/annuaire/index/NoResult";
 import SEO from "~/components/Seo";
 
 import { GetActiveStructuresResponse } from "@refugies-info/api-types";
+import { useLocale } from "~/hooks";
 import isInBrowser from "~/lib/isInBrowser";
 import { Event } from "~/lib/tracking";
 import styles from "~/scss/pages/annuaire.module.scss";
@@ -55,6 +56,7 @@ const computeTypeFromUrl = (query: NextParsedUrlQuery) => {
 
 const Annuaire = () => {
   const router = useRouter();
+  const locale = useLocale();
 
   const [keyword, setKeyword] = useState((router.query.keyword as string) || "");
   const [typeSelected, setTypeSelected] = useState<string[]>(computeTypeFromUrl(router.query) || []);
@@ -102,7 +104,7 @@ const Annuaire = () => {
       if (isInBrowser())
         router.push(
           {
-            pathname: getPath("/annuaire", router.locale),
+            pathname: getPath("/annuaire", locale),
             search: qs.stringify(query),
           },
           undefined,
@@ -180,7 +182,7 @@ const Annuaire = () => {
 
     // Bug router: https://github.com/vercel/next.js/issues/18127#issuecomment-950907739
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [typeSelected, depName, depNumber, keyword, isCitySelected, structures, ville, router.locale]);
+  }, [typeSelected, depName, depNumber, keyword, isCitySelected, structures, ville, locale]);
 
   const letters = "abcdefghijklmnopqrstuvwxyz".split("");
   const lettersClickable = defineLettersClickable(filteredStructures);

--- a/apps/client/src/pages/mentions-legales.tsx
+++ b/apps/client/src/pages/mentions-legales.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { getPath } from "routes";
 import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
 import SEO from "~/components/Seo";
+import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import styles from "~/scss/pages/legal-pages.module.scss";
 
 const MentionsLegales = () => {
-  const router = useRouter();
+  const locale = useLocale();
 
   return (
     <div className="w-full">
@@ -52,7 +52,7 @@ const MentionsLegales = () => {
         <p>
           Les informations personnelles collectées ne sont en aucun cas confiées à des tiers. Pour plus
           d&apos;information consultez la page relative à{" "}
-          <Link legacyBehavior href={getPath("/politique-de-confidentialite", router.locale)} prefetch={false}>
+          <Link legacyBehavior href={getPath("/politique-de-confidentialite", locale)} prefetch={false}>
             <a>
               <strong>notre politique de confidentialité</strong>
             </a>

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -1,15 +1,15 @@
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { getPath } from "routes";
 import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
 import SEO from "~/components/Seo";
+import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import { Event } from "~/lib/tracking";
 import styles from "~/scss/pages/legal-pages.module.scss";
 
 const PlanDuSite = () => {
-  const router = useRouter();
+  const locale = useLocale();
   const { t } = useTranslation();
   return (
     <div className="flex w-full flex-col justify-center">
@@ -19,20 +19,20 @@ const PlanDuSite = () => {
         <h1>Plan du site</h1>
         <ul>
           <li>
-            <Link href={getPath("/", router.locale)}>Accueil</Link>
+            <Link href={getPath("/", locale)}>Accueil</Link>
           </li>
           <li>
-            <Link href={getPath("/recherche", router.locale)} prefetch={false}>
+            <Link href={getPath("/recherche", locale)} prefetch={false}>
               {t("Toolbar.find_information", "Trouver de l'information")}
             </Link>
           </li>
           <li>
-            <Link href={getPath("/publier", router.locale)} prefetch={false}>
+            <Link href={getPath("/publier", locale)} prefetch={false}>
               {t("Toolbar.Publier une fiche", "Publier une fiche")}
             </Link>
           </li>
           <li>
-            <Link href={getPath("/traduire", router.locale)} prefetch={false}>
+            <Link href={getPath("/traduire", locale)} prefetch={false}>
               {t("Toolbar.Traduire", "Traduire")}
             </Link>
           </li>

--- a/apps/client/src/pages/politique-de-confidentialite.tsx
+++ b/apps/client/src/pages/politique-de-confidentialite.tsx
@@ -1,13 +1,13 @@
 import Link from "next/link";
-import { useRouter } from "next/router";
 import { getPath } from "routes";
 import { HelpNotice } from "~/components/Pages/recherche/HelpNotice/HelpNotice";
 import SEO from "~/components/Seo";
+import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import styles from "~/scss/pages/legal-pages.module.scss";
 
 const PolitiqueConfidentialite = () => {
-  const router = useRouter();
+  const locale = useLocale();
 
   return (
     <div className="w-full">
@@ -18,7 +18,7 @@ const PolitiqueConfidentialite = () => {
         <h2>Qui sommes-nous ?</h2>
         <p>
           Ce site est édité par <strong>Refugies.info</strong>. Visitez la page{" "}
-          <Link legacyBehavior href={getPath("/mentions-legales", router.locale)} prefetch={false}>
+          <Link legacyBehavior href={getPath("/mentions-legales", locale)} prefetch={false}>
             <a>Mentions légales</a>
           </Link>{" "}
           pour plus d&apos;informations.

--- a/apps/client/src/pages/recherche.tsx
+++ b/apps/client/src/pages/recherche.tsx
@@ -12,7 +12,7 @@ import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
 import SearchHeader from "~/components/Pages/recherche/SearchHeader";
 import SearchResults from "~/components/Pages/recherche/SearchResults";
 import SEO from "~/components/Seo";
-import { useUtmz } from "~/hooks";
+import { useLocale, useUtmz } from "~/hooks";
 import { cls } from "~/lib/classname";
 import { getLanguageFromLocale } from "~/lib/getLanguageFromLocale";
 import { buildUrlQuery } from "~/lib/recherche/buildUrlQuery";
@@ -67,6 +67,7 @@ const Recherche = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
   const router = useRouter();
+  const locale = useLocale();
   const { params } = useUtmz();
 
   const dispositifs = useSelector(activeDispositifsSelector);
@@ -90,13 +91,12 @@ const Recherche = () => {
   useEffect(() => {
     // update url
     const updateUrl = () => {
-      const locale = router.locale;
       const oldQueryString = router.asPath.split("?")[1] || "";
       const newQueryString = buildUrlQuery(query, params);
       if (oldQueryString !== newQueryString) {
         router.push(
           {
-            pathname: getPath("/recherche", router.locale),
+            pathname: getPath("/recherche", locale),
             search: newQueryString,
           },
           undefined,
@@ -112,7 +112,7 @@ const Recherche = () => {
         dispatch(setSearchResultsActionCreator(res));
       });
     }
-  }, [query, dispositifs, dispatch, router, isNavigating, languei18nCode, params, allNeeds]);
+  }, [query, dispositifs, dispatch, router, isNavigating, languei18nCode, params, allNeeds, locale]);
 
   // generate list of demarches to show when no results
   useEffect(() => {


### PR DESCRIPTION
### Changements

- utilisation du hook `useLocale` au lieu de `router.locale`qui empêchait le SSR
- utilisation sans next/dynamic de deux composants radix-ui qui avaient signalé des problèmes avec le SSR par le passé

### Pour tester

```shell
curl --request GET --url http://localhost:3000 --header 'Accept: */*'  --header 'Accept-Encoding: identity'  --header 'Connection: keep-alive' --output output.html
``` 

Chercher la balise `<div id="__next">`dans le fichier `output.html`.  Celle-ci ne doit pas être vide de contenu.