### PR TITLE
Chore: Fix breadcrumbs icons sizes

### DIFF
--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/Breadcrumb.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/Breadcrumb.tsx
@@ -13,7 +13,7 @@ const Breadcrumb = ({ dispositif }: Props) => {
 
   if (!dispositif) return null;
   return (
-    <div className="w-full bg-white/80 py-3" style={{ backgroundColor: theme?.colors.color30 || "" }}>
+    <div className="w-full bg-white/80 py-3 text-xs" style={{ backgroundColor: theme?.colors.color30 || "" }}>
       <div className="fr-container flex justify-between">
         <div className="flex items-center">
           <BreadcrumbDetails dispositif={dispositif} />

--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
@@ -1,4 +1,5 @@
 import { ContentType, GetDispositifResponse } from "@refugies-info/api-types";
+import { cn } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { useMemo, useState } from "react";
@@ -23,7 +24,14 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
   const theme = useSelector(themeSelector(dispositif?.theme));
   const need = useSelector(needSelector(dispositif?.needs?.[0] || null));
   const chevron = useMemo(
-    () => <i className={`${isRTL ? "ri-arrow-left-s-line" : "ri-arrow-right-s-line"} text-mention-grey`} />,
+    () => (
+      <i
+        className={cn(
+          "text-mention-grey [&::before]:![--icon-size:1rem]",
+          isRTL ? "ri-arrow-left-s-line" : "ri-arrow-right-s-line",
+        )}
+      />
+    ),
     [isRTL],
   );
 
@@ -37,7 +45,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
       {(!isTablet || showBreadcrumb) && (
         <div className="">
           <Link href={getPath("/", "fr")} className="" title={t("homepage")}>
-            <i className="ri-home-4-line text-mention-grey" />
+            <i className="ri-home-4-line text-mention-grey text-xs [&::before]:![--icon-size:1.25rem]" />
           </Link>
 
           {chevron}


### PR DESCRIPTION
Welcome back @kaaloo !

<img src="https://media2.giphy.com/media/v1.Y2lkPWJkM2VhNTdlNzMzdmhrbG1tNmZnMHZ5a2I2M3Z4aDEzY3plbHpyOW82bGxvMWlnbSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/YQpAgiAtZzpOtEHyvs/giphy.gif"/>

Glad to make some PRs with you ^^

This one can be tricky sometimes.
As we don't have a proper dsfr icon component I found a bit hacky way to override the dsfr icon size.
As this need can repeat itself a few times I can make a reusable icon component but as we are in a rush I keep this one for later.
WDYT ? 
