### PR TITLE
RI-732: Crisp n'indexe pas toutes les pages demarches et dispositifs

### DIFF
--- a/apps/client/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,18 @@ exports[`homepage renders homepage 1`] = `
     class="main"
   >
     <div
+      aria-hidden="true"
+      hidden=""
+    >
+      <a
+        href="/sitemap"
+      >
+        <span>
+          sitemap
+        </span>
+      </a>
+    </div>
+    <div
       class="fr-notice fr-notice--info"
       id="fr-notice-:r0:"
     >

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -9,6 +9,7 @@ import { Carrousel } from "@refugies-info/ui";
 import { logger } from "logger";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import Link from "next/link";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
 import { END } from "redux-saga";
@@ -57,6 +58,11 @@ const Homepage = (props: Props) => {
 
   return (
     <div className={commonStyles.main}>
+      <div hidden aria-hidden="true">
+        <Link href="/sitemap" prefetch={false}>
+          <span>sitemap</span>
+        </Link>
+      </div>
       <SEO
         title={
           isMobile

--- a/apps/client/src/pages/sitemap.tsx
+++ b/apps/client/src/pages/sitemap.tsx
@@ -36,35 +36,27 @@ Sitemap.getLayout = (page: ReactElement) => page;
 
 export const getServerSideProps: GetServerSideProps = async ({ res, locales = [] }) => {
   const availableLocales = locales.filter((ln) => ln !== "default");
-  const allUrls: string[] = [];
 
-  // Fetch URLs for each locale
-  for (const loc of availableLocales) {
-    // Get dispositifs
-    const dispositifs = await API.getDispositifs({
-      type: ContentType.DISPOSITIF,
-      locale: loc,
-    });
-
-    // Get démarches
-    const demarches = await API.getDispositifs({
-      type: ContentType.DEMARCHE,
-      locale: loc,
-    });
-
-    // Add all URLs to the list
+  // Fetch URLs for each locale in parallel
+  const urlPromises = availableLocales.map(async (loc) => {
+    const dispositifs = await API.getDispositifs({ type: ContentType.DISPOSITIF, locale: loc });
+    const demarches = await API.getDispositifs({ type: ContentType.DEMARCHE, locale: loc });
+    const localeUrls: string[] = [];
     dispositifs.forEach((d) => {
-      allUrls.push(
+      localeUrls.push(
         `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/dispositif/[id]", loc).replace("[id]", d._id.toString())}`,
       );
     });
-
     demarches.forEach((d) => {
-      allUrls.push(
+      localeUrls.push(
         `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/demarche/[id]", loc).replace("[id]", d._id.toString())}`,
       );
     });
-  }
+    return localeUrls;
+  });
+
+  const allUrlsArrays = await Promise.all(urlPromises);
+  const allUrls = allUrlsArrays.flat();
 
   // Set cache headers - cache for 1 day, revalidate after 1 hour
   res?.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");

--- a/apps/client/src/pages/sitemap.tsx
+++ b/apps/client/src/pages/sitemap.tsx
@@ -1,0 +1,85 @@
+import { ContentType } from "@refugies-info/api-types";
+import { GetServerSideProps, NextPage } from "next";
+import Head from "next/head";
+import { ReactElement } from "react";
+import { getPath } from "routes";
+import API from "~/utils/API";
+
+interface SitemapProps {
+  urls: string[];
+}
+
+type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
+  getLayout?: (page: ReactElement) => ReactElement;
+};
+
+// This page is designed to be consumed by crawlers, not humans.
+const Sitemap: NextPageWithLayout<SitemapProps> = ({ urls }) => {
+  return (
+    <>
+      <Head>
+        <title>Sitemap - Réfugiés.info</title>
+        <meta name="robots" content="noindex, follow" />
+        <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
+      </Head>
+      {urls.map((url, index) => (
+        <div key={index}>
+          <a href={url}>{url}</a>
+        </div>
+      ))}
+    </>
+  );
+};
+
+// Disable layout for this page
+Sitemap.getLayout = (page: ReactElement) => page;
+
+export const getServerSideProps: GetServerSideProps = async ({ res, locales = [] }) => {
+  const availableLocales = locales.filter((ln) => ln !== "default");
+  const allUrls: string[] = [];
+
+  // Fetch URLs for each locale
+  for (const loc of availableLocales) {
+    // Get dispositifs
+    const dispositifs = await API.getDispositifs({
+      type: ContentType.DISPOSITIF,
+      locale: loc,
+    });
+
+    // Get démarches
+    const demarches = await API.getDispositifs({
+      type: ContentType.DEMARCHE,
+      locale: loc,
+    });
+
+    // Add all URLs to the list
+    dispositifs.forEach((d) => {
+      allUrls.push(
+        `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/dispositif/[id]", loc).replace("[id]", d._id.toString())}`,
+      );
+    });
+
+    demarches.forEach((d) => {
+      allUrls.push(
+        `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/demarche/[id]", loc).replace("[id]", d._id.toString())}`,
+      );
+    });
+  }
+
+  // Set cache headers - cache for 1 day, revalidate after 1 hour
+  res?.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");
+  res?.setHeader("Content-Type", "text/html; charset=utf-8");
+
+  // Prevent Next.js from using the default layout
+  res?.setHeader("X-Content-Type-Options", "nosniff");
+  res?.setHeader("X-Frame-Options", "DENY");
+  res?.setHeader("X-XSS-Protection", "1; mode=block");
+
+  return {
+    props: {
+      urls: allUrls,
+    },
+  };
+};
+
+export default Sitemap;


### PR DESCRIPTION
# Crisp Sitemap Implementation

![image](https://github.com/user-attachments/assets/3690f5f8-c79b-48c6-8c23-c1ef8aaa2ccd)

## Changes Made

1. **Added Dynamic Sitemap Page**
   - Created `/sitemap` page that generates a list of all dispositifs and démarches
   - Implemented server-side rendering for optimal SEO and performance
   - Added proper caching headers (1-hour cache, 1-day revalidation)

2. **Optimized Data Fetching**
   - Parallelized API calls for different locales using `Promise.all`
   - Improved performance by fetching data in parallel instead of sequentially
   - Used `flat()` to combine arrays of URLs from different locales

3. **Added Hidden Sitemap Link**
   - Added an invisible link to the sitemap on the home page
   - Implemented with `hidden` and `aria-hidden="true"` for complete invisibility
   - Used Next.js `Link` with `prefetch={false}` to prevent unnecessary prefetching

4. **Performance Considerations**
   - Ensured proper content-type headers for the sitemap
   - Set appropriate cache headers for the sitemap response

## Testing
- Verified the sitemap is accessible at `/sitemap`
- Confirmed the hidden link is present in the DOM but not visible to users
- Checked that the sitemap includes all expected URLs for each locale

