### PR TITLE
fix(client): :bug: handle null sponsor logo in autosaving dispositif

### DIFF
--- a/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalSponsors/ModalSponsors.tsx
+++ b/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalSponsors/ModalSponsors.tsx
@@ -46,7 +46,7 @@ const ModalSponsors = (props: Props) => {
       const sponsor = getValues("sponsors")?.[props.currentSponsorIndex];
       setName(sponsor?.name);
       setLink(sponsor?.link);
-      setLogo(sponsor?.logo);
+      setLogo(sponsor?.logo || undefined);
     } else {
       resetForm();
     }

--- a/apps/client/src/lib/dispositifForm.ts
+++ b/apps/client/src/lib/dispositifForm.ts
@@ -94,7 +94,10 @@ export const getDefaultValue = (dispositif: GetDispositifResponse | null): Updat
     mainSponsor: dispositif.mainSponsor?._id.toString(),
     theme: dispositif.theme?.toString(),
     secondaryThemes: dispositif.secondaryThemes?.map((t) => t.toString()),
-    sponsors: dispositif.sponsors as Sponsor[],
+    sponsors: (dispositif.sponsors as Sponsor[])?.map((sponsor) => {
+      const { logo, ...rest } = sponsor;
+      return logo === null ? rest : sponsor;
+    }),
   };
 
   if (defaultValues.why)

--- a/packages/api-types/src/generics.ts
+++ b/packages/api-types/src/generics.ts
@@ -98,7 +98,9 @@ export interface MainSponsor {
 
 export interface Sponsor {
   name: string;
-  logo?: Picture;
+  // Unfortunately there are occurrences in the database with a null logo
+  // See https://linear.app/refugiesinfo/issue/RI-794/bug-erreur-lors-de-la-sauvegarde-automatique-dun-fiche
+  logo?: Picture | null;
   link?: string;
 }
 


### PR DESCRIPTION
This PR introduces some safeguards to better deal with the situation where the sponsors logo is missing.

- update the Sponsor type to reflect that the logo field may be null
- filter out null logo fields when loading data
- don't save null logo fields

To test, this dispositif has a sponsor with a null logo:

http://localhost:3000/dispositif/5f7d914a5e0d1400466bf4b9

You can go into edit mode, click on a section text and autosave should be triggered and should not cause an error.