### PR TITLE
Fix: Update import syntax for withXcodeProject to prevent build failure

### DIFF
--- a/apps/mobile/src/utils/withSimulatorExcludedArchitectures.js
+++ b/apps/mobile/src/utils/withSimulatorExcludedArchitectures.js
@@ -1,4 +1,8 @@
-import { withXcodeProject } from "@expo/config-plugins";
+// Cannot refactor this import to
+// import { withXcodeProject } from "@expo/config-plugins";
+// because it will break the build
+import expoConfigPlugins from "@expo/config-plugins";
+const { withXcodeProject } = expoConfigPlugins;
 
 /**
  * Exclude building for arm64 on simulator devices in the pbxproj project.

--- a/package.json
+++ b/package.json
@@ -20,8 +20,10 @@
       "core-js",
       "core-js-pure",
       "esbuild",
+      "mongodb-memory-server",
       "protobufjs",
-      "sharp"
+      "sharp",
+      "unrs-resolver"
     ],
     "patchedDependencies": {
       "@codegouvfr/react-dsfr@1.20.2": "patches/@codegouvfr__react-dsfr@1.20.2.patch"


### PR DESCRIPTION
This PR fixes the import syntax for withXcodeProject in the mobile app to prevent build failures. The previous import was causing issues with the production build, so I've updated it to use the default import approach.