### PR TITLE
:wrench: Fix No tsconfigRootDir was set

### DIFF
--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -1,15 +1,6 @@
-import eslint from "@eslint/js";
-import path from "path";
-import tseslint from "typescript-eslint";
-import { fileURLToPath } from "url";
-
-// Get the directory name of the current module
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 export default tseslint.config(
-  eslint.configs.recommended,
+  ...tseslint.configs.recommendedTypeChecked,
   {
-    ...tseslint.configs.recommended,
     languageOptions: {
       parserOptions: {
         tsconfigRootDir: __dirname,

--- a/apps/server/eslint.config.mjs
+++ b/apps/server/eslint.config.mjs
@@ -1,6 +1,23 @@
 import eslint from "@eslint/js";
+import path from "path";
 import tseslint from "typescript-eslint";
+import { fileURLToPath } from "url";
 
-export default tseslint.config(eslint.configs.recommended, tseslint.configs.recommended, {
-  ignores: ["dist"],
-});
+// Get the directory name of the current module
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  {
+    ...tseslint.configs.recommended,
+    languageOptions: {
+      parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: ["./tsconfig.json"],
+      },
+    },
+  },
+  {
+    ignores: ["dist"],
+  },
+);


### PR DESCRIPTION
@kaaloo J'ai un souci dans mon ide depuis la semaine dernière.

Voici l'erreur qui apparaît sur les imports de tous les fichiers que j'ouvre : 

````
Explain what this problem is and help me fix it: Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present:
 - /Users/jeremie/refugies.info/karfur/apps/server
 - /Users/jeremie/refugies.info/karfur/packages/ui
You'll need to explicitly set tsconfigRootDir in your parser options.
See: https://typescript-eslint.io/packages/parser/#tsconfigrootdir @dispositif.repository.ts#L1
`````
J'ai trouvé ce fix sur l'**eslint.config.mjs** ça te semble cohérent par rapport à notre monorepo ?
`````
export default tseslint.config(
  ...tseslint.configs.recommendedTypeChecked,
  {
    languageOptions: {
      parserOptions: {
        tsconfigRootDir: __dirname,
        project: ["./tsconfig.json"],
      },
    },
  },
  {
    ignores: ["dist"],
  },
);

````