### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -1,5 +1,8 @@
 name: Chromatic
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/refugies-info/karfur/security/code-scanning/23](https://github.com/refugies-info/karfur/security/code-scanning/23)

To fix the problem, we should add an explicit `permissions` block to the workflow YAML specifying the minimum privileges needed. The best place is at the root level of the workflow, which will apply to all jobs unless overridden. For most CI build/test/deploy workflows that do not require writing to the repository, the minimal permissions setting is `contents: read`, as suggested by CodeQL. Based on the steps shown (checkout, dependency install, build, and run Chromatic), there are no write operations back to GitHub, so this minimal configuration is appropriate. The change should be made near the top of the file (just below or above the `on:` block).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
