### PR TITLE
Jeremie/ri 857 ajouter le hover des tags

### DIFF
--- a/apps/client/src/components/Backend/screens/Admin/Needs/ThemeFormModal.tsx
+++ b/apps/client/src/components/Backend/screens/Admin/Needs/ThemeFormModal.tsx
@@ -283,7 +283,7 @@ export const ThemeFormModal = (props: Props) => {
                 </div>
               ))}
             </div>
-            <p className="text-sm ">Sur le site color60 = couleur de fond, color40 = couleur de survol</p>
+            <p className="text-sm ">Sur le site color40 = couleur de fond, color60 = couleur de survol</p>
             <Label htmlFor="colors">Couleurs du dégradé du thème</Label>
             <div className={styles.colors}>
               <div>

--- a/apps/client/src/components/Backend/screens/Admin/Needs/ThemeFormModal.tsx
+++ b/apps/client/src/components/Backend/screens/Admin/Needs/ThemeFormModal.tsx
@@ -279,9 +279,11 @@ export const ThemeFormModal = (props: Props) => {
                     onChange={(e: any) => setColors({ ...colors, [i]: e.target.value as string })}
                     style={{ backgroundColor: colors[i] }}
                   />
+                  <small>{i}</small>
                 </div>
               ))}
             </div>
+            <p className="text-sm ">Sur le site color60 = couleur de fond, color40 = couleur de survol</p>
             <Label htmlFor="colors">Couleurs du dégradé du thème</Label>
             <div className={styles.colors}>
               <div>

--- a/apps/client/src/components/UI/SearchThemeButton/SearchThemeButton.tsx
+++ b/apps/client/src/components/UI/SearchThemeButton/SearchThemeButton.tsx
@@ -1,6 +1,6 @@
 import { GetThemeResponse } from "@refugies-info/api-types";
 import Link from "next/link";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import Image from "~/components/UI/Image";
 
 interface Props {
@@ -11,6 +11,7 @@ interface Props {
 }
 
 const SearchThemeButton = (props: Props) => {
+  const [hover, setHover] = useState(false);
   const content = useMemo(
     () => (
       <span className="flex items-center justify-center gap-1 p-1 md:px-0.5 md:py-0.5">
@@ -27,10 +28,14 @@ const SearchThemeButton = (props: Props) => {
     <Link
       className="flex flex-col items-center rounded-full px-2"
       style={{
-        backgroundColor: props.theme.colors.color40,
+        backgroundColor: hover ? props.theme.colors.color60 : props.theme.colors.color40,
       }}
       href={props.href}
       onClick={props.onClick}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onFocus={() => setHover(true)}
+      onBlur={() => setHover(false)}
     >
       {content}
     </Link>

--- a/apps/client/src/components/UI/SearchThemeButton/SearchThemeButton.tsx
+++ b/apps/client/src/components/UI/SearchThemeButton/SearchThemeButton.tsx
@@ -49,6 +49,10 @@ const SearchThemeButton = (props: Props) => {
         if (props.onClick) props.onClick();
         window.scrollTo(0, 0);
       }}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onFocus={() => setHover(true)}
+      onBlur={() => setHover(false)}
     >
       {content}
     </button>


### PR DESCRIPTION
✨ Amélioration de l'expérience utilisateur des tags thématiques

@kaaloo cette PR améliore l'interaction avec les tags thématiques sur les dispositifs en ajoutant un effet de survol et en clarifiant l'utilisation des couleurs dans l'interface d'administration.

La checklist :
- Ajout d'un effet de survol sur les tags thématiques avec changement de couleur (color40 → color60)
- Documentation des couleurs dans l'interface d'administration pour faciliter la maintenance
- Amélioration de l'accessibilité avec support du focus clavier
