### PR TITLE
:art: Handle DSFR Callouts components

### DIFF
--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -36,6 +36,7 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
     () => (sectionKey === "what" ? dispositif?.[sectionKey] || "" : undefined),
     [sectionKey, dispositif],
   );
+
   const contentAccordions: InfoSections | undefined = useMemo(
     () => (sectionKey !== "what" ? dispositif?.[sectionKey] : undefined),
     [sectionKey, dispositif],

--- a/apps/client/src/components/Pages/dispositif/Text/Text.tsx
+++ b/apps/client/src/components/Pages/dispositif/Text/Text.tsx
@@ -2,9 +2,10 @@ import { useTranslation } from "next-i18next";
 import { useContext } from "react";
 import { useSanitizedContent } from "~/hooks";
 import { cn } from "~/lib/classname";
-import { getCalloutTranslationKey, translationParsing } from "~/lib/contentParsing";
+import { CalloutSegment, getCalloutTranslationKey, htmlParsing, TextSegment, translationParsing } from "~/lib/contentParsing";
 import PageContext from "~/utils/pageContext";
 import styles from "./Text.module.scss";
+import { CallOut } from "@codegouvfr/react-dsfr/CallOut";
 
 interface Props {
   id: string;
@@ -13,9 +14,7 @@ interface Props {
   className?: string;
 }
 
-/**
- * Displays a text (string or HTML) which can be highlighted
- */
+
 const Text = (props: Props) => {
   const { t } = useTranslation();
   const pageContext = useContext(PageContext);
@@ -26,19 +25,55 @@ const Text = (props: Props) => {
         { nodeAttr: /data-callout=["']important["']/, translation: t(getCalloutTranslationKey("important")) },
       ])
     : props.children;
+    
+    const isClient = typeof window !== 'undefined';
+    
+    const { contentSegments } = isClient && props.html 
+      ? htmlParsing(convertedContent as string) 
+      : { contentSegments: [{ type: 'text', content: convertedContent as string }] };
 
-  const safeContent = useSanitizedContent(convertedContent);
 
   return props.html ? (
     <div
       data-section={props.id}
-      dangerouslySetInnerHTML={{ __html: safeContent }}
-      className={cn(styles.content, pageContext.activeSection === props.id && styles.highlighted, props.className)}
-    />
+      className={cn( styles.content, pageContext.activeSection === props.id && styles.highlighted, props.className)}
+    >
+      {contentSegments.map((segment, index) => {
+        if (segment.type === 'text') {
+          const textSegment = segment as TextSegment;
+          const sanitizedContent = useSanitizedContent(textSegment.content);
+          return (
+            <div 
+              key={`text-${index}`}
+              dangerouslySetInnerHTML={{ __html: sanitizedContent }}
+            />
+          );
+        } else if (segment.type === 'callout') {
+          const calloutSegment = segment as CalloutSegment;
+          const iconId = calloutSegment.calloutType === 'important' 
+            ? "fr-icon-warning-fill" 
+            : "ri-information-line";
+          
+          return (
+            <CallOut 
+              key={`callout-${calloutSegment.calloutType}-${index}`}
+              title={calloutSegment.title}
+              iconId={iconId}
+              colorVariant={calloutSegment.calloutType === 'important' ? 'yellow-tournesol' : 'blue-cumulus'}
+            >
+              <p className="not-prose" dangerouslySetInnerHTML={{ __html: calloutSegment.content }} />
+            </CallOut>
+          );
+        }
+        return null;
+      })}
+    </div>
   ) : (
-    <span className={pageContext.activeSection === props.id ? styles.highlighted : ""} data-section={props.id}>
-      {convertedContent}
-    </span>
+    <>
+      <span className={pageContext.activeSection === props.id ? styles.highlighted : ""} data-section={props.id}>
+        {convertedContent}
+      </span>
+    </>
   );
 };
 

--- a/apps/client/src/components/Pages/dispositif/Text/Text.tsx
+++ b/apps/client/src/components/Pages/dispositif/Text/Text.tsx
@@ -1,11 +1,16 @@
+import { CallOut } from "@codegouvfr/react-dsfr/CallOut";
 import { useTranslation } from "next-i18next";
 import { useContext } from "react";
-import { useSanitizedContent } from "~/hooks";
 import { cn } from "~/lib/classname";
-import { CalloutSegment, getCalloutTranslationKey, htmlParsing, TextSegment, translationParsing } from "~/lib/contentParsing";
+import {
+  CalloutSegment,
+  getCalloutTranslationKey,
+  htmlParsing,
+  TextSegment,
+  translationParsing,
+} from "~/lib/contentParsing";
 import PageContext from "~/utils/pageContext";
 import styles from "./Text.module.scss";
-import { CallOut } from "@codegouvfr/react-dsfr/CallOut";
 
 interface Props {
   id: string;
@@ -13,7 +18,6 @@ interface Props {
   html?: boolean;
   className?: string;
 }
-
 
 const Text = (props: Props) => {
   const { t } = useTranslation();
@@ -25,41 +29,33 @@ const Text = (props: Props) => {
         { nodeAttr: /data-callout=["']important["']/, translation: t(getCalloutTranslationKey("important")) },
       ])
     : props.children;
-    
-    const isClient = typeof window !== 'undefined';
-    
-    const { contentSegments } = isClient && props.html 
-      ? htmlParsing(convertedContent as string) 
-      : { contentSegments: [{ type: 'text', content: convertedContent as string }] };
 
+  const isClient = typeof window !== "undefined";
+
+  const { contentSegments } =
+    isClient && props.html
+      ? htmlParsing(convertedContent as string)
+      : { contentSegments: [{ type: "text", content: convertedContent as string }] };
 
   return props.html ? (
     <div
       data-section={props.id}
-      className={cn( styles.content, pageContext.activeSection === props.id && styles.highlighted, props.className)}
+      className={cn(styles.content, pageContext.activeSection === props.id && styles.highlighted, props.className)}
     >
       {contentSegments.map((segment, index) => {
-        if (segment.type === 'text') {
+        if (segment.type === "text") {
           const textSegment = segment as TextSegment;
-          const sanitizedContent = useSanitizedContent(textSegment.content);
-          return (
-            <div 
-              key={`text-${index}`}
-              dangerouslySetInnerHTML={{ __html: sanitizedContent }}
-            />
-          );
-        } else if (segment.type === 'callout') {
+          return <div key={`text-${index}`} dangerouslySetInnerHTML={{ __html: textSegment.content }} />;
+        } else if (segment.type === "callout") {
           const calloutSegment = segment as CalloutSegment;
-          const iconId = calloutSegment.calloutType === 'important' 
-            ? "fr-icon-warning-fill" 
-            : "ri-information-line";
-          
+          const iconId = calloutSegment.calloutType === "important" ? "fr-icon-warning-fill" : "ri-information-line";
+
           return (
-            <CallOut 
+            <CallOut
               key={`callout-${calloutSegment.calloutType}-${index}`}
               title={calloutSegment.title}
               iconId={iconId}
-              colorVariant={calloutSegment.calloutType === 'important' ? 'yellow-tournesol' : 'blue-cumulus'}
+              colorVariant={calloutSegment.calloutType === "important" ? "yellow-tournesol" : "blue-cumulus"}
             >
               <p className="not-prose" dangerouslySetInnerHTML={{ __html: calloutSegment.content }} />
             </CallOut>

--- a/apps/client/src/lib/contentParsing.ts
+++ b/apps/client/src/lib/contentParsing.ts
@@ -1,4 +1,5 @@
 import { t } from "i18next";
+import { useSanitizedContent } from "~/hooks";
 
 export const getCalloutTranslationKey = (level: "info" | "important") => {
   switch (level) {
@@ -22,9 +23,8 @@ export const translationParsing = (originalHTML: string, toParse: ToParse[]) => 
   return parsedHTML;
 };
 
-
-export type TextSegment = { type: 'text'; content: string };
-export type CalloutSegment = { type: 'callout'; calloutType: 'important' | 'info'; title: string; content: string };
+export type TextSegment = { type: "text"; content: string };
+export type CalloutSegment = { type: "callout"; calloutType: "important" | "info"; title: string; content: string };
 export type ContentSegment = TextSegment | CalloutSegment;
 
 /**
@@ -33,53 +33,51 @@ export type ContentSegment = TextSegment | CalloutSegment;
  * @returns An object containing an array of content segments.
  */
 export const htmlParsing = (htmlContent: string) => {
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(htmlContent, 'text/html');
-    const body = doc.body;
-    
-    const contentSegments: ContentSegment[] = [];
-    
-    const processNode = (parentNode: Node) => {
-      Array.from(parentNode.childNodes).forEach(node => {
-        if (
-          node.nodeType === Node.ELEMENT_NODE && 
-          (node as Element).classList?.contains('callout')
-        ) {
-          const element = node as Element;
-          const isImportant = element.classList.contains('callout--important');
-          const isInfo = element.classList.contains('callout--info');
-          
-          if (isImportant || isInfo) {
-            const calloutType = isImportant ? 'important' : 'info';
-            const title = element.getAttribute('data-title') || 
-                          (isImportant ? t(getCalloutTranslationKey("important")) : t(getCalloutTranslationKey("info")));
-            const content = element.innerHTML;
-            
-            contentSegments.push({
-              type: 'callout',
-              calloutType,
-              title,
-              content
-            });
-          }
-        } else {
-          const tempDoc = document.implementation.createHTMLDocument('');
-          const tempDiv = tempDoc.createElement('div');
-          tempDiv.appendChild(node.cloneNode(true));
-          
-          if (tempDiv.innerHTML.trim()) {
-            contentSegments.push({
-              type: 'text',
-              content: tempDiv.innerHTML
-            });
-          }
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(htmlContent, "text/html");
+  const body = doc.body;
+
+  const contentSegments: ContentSegment[] = [];
+
+  const processNode = (parentNode: Node) => {
+    Array.from(parentNode.childNodes).forEach((node) => {
+      if (node.nodeType === Node.ELEMENT_NODE && (node as Element).classList?.contains("callout")) {
+        const element = node as Element;
+        const isImportant = element.classList.contains("callout--important");
+        const isInfo = element.classList.contains("callout--info");
+
+        if (isImportant || isInfo) {
+          const calloutType = isImportant ? "important" : "info";
+          const title =
+            element.getAttribute("data-title") ||
+            (isImportant ? t(getCalloutTranslationKey("important")) : t(getCalloutTranslationKey("info")));
+          const content = element.innerHTML;
+
+          contentSegments.push({
+            type: "callout",
+            calloutType,
+            title,
+            content: useSanitizedContent(content),
+          });
         }
-      });
-    };
-    
-    processNode(body);
-    
-    return {
-      contentSegments
-    };
+      } else {
+        const tempDoc = document.implementation.createHTMLDocument("");
+        const tempDiv = tempDoc.createElement("div");
+        tempDiv.appendChild(node.cloneNode(true));
+
+        if (tempDiv.innerHTML.trim()) {
+          contentSegments.push({
+            type: "text",
+            content: useSanitizedContent(tempDiv.innerHTML),
+          });
+        }
+      }
+    });
   };
+
+  processNode(body);
+
+  return {
+    contentSegments,
+  };
+};

--- a/apps/client/src/lib/contentParsing.ts
+++ b/apps/client/src/lib/contentParsing.ts
@@ -1,3 +1,5 @@
+import { t } from "i18next";
+
 export const getCalloutTranslationKey = (level: "info" | "important") => {
   switch (level) {
     case "info":
@@ -19,3 +21,65 @@ export const translationParsing = (originalHTML: string, toParse: ToParse[]) => 
   }
   return parsedHTML;
 };
+
+
+export type TextSegment = { type: 'text'; content: string };
+export type CalloutSegment = { type: 'callout'; calloutType: 'important' | 'info'; title: string; content: string };
+export type ContentSegment = TextSegment | CalloutSegment;
+
+/**
+ * Parses HTML content to extract text and callout segments.
+ * @param htmlContent The HTML content to parse.
+ * @returns An object containing an array of content segments.
+ */
+export const htmlParsing = (htmlContent: string) => {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlContent, 'text/html');
+    const body = doc.body;
+    
+    const contentSegments: ContentSegment[] = [];
+    
+    const processNode = (parentNode: Node) => {
+      Array.from(parentNode.childNodes).forEach(node => {
+        if (
+          node.nodeType === Node.ELEMENT_NODE && 
+          (node as Element).classList?.contains('callout')
+        ) {
+          const element = node as Element;
+          const isImportant = element.classList.contains('callout--important');
+          const isInfo = element.classList.contains('callout--info');
+          
+          if (isImportant || isInfo) {
+            const calloutType = isImportant ? 'important' : 'info';
+            const title = element.getAttribute('data-title') || 
+                          (isImportant ? t(getCalloutTranslationKey("important")) : t(getCalloutTranslationKey("info")));
+            const content = element.innerHTML;
+            
+            contentSegments.push({
+              type: 'callout',
+              calloutType,
+              title,
+              content
+            });
+          }
+        } else {
+          const tempDoc = document.implementation.createHTMLDocument('');
+          const tempDiv = tempDoc.createElement('div');
+          tempDiv.appendChild(node.cloneNode(true));
+          
+          if (tempDiv.innerHTML.trim()) {
+            contentSegments.push({
+              type: 'text',
+              content: tempDiv.innerHTML
+            });
+          }
+        }
+      });
+    };
+    
+    processNode(body);
+    
+    return {
+      contentSegments
+    };
+  };


### PR DESCRIPTION
# 🎨 Intégration des composants DSFR Callouts
@kaaloo petite PR pour moderniser notre système d'affichage des callouts en les migrant vers les composants DSFR.

https://components.react-dsfr.codegouv.studio/?path=/docs/components-callout--default

Ce que ça fait :
- Remplacement des callouts HTML personnalisés par les composants CallOut du DSFR
- Ajout d'un parser HTML intelligent qui identifie et convertit les callouts existants
- Distinction visuelle claire entre les callouts d'information (bleu) et d'alerte (jaune)
- Support des titres personnalisés et du contenu HTML dans les callouts

Avantages :
- Interface utilisateur plus cohérente avec les standards DSFR
- Meilleure accessibilité grâce aux composants DSFR
- Code plus maintenable avec séparation claire entre contenu et présentation

WDYT ?