### PR TITLE
Jeremie/ri 881 en zoom a 200 le dropdown des langues ne saffiche pas

### DIFF
--- a/apps/client/src/components/Content/Dispositif/Dispositif.tsx
+++ b/apps/client/src/components/Content/Dispositif/Dispositif.tsx
@@ -37,6 +37,7 @@ const Dispositif = (props: Props) => {
   // Use the hook to ensure all rtri-link class links open in a new tab
   useRtriLinks(dispositifRef);
   const { isTablet, isMobile, isDesktop, isLargeDesktop } = useWindowSize();
+  console.log(isTablet, isMobile, isDesktop, isLargeDesktop);
   const pageContext = useContext(PageContext);
   const dispositif = useSelector(selectedDispositifSelector);
   const theme = useSelector(themeSelector(dispositif?.theme));

--- a/apps/client/src/components/Content/Dispositif/Dispositif.tsx
+++ b/apps/client/src/components/Content/Dispositif/Dispositif.tsx
@@ -37,7 +37,6 @@ const Dispositif = (props: Props) => {
   // Use the hook to ensure all rtri-link class links open in a new tab
   useRtriLinks(dispositifRef);
   const { isTablet, isMobile, isDesktop, isLargeDesktop } = useWindowSize();
-  console.log(isTablet, isMobile, isDesktop, isLargeDesktop);
   const pageContext = useContext(PageContext);
   const dispositif = useSelector(selectedDispositifSelector);
   const theme = useSelector(themeSelector(dispositif?.theme));

--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -255,14 +255,6 @@ const Layout = (props: Props) => {
   return (
     <div dir={isRTL ? "rtl" : "ltr"} onMouseOver={toggleHover} onTouchStart={toggleHover}>
       {!showLangModal && <ConsentBannerAndConsentManagement />}
-      <LanguageModal
-        show={showLangModal}
-        currentLanguage={router.locale || "fr"}
-        toggle={toggleLanguageModal}
-        changeLanguage={changeLanguageCallback}
-        languages={langues}
-        isLanguagesLoading={isLanguagesLoading}
-      />
       <DownloadAppBanner />
       <Navbar />
       <div id="contenu" className={styles.main}>
@@ -274,6 +266,14 @@ const Layout = (props: Props) => {
       <DownloadAppModal show={showMobileModal} toggle={toggleMobileAppModal} />
       <NewProfileModal />
       <SubscribeNewsletterModal />
+      <LanguageModal
+        show={showLangModal}
+        currentLanguage={router.locale || "fr"}
+        toggle={toggleLanguageModal}
+        changeLanguage={changeLanguageCallback}
+        languages={langues}
+        isLanguagesLoading={isLanguagesLoading}
+      />
     </div>
   );
 };

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
@@ -46,7 +46,7 @@ const LanguageMenu = ({
   }
 
   const { isMobile, zoomLevel } = useWindowSize();
-  console.log(zoomLevel);
+
   const stylesDisabled = useStylesDisabled();
   const { t } = useTranslation();
 

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
@@ -45,7 +45,8 @@ const LanguageMenu = ({
     currentLanguage = activatedLanguages.find((lang) => lang.i18nCode === "fr");
   }
 
-  const { isMobile } = useWindowSize();
+  const { isMobile, zoomLevel } = useWindowSize();
+  console.log(zoomLevel);
   const stylesDisabled = useStylesDisabled();
   const { t } = useTranslation();
 
@@ -90,7 +91,7 @@ const LanguageMenu = ({
 
       {(isMobile && mobileMode === "dropdown") || (!isMobile && desktopMode === "dropdown") ? (
         <DropdownRoot
-          className={className}
+          className={cn( className, zoomLevel >= 175 && "!w-full")}
           ref={dropdownRef}
           key={key}
           onOpenChange={(open) => setLangMenuOpened(open)}
@@ -106,7 +107,7 @@ const LanguageMenu = ({
               <i className={cn(langMenuOpened ? "fr-icon-arrow-up-s-line" : "fr-icon-arrow-down-s-line")} />
             </Button>
           </DropdownTrigger>
-          <DropdownContent position="start" className={dropDownClassName}>
+          <DropdownContent position="start" className={cn(dropDownClassName, zoomLevel > 175 && "!w-full")}>
             <LanguageSelector
               onChangeLang={handleToggleDesktopDopdown}
               type={languageSelectorType}

--- a/apps/client/src/hooks/useWindowSize.ts
+++ b/apps/client/src/hooks/useWindowSize.ts
@@ -31,22 +31,24 @@ const useWindowSize = () => {
 
   useEffect(() => {
     if (hasMounted && isInBrowser()) {
-      const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-      
+      const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
+
       if (isFirefox) {
         const defaultFontSize = 16;
         const currentZoom = Math.round((fontSize / defaultFontSize) * 100);
         setZoomLevel(currentZoom);
       } else {
-        const isHiDPI = window.matchMedia && window.matchMedia('(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)').matches;
-        
+        const isHiDPI =
+          window.matchMedia &&
+          window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)").matches;
+
         let currentZoom;
         if (isHiDPI) {
           currentZoom = Math.round((window.devicePixelRatio / 2) * 100);
         } else {
           currentZoom = Math.round(window.devicePixelRatio * 100);
         }
-        
+
         setZoomLevel(currentZoom);
       }
     }
@@ -135,37 +137,39 @@ const useWindowSize = () => {
           handleFontSizeChange();
         }
       };
-      
+
       const wheelHandler = (e: WheelEvent) => {
         if (e.ctrlKey || e.metaKey) {
           handleFontSizeChange();
         }
       };
-      
+
       window.addEventListener("keydown", keydownHandler);
       window.addEventListener("wheel", wheelHandler);
-      
-      const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
-      
+
+      const isFirefox = navigator.userAgent.toLowerCase().indexOf("firefox") > -1;
+
       const chromeZoomHandler = () => {
         if (!isFirefox && isInBrowser()) {
-          const isHiDPI = window.matchMedia && window.matchMedia('(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)').matches;
-          
+          const isHiDPI =
+            window.matchMedia &&
+            window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)").matches;
+
           let currentZoom;
           if (isHiDPI) {
             currentZoom = Math.round((window.devicePixelRatio / 2) * 100);
           } else {
             currentZoom = Math.round(window.devicePixelRatio * 100);
           }
-          
+
           setZoomLevel(currentZoom);
         }
       };
-      
+
       if (!isFirefox) {
         window.addEventListener("resize", chromeZoomHandler);
       }
-      
+
       const bodyObserver = new MutationObserver(handleFontSizeChange);
       if (document.body) {
         bodyObserver.observe(document.body, { attributes: true, attributeFilter: ["style", "class"] });
@@ -176,16 +180,16 @@ const useWindowSize = () => {
         if (document.body) {
           bodyObserver.disconnect();
         }
-        
+
         window.removeEventListener("resize", handleResize);
         window.removeEventListener("load", handleFontSizeChange);
         window.removeEventListener("keydown", keydownHandler);
         window.removeEventListener("wheel", wheelHandler);
-        
+
         if (!isFirefox) {
           window.removeEventListener("resize", chromeZoomHandler);
         }
-        
+
         if (rafId !== undefined) {
           cancelAnimationFrame(rafId);
         }

--- a/apps/client/src/hooks/useWindowSize.ts
+++ b/apps/client/src/hooks/useWindowSize.ts
@@ -195,7 +195,7 @@ const useWindowSize = () => {
     return () => {};
   }, [hasMounted, windowSize.width, fontSize]);
 
-  return { windowSize, ...responsiveFlags };
+  return { windowSize, zoomLevel, ...responsiveFlags };
 };
 
 export default useWindowSize;

--- a/apps/client/src/hooks/useWindowSize.ts
+++ b/apps/client/src/hooks/useWindowSize.ts
@@ -27,6 +27,30 @@ const useWindowSize = () => {
   });
   const [hasMounted, setHasMounted] = useState(false);
   const [fontSize, setFontSize] = useState(16);
+  const [zoomLevel, setZoomLevel] = useState(100);
+
+  useEffect(() => {
+    if (hasMounted && isInBrowser()) {
+      const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+      
+      if (isFirefox) {
+        const defaultFontSize = 16;
+        const currentZoom = Math.round((fontSize / defaultFontSize) * 100);
+        setZoomLevel(currentZoom);
+      } else {
+        const isHiDPI = window.matchMedia && window.matchMedia('(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)').matches;
+        
+        let currentZoom;
+        if (isHiDPI) {
+          currentZoom = Math.round((window.devicePixelRatio / 2) * 100);
+        } else {
+          currentZoom = Math.round(window.devicePixelRatio * 100);
+        }
+        
+        setZoomLevel(currentZoom);
+      }
+    }
+  }, [fontSize, hasMounted, windowSize]);
 
   useEffect(() => {
     const checkResponsiveFlags = () => {
@@ -106,19 +130,65 @@ const useWindowSize = () => {
 
       window.addEventListener("resize", handleResize);
       window.addEventListener("load", handleFontSizeChange);
-      window.addEventListener("keydown", (e) => {
+      const keydownHandler = (e: KeyboardEvent) => {
         if ((e.ctrlKey || e.metaKey) && ["+", "-", "0", "="].includes(e.key)) {
           handleFontSizeChange();
         }
-      });
-      window.addEventListener("wheel", (e) => e.ctrlKey && handleFontSizeChange());
+      };
+      
+      const wheelHandler = (e: WheelEvent) => {
+        if (e.ctrlKey || e.metaKey) {
+          handleFontSizeChange();
+        }
+      };
+      
+      window.addEventListener("keydown", keydownHandler);
+      window.addEventListener("wheel", wheelHandler);
+      
+      const isFirefox = navigator.userAgent.toLowerCase().indexOf('firefox') > -1;
+      
+      const chromeZoomHandler = () => {
+        if (!isFirefox && isInBrowser()) {
+          const isHiDPI = window.matchMedia && window.matchMedia('(-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi)').matches;
+          
+          let currentZoom;
+          if (isHiDPI) {
+            currentZoom = Math.round((window.devicePixelRatio / 2) * 100);
+          } else {
+            currentZoom = Math.round(window.devicePixelRatio * 100);
+          }
+          
+          setZoomLevel(currentZoom);
+        }
+      };
+      
+      if (!isFirefox) {
+        window.addEventListener("resize", chromeZoomHandler);
+      }
+      
+      const bodyObserver = new MutationObserver(handleFontSizeChange);
+      if (document.body) {
+        bodyObserver.observe(document.body, { attributes: true, attributeFilter: ["style", "class"] });
+      }
 
       return () => {
         [resizeObserver, mutationObserver].forEach((observer) => observer.disconnect());
-        ["resize", "load"].forEach((event) => window.removeEventListener(event, handleResize));
-        window.removeEventListener("keydown", handleFontSizeChange);
-        window.removeEventListener("wheel", handleFontSizeChange);
-        clearTimeout(rafId);
+        if (document.body) {
+          bodyObserver.disconnect();
+        }
+        
+        window.removeEventListener("resize", handleResize);
+        window.removeEventListener("load", handleFontSizeChange);
+        window.removeEventListener("keydown", keydownHandler);
+        window.removeEventListener("wheel", wheelHandler);
+        
+        if (!isFirefox) {
+          window.removeEventListener("resize", chromeZoomHandler);
+        }
+        
+        if (rafId !== undefined) {
+          cancelAnimationFrame(rafId);
+        }
       };
     }
     // Return empty cleanup function if conditions are not met


### PR DESCRIPTION
Hello @kaaloo,

On a un souci avec l’affichage du sous-menu de langue quand on zoome à 175–200 % sur desktop : la largeur du menu de langues est problémaitique.

J’ai donc fait évoluer notre useWindowSize pour détecter le zoom (avec un calcul qui marche à la fois sur Firefox et Chrome, qui gèrent ça différemment). Ça permet d’appliquer les classes uniquement dans les cas de zoom et de garder un rendu propre.

C’est un peu plus complexe que ce que j’aurais voulu, mais je n’ai pas trouvé plus simple. 
Dis-moi ce que tu en penses !