### PR TITLE
[HOTFIX][PROD] Disable search counts

### DIFF
--- a/apps/client/cloudbuild.yaml
+++ b/apps/client/cloudbuild.yaml
@@ -58,6 +58,7 @@ steps:
           --region ${_REGION} \
           --service-account ${_SA} \
           --set-secrets MONGODB_URI=${_MONGODB_VAR}:latest \
+          --set-env-vars DISABLE_SEARCH_COUNTS=${_DISABLE_SEARCH_COUNTS} \
           "${vpc_args[@]}"
 
 options:
@@ -70,5 +71,6 @@ substitutions:
   _REGION: europe-west1
   _REGISTRY: "registry-${_ENV}"
   _REGISTRY_URL: "${_REGION}-docker.pkg.dev"
+  _DISABLE_SEARCH_COUNTS: "false"
 
 timeout: 1200s

--- a/apps/client/example-env-file.env
+++ b/apps/client/example-env-file.env
@@ -9,3 +9,4 @@ NEXT_PUBLIC_REACT_APP_ALGOLIA_INDEX_PROD=demo
 NEXT_PUBLIC_REACT_APP_GOOGLE_ANALYTICS_PROD=demo
 NEXT_PUBLIC_REACT_APP_GOOGLE_ANALYTICS_STAG=demo
 NEXT_PUBLIC_SR_DEBUG=true # pour activer le debug du ScreenReaderAnnouncer
+DISABLE_SEARCH_COUNTS=false # set to true to disable search counts API when database load is too high

--- a/apps/client/src/pages/api/search/counts.ts
+++ b/apps/client/src/pages/api/search/counts.ts
@@ -322,6 +322,11 @@ const handler = async (req: NextApiRequest, res: NextApiResponse<SearchCountsRes
     return res.status(405).json({ message: "Method Not Allowed" });
   }
 
+  // Check if the search counts API is disabled via environment variable
+  if (process.env.DISABLE_SEARCH_COUNTS === "true") {
+    return res.status(503).json({ message: "Search counts temporarily unavailable" });
+  }
+
   try {
     const conn = await dbConnect();
     const queryParams = buildQueryParams(req.query);


### PR DESCRIPTION
Add DISABLE_SEARCH_COUNTS environment variable to temporarily disable the search counts API when database load is too high. This provides a quick way to reduce database load until Redis caching is implemented.

Changes:
- Add env var check in /api/search/counts endpoint (returns 503 when disabled)
- Add DISABLE_SEARCH_COUNTS to example-env-file.env with documentation
- Add _DISABLE_SEARCH_COUNTS substitution to cloudbuild.yaml for Cloud Run deployment
- Default value is "false" to keep API enabled by default