### PR TITLE
fix(client): show "toute la france" fiches in department-filtered search results

### DIFF
--- a/apps/client/src/lib/recherche/filterContents.ts
+++ b/apps/client/src/lib/recherche/filterContents.ts
@@ -62,6 +62,8 @@ export const filterByLocations = (dispositif: SimpleDispositif, departments: str
   if (departments.length === 0) return true;
   const location = dispositif.metadatas?.location as any;
   if (!location) return false;
+  // Fiches "toute la france" should always appear when filtering by department
+  if (location === "france") return true;
   const matchDep = (val: string) => {
     if (!val) return false;
     const parts = val.split(" - ");

--- a/apps/client/src/lib/recherche/filterContents.ts
+++ b/apps/client/src/lib/recherche/filterContents.ts
@@ -62,10 +62,10 @@ export const filterByLocations = (dispositif: SimpleDispositif, departments: str
   if (departments.length === 0) return true;
   const location = dispositif.metadatas?.location as any;
   if (!location) return false;
-  // Fiches "toute la france" should always appear when filtering by department
-  if (location === "france") return true;
   const matchDep = (val: string) => {
     if (!val) return false;
+    // Fiches "toute la france" should always appear when filtering by department
+    if (val === "france") return true;
     const parts = val.split(" - ");
     const code = parts.length > 1 ? parts[1] : val;
     return departments.includes(code);


### PR DESCRIPTION
## Description
Fiches marked as "toute la france" (location === "france") should always appear when filtering search results by department. Previously, they were being filtered out because the `filterByLocations` function didn't handle this case.

## Changes
- Updated `filterByLocations` in `apps/client/src/lib/recherche/filterContents.ts` to check if `location === "france"` and return `true` immediately, ensuring national fiches are always displayed regardless of department filters.

<img width="1377" height="812" alt="image" src="https://github.com/user-attachments/assets/92f76210-2efc-482f-80f8-8935c001dc61" />

## Related Issue
Fixes #913