### PR TITLE
Increase résumé section character limit from 110 to 200

### DIFF
--- a/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx
+++ b/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx
@@ -38,7 +38,7 @@ const ModalAbstract = (props: Props) => {
   return (
     <BaseModal show={props.show} toggle={props.toggle} help={help} title="Ajoutez un résumé">
       <div>
-        <p>Le résumé doit faire moins de 200 caractères.</p>
+        <p>{`Le résumé doit faire moins de ${MAX_LENGTH} caractères.`}</p>
         <div className="flex">
           <div>
             <div className={styles.text}>

--- a/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx
+++ b/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx
@@ -7,6 +7,7 @@ import BaseModal from "~/components/UI/BaseModal";
 import DispositifCard from "~/components/UI/DispositifCard";
 import EVAIcon from "~/components/UI/EVAIcon/EVAIcon";
 import Image from "~/components/UI/Image";
+import { DISPOSITIF_FORM_CONSTANTS } from "~/constants/dispositif";
 import { useContentType } from "~/hooks/dispositif";
 import { SimpleFooter } from "../components";
 import { help } from "./data";
@@ -19,7 +20,7 @@ interface Props {
   toggle: () => void;
 }
 
-const MAX_LENGTH = 200;
+const { ABSTRACT_MAX_LENGTH } = DISPOSITIF_FORM_CONSTANTS;
 
 const ModalAbstract = (props: Props) => {
   const formContext = useFormContext<CreateDispositifRequest>();
@@ -32,13 +33,13 @@ const ModalAbstract = (props: Props) => {
     props.toggle();
   };
 
-  const remainingChars = useMemo(() => MAX_LENGTH - (abstract || "").length, [abstract]);
+  const remainingChars = useMemo(() => ABSTRACT_MAX_LENGTH - (abstract || "").length, [abstract]);
   const sponsor = useSponsorData(values, typeContenu);
 
   return (
     <BaseModal show={props.show} toggle={props.toggle} help={help} title="Ajoutez un résumé">
       <div>
-        <p>{`Le résumé doit faire moins de ${MAX_LENGTH} caractères.`}</p>
+        <p>{`Le résumé doit faire moins de ${ABSTRACT_MAX_LENGTH} caractères.`}</p>
         <div className="flex">
           <div>
             <div className={styles.text}>
@@ -47,7 +48,7 @@ const ModalAbstract = (props: Props) => {
                 placeholder="Résumez votre action en quelques mots"
                 value={abstract}
                 className={styles.input}
-                maxLength={MAX_LENGTH}
+                maxLength={ABSTRACT_MAX_LENGTH}
               />
 
               <p className={styles.help}>

--- a/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx
+++ b/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx
@@ -19,7 +19,7 @@ interface Props {
   toggle: () => void;
 }
 
-const MAX_LENGTH = 110;
+const MAX_LENGTH = 200;
 
 const ModalAbstract = (props: Props) => {
   const formContext = useFormContext<CreateDispositifRequest>();
@@ -38,7 +38,7 @@ const ModalAbstract = (props: Props) => {
   return (
     <BaseModal show={props.show} toggle={props.toggle} help={help} title="Ajoutez un résumé">
       <div>
-        <p>Le résumé doit faire moins de 110 caractères.</p>
+        <p>Le résumé doit faire moins de 200 caractères.</p>
         <div className="flex">
           <div>
             <div className={styles.text}>
@@ -57,7 +57,7 @@ const ModalAbstract = (props: Props) => {
                   fill={fr.colors.decisions.background.actionHigh.error.default}
                   className="me-2"
                 />
-                {remainingChars} sur 110 caractères restants
+                {remainingChars} sur 200 caractères restants
               </p>
             </div>
           </div>

--- a/apps/client/src/constants/dispositif.ts
+++ b/apps/client/src/constants/dispositif.ts
@@ -1,0 +1,7 @@
+/**
+ * Constants related to dispositif forms and validation
+ */
+export const DISPOSITIF_FORM_CONSTANTS = {
+  // Character limits
+  ABSTRACT_MAX_LENGTH: 200,
+};

--- a/apps/client/src/hooks/dispositif/useDispositifTranslation/useDispositifTranslation.ts
+++ b/apps/client/src/hooks/dispositif/useDispositifTranslation/useDispositifTranslation.ts
@@ -10,6 +10,7 @@ import get from "lodash/get";
 import { useRouter } from "next/router";
 import { useCallback, useMemo, useState } from "react";
 import { useFormContext, useWatch } from "react-hook-form";
+import { DISPOSITIF_FORM_CONSTANTS } from "~/constants/dispositif";
 import { useUser } from "~/hooks";
 import { TranslateForm } from "../useDispositifTranslateForm";
 import {
@@ -177,7 +178,7 @@ const useDispositifTranslation = (
         isHTML: isInputHTML(section),
         size: getInputSize(section),
         noAutoTrad: section.includes("titreMarque") || section.includes("administrationName"),
-        maxLength: section.includes("abstract") ? 200 : undefined,
+        maxLength: section.includes("abstract") ? DISPOSITIF_FORM_CONSTANTS.ABSTRACT_MAX_LENGTH : undefined,
       };
     },
     [defaultTraduction, translations, language, validate, deleteTrad, data, user, validator, hasChangeForm],

--- a/apps/client/src/hooks/dispositif/useDispositifTranslation/useDispositifTranslation.ts
+++ b/apps/client/src/hooks/dispositif/useDispositifTranslation/useDispositifTranslation.ts
@@ -177,7 +177,7 @@ const useDispositifTranslation = (
         isHTML: isInputHTML(section),
         size: getInputSize(section),
         noAutoTrad: section.includes("titreMarque") || section.includes("administrationName"),
-        maxLength: section.includes("abstract") ? 110 : undefined,
+        maxLength: section.includes("abstract") ? 200 : undefined,
       };
     },
     [defaultTraduction, translations, language, validate, deleteTrad, data, user, validator, hasChangeForm],


### PR DESCRIPTION
## Centralize Form Constants and Improve Résumé Length Handling

### Changes
1. **Centralized constants**: Created new [dispositif.ts](cci:7://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/constants/dispositif.ts:0:0-0:0) constants file
2. **Improved code quality**: Destructured constant usage in components
3. **Maintained functionality**: Kept 200 character limit from RI-912

### Files Modified
- [apps/client/src/constants/dispositif.ts](cci:7://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/constants/dispositif.ts:0:0-0:0) (new)
- [apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx](cci:7://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/ModalAbstract.tsx:0:0-0:0)
- [apps/client/src/hooks/dispositif/useDispositifTranslation/useDispositifTranslation.ts](cci:7://file:///Users/luis/Code/refugies_info/karfur/apps/client/src/hooks/dispositif/useDispositifTranslation/useDispositifTranslation.ts:0:0-0:0)

### Related Tickets
- [RI-912](https://linear.app/refugiesinfo/issue/RI-912/augmenter-le-nombre-de-caracteres-autorises-dans-la-section-resume-du)