### PR TITLE
fix(search): include "toute la france" entries in department filter counts

### DIFF
--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -67,7 +67,8 @@ export const buildBaseMatch = (queryParams: Omit<QueryParams, "sort">, algoliaId
       if (dep === "france" || dep === "online" || dep.includes(" - ")) return dep;
       return new RegExp(` \\- ${escapeRegExp(dep)}$`, "i");
     });
-    match["metadatas.location"] = { $in: tokensOrRegexes };
+    // Fiches "toute la france" should always appear when filtering by department
+    match["metadatas.location"] = { $in: [...tokensOrRegexes, "france"] };
   }
 
   const themes = (queryParams.themes ?? []).filter((v) => typeof v === "string" && v.trim().length > 0);


### PR DESCRIPTION
## Summary
Fixes an inconsistency between frontend filtering and backend search counts where "toute la france" entries were not being included in department-filtered counts.

## Problem
When users filtered by specific departments, the search counts API would exclude resources with `metadatas.location` set to "france", even though these national-level resources should always appear when filtering by department (as implemented in `filterContents.ts`).

## Solution
Updated the `buildBaseMatch` function in `search-helpers.ts` to always include "france" entries when filtering by departments, matching the behavior in `filterContents.ts`:

```typescript
// Fiches "toute la france" should always appear when filtering by department
match["metadatas.location"] = { $in: [...tokensOrRegexes, "france"] };
```

## Changes
- **apps/client/src/lib/search-helpers.ts**: Added "france" to the location filter `$in` array when departments are specified

## Impact
- Ensures search counts API returns consistent results with frontend filtering logic
- Fixes issue where department-filtered counts would exclude national-level resources
- Users will now see accurate counts that include "toute la france" resources when filtering by departments

## Testing
- Verified that the search counts API now includes "france" entries when `departments` parameter is provided
- Confirmed behavior matches the existing `filterContents.ts` logic