### PR TITLE
Jeremie/ri-505-passer-le-plan-du-site-au-dsfrvocalisation

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -812,7 +812,7 @@
       "helpCenter": "Centre d'aide",
       "accessibility": "Déclaration d'accessibilité",
       "legalNotice": "Mentions légales",
-      "personalData": "Données personnelles",
+      "privacyPolicy": "Politique de confidentialité",
       "statistics": "Statistiques",
       "youtube": "Chaîne YouTube",
       "facebook": "Facebook",

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -785,6 +785,45 @@
     "navbarItem8": "Voir les statistiques",
     "join_title": "Travaillons ensemble ! Vous êtes... ? "
   },
+  "sitemap": {
+    "title": "Plan du site",
+    "sections": {
+      "mainNavigation": "Navigation principale",
+      "quickLinks": "Liens d'accès rapide",
+      "socialNetworks": "Réseaux sociaux"
+    },
+    "links": {
+      "home": "Accueil",
+      "findInformation": "Trouver de l'information",
+      "publishSheet": "Publier une fiche",
+      "translateSheet": "Traduire une fiche",
+      "login": "Connexion",
+      "procedures": "Fiches démarches",
+      "localDevices": "Dispositifs locaux",
+      "act": "AGIR",
+      "missionImpact": "Mission et impact",
+      "freeResources": "Ressources gratuites",
+      "communicationKit": "Kit de communication",
+      "orderPosters": "Commander des affiches et dépliants",
+      "forPress": "Pour la presse",
+      "forAmbassadors": "Pour les ambassadeurs",
+      "forUkraine": "Pour l'Ukraine",
+      "installApp": "Installer l'application",
+      "helpCenter": "Centre d'aide",
+      "accessibility": "Déclaration d'accessibilité",
+      "legalNotice": "Mentions légales",
+      "personalData": "Données personnelles",
+      "statistics": "Statistiques",
+      "youtube": "Chaîne YouTube",
+      "facebook": "Facebook",
+      "linkedin": "LinkedIn",
+      "instagram": "Instagram",
+      "signup": "Inscription",
+      "postersLeaflets": "Affiches et dépliants",
+      "talkAboutUs": "Parler de nous",
+      "translate": "Traduire"
+    }
+  },
   "ui": {
     "carrouselSeemore": "Voir tout",
     "carrouselPrev": "Faire défiler à gauche",

--- a/apps/client/src/components/Layout/LegalPagesLayout.tsx
+++ b/apps/client/src/components/Layout/LegalPagesLayout.tsx
@@ -1,0 +1,41 @@
+import { Breadcrumb, type BreadcrumbProps as UIBreadcrumbProps } from "@refugies-info/ui";
+import { useRouter } from "next/router";
+import React from "react";
+import Layout from "~/components/Layout/Layout";
+import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
+
+interface LegalPagesLayoutProps {
+  children: React.ReactNode;
+  history?: string[];
+  BreadcrumbProps?: Omit<UIBreadcrumbProps, "className">;
+}
+
+export default function LegalPagesLayout({
+  children,
+  history = [],
+  BreadcrumbProps = {
+    segments: [],
+    currentPageLabel: "",
+  },
+}: LegalPagesLayoutProps) {
+  const router = useRouter();
+  const pageHistory = history.length > 0 ? history : [router.asPath];
+
+  return (
+    <Layout history={pageHistory}>
+      <div>
+        <HelpNotice className="w-screen" />
+        <div className="fr-container w-full">
+          {BreadcrumbProps && (
+            <Breadcrumb
+              className="w-full"
+              segments={BreadcrumbProps.segments || []}
+              currentPageLabel={BreadcrumbProps.currentPageLabel || ""}
+            />
+          )}
+          <main className="mx-auto mb-10 w-full max-w-3xl">{children}</main>
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/apps/client/src/components/Layout/LegalPagesLayout.tsx
+++ b/apps/client/src/components/Layout/LegalPagesLayout.tsx
@@ -7,15 +7,16 @@ import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
 interface LegalPagesLayoutProps {
   children: React.ReactNode;
   history?: string[];
-  BreadcrumbProps?: Omit<UIBreadcrumbProps, "className">;
+  title: string;
+  BreadcrumbProps?: Omit<UIBreadcrumbProps, "className" | "currentPageLabel">;
 }
 
 export default function LegalPagesLayout({
   children,
   history = [],
+  title,
   BreadcrumbProps = {
     segments: [],
-    currentPageLabel: "",
   },
 }: LegalPagesLayoutProps) {
   const router = useRouter();
@@ -26,13 +27,7 @@ export default function LegalPagesLayout({
       <div>
         <HelpNotice className="w-screen" />
         <div className="fr-container w-full">
-          {BreadcrumbProps && (
-            <Breadcrumb
-              className="w-full"
-              segments={BreadcrumbProps.segments || []}
-              currentPageLabel={BreadcrumbProps.currentPageLabel || ""}
-            />
-          )}
+          <Breadcrumb className="w-full" segments={BreadcrumbProps.segments} currentPageLabel={title} />
           <main className="mx-auto mb-10 w-full max-w-3xl">{children}</main>
         </div>
       </div>

--- a/apps/client/src/components/Pages/recherche/HelpNotice/HelpNotice.tsx
+++ b/apps/client/src/components/Pages/recherche/HelpNotice/HelpNotice.tsx
@@ -5,9 +5,10 @@ interface NoticeContentItem {
   title?: string;
   link: string;
   text: string;
+  className?: string;
 }
 
-export const HelpNotice = () => {
+export const HelpNotice = ({ className }: { className?: string }) => {
   const noticeContent = {
     fr: {
       title: "Réfugiés.info a été nommé Service numérique à impact national ! ",
@@ -52,6 +53,7 @@ export const HelpNotice = () => {
   return (
     <Notice
       isClosable
+      className={className}
       title={
         <>
           {content.title && content.title}

--- a/apps/client/src/pages/mentions-legales.tsx
+++ b/apps/client/src/pages/mentions-legales.tsx
@@ -1,92 +1,101 @@
 import Link from "next/link";
+import { ReactElement } from "react";
 import { getPath } from "routes";
-import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
+import LegalPagesLayout from "~/components/Layout/LegalPagesLayout";
 import SEO from "~/components/Seo";
 import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
-import styles from "~/scss/pages/legal-pages.module.scss";
 
 const MentionsLegales = () => {
   const locale = useLocale();
 
   return (
-    <div className="w-full">
-      <HelpNotice />
-      <div className={styles.legal_pages + " animated fadeIn texte-small"}>
-        <SEO title="Mentions légales" />
-        <h1>Mentions légales</h1>
-        <h2>Site édité par</h2>
-        <strong>Refugies.info</strong>
-        <p>Place Beauvau 75800 Paris Cedex 08</p>
+    <div className={"animated fadeIn texte-small"}>
+      <SEO title="Mentions légales" />
+      <h1 className="mb-8 md:mb-20">Mentions légales</h1>
+      <h2>Site édité par</h2>
+      <strong>Refugies.info</strong>
+      <p>Place Beauvau 75800 Paris Cedex 08</p>
 
-        <h2>Directeur de la publication</h2>
+      <h2>Directeur de la publication</h2>
 
+      <p>
+        <strong>Yannick Prost</strong>
+      </p>
+
+      <h2>Droit d’accès</h2>
+
+      <div>
         <p>
-          <strong>Yannick Prost</strong>
-        </p>
-
-        <h2>Droit d’accès</h2>
-
-        <div>
-          <p>
-            En application de la loi Informatique et liberté, vous disposez d’un droit d’accès, de rectification, de
-            modification et de suppression concernant des données qui vous concernent personnellement. Ce droit peut
-            être exercé par voie électronique à l’adresse email suivante :{" "}
-            <a title="Email" href="mailto:contact@email.refugies.info">
-              contact@email.refugies.info
-            </a>
-            . Ou par courrier postal, daté et signé, accompagné d&apos;une copie d’un titre d’identité, à l&apos;adresse
-            suivante :
-          </p>
-          <p>
-            <strong>Le délégué interministériel chargé de l&apos;accueil et de l&apos;intégration des réfugiés</strong>
-            <br />
-            18 rue des Pyrénées
-            <br />
-            75020 Paris
-          </p>
-        </div>
-
-        <h2>Politique de confidentialité</h2>
-
-        <p>
-          Les informations personnelles collectées ne sont en aucun cas confiées à des tiers. Pour plus
-          d&apos;information consultez la page relative à{" "}
-          <Link legacyBehavior href={getPath("/politique-de-confidentialite", locale)} prefetch={false}>
-            <a>
-              <strong>notre politique de confidentialité</strong>
-            </a>
-          </Link>
-          .
-        </p>
-
-        <h2>Propriété intellectuelle</h2>
-
-        <p>
-          Tout le contenu de notre site, incluant, de façon non limitative, les graphismes, images, textes, vidéos,
-          animations, sons, logos et icônes, sont la propriété exclusive de l&apos;éditeur du site, à l’exception des
-          marques, logos ou contenus appartenant à d’autres organisations. Pour toute demande d’autorisation ou
-          d’information, veuillez nous contacter par email :{" "}
+          En application de la loi Informatique et liberté, vous disposez d’un droit d’accès, de rectification, de
+          modification et de suppression concernant des données qui vous concernent personnellement. Ce droit peut être
+          exercé par voie électronique à l’adresse email suivante :{" "}
           <a title="Email" href="mailto:contact@email.refugies.info">
             contact@email.refugies.info
           </a>
-          . Des conditions spécifiques sont prévues pour la presse.
+          . Ou par courrier postal, daté et signé, accompagné d&apos;une copie d’un titre d’identité, à l&apos;adresse
+          suivante :
         </p>
-
-        <h2>Hébergeur</h2>
-
         <p>
-          Le site Refugies.info est hébergé par la société{" "}
-          <a href="https://www.ovh.com" target="_blank">
-            OVH
-          </a>
-          . 2 rue Kellermann – 59100 Roubaix – France Téléphone : 08 90 39 09 75 (France)
+          <strong>Le délégué interministériel chargé de l&apos;accueil et de l&apos;intégration des réfugiés</strong>
+          <br />
+          18 rue des Pyrénées
+          <br />
+          75020 Paris
         </p>
       </div>
+
+      <h2>Politique de confidentialité</h2>
+
+      <p>
+        Les informations personnelles collectées ne sont en aucun cas confiées à des tiers. Pour plus d&apos;information
+        consultez la page relative à{" "}
+        <Link legacyBehavior href={getPath("/politique-de-confidentialite", locale)} prefetch={false}>
+          <a>
+            <strong>notre politique de confidentialité</strong>
+          </a>
+        </Link>
+        .
+      </p>
+
+      <h2>Propriété intellectuelle</h2>
+
+      <p>
+        Tout le contenu de notre site, incluant, de façon non limitative, les graphismes, images, textes, vidéos,
+        animations, sons, logos et icônes, sont la propriété exclusive de l&apos;éditeur du site, à l’exception des
+        marques, logos ou contenus appartenant à d’autres organisations. Pour toute demande d’autorisation ou
+        d’information, veuillez nous contacter par email :{" "}
+        <a title="Email" href="mailto:contact@email.refugies.info">
+          contact@email.refugies.info
+        </a>
+        . Des conditions spécifiques sont prévues pour la presse.
+      </p>
+
+      <h2>Hébergeur</h2>
+
+      <p>
+        Le site Refugies.info est hébergé par la société{" "}
+        <a href="https://www.ovh.com" target="_blank">
+          OVH
+        </a>
+        . 2 rue Kellermann – 59100 Roubaix – France Téléphone : 08 90 39 09 75 (France)
+      </p>
     </div>
   );
 };
 
+MentionsLegales.getLayout = (page: ReactElement) => {
+  return (
+    <LegalPagesLayout
+      BreadcrumbProps={{
+        segments: [],
+        currentPageLabel: "Mentions légales",
+      }}
+    >
+      {page}
+    </LegalPagesLayout>
+  );
+};
 export const getStaticProps = defaultStaticProps;
 
 export default MentionsLegales;

--- a/apps/client/src/pages/mentions-legales.tsx
+++ b/apps/client/src/pages/mentions-legales.tsx
@@ -84,18 +84,9 @@ const MentionsLegales = () => {
   );
 };
 
-MentionsLegales.getLayout = (page: ReactElement) => {
-  return (
-    <LegalPagesLayout
-      BreadcrumbProps={{
-        segments: [],
-        currentPageLabel: "Mentions légales",
-      }}
-    >
-      {page}
-    </LegalPagesLayout>
-  );
-};
+MentionsLegales.getLayout = (page: ReactElement) => (
+  <LegalPagesLayout title="Mentions légales">{page}</LegalPagesLayout>
+);
 export const getStaticProps = defaultStaticProps;
 
 export default MentionsLegales;

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -1,81 +1,240 @@
+import { Breadcrumb } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { getPath } from "routes";
-import { HelpNotice } from "~/components/Pages/recherche/HelpNotice";
 import SEO from "~/components/Seo";
 import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import { Event } from "~/lib/tracking";
-import styles from "~/scss/pages/legal-pages.module.scss";
+
+interface SitemapLink {
+  id: string;
+  label: string;
+  href: string;
+  isExternal?: boolean;
+  onClick?: () => void;
+  children?: SitemapLink[];
+}
+
+interface SitemapSection {
+  id: string;
+  title: string;
+  links: SitemapLink[];
+}
 
 const PlanDuSite = () => {
   const locale = useLocale();
   const { t } = useTranslation();
+
+  const sitemapData: SitemapSection[] = [
+    {
+      id: "mainNavigation",
+      title: t("sitemap.sections.mainNavigation", "Navigation principale"),
+      links: [
+        {
+          id: "home",
+          label: t("sitemap.links.home", "Accueil"),
+          href: "/",
+          isExternal: true,
+        },
+        {
+          id: "publishSheet",
+          label: t("sitemap.links.publishSheet", "Publier une fiche"),
+          href: "/publier",
+          isExternal: true,
+        },
+        {
+          id: "translateSheet",
+          label: t("sitemap.links.translateSheet", "Traduire une fiche"),
+          href: "/traduire",
+          isExternal: true,
+        },
+        {
+          id: "login",
+          label: t("sitemap.links.login", "Connexion"),
+          href: "/auth",
+          isExternal: true,
+          onClick: () => Event("AUTH", "start", "footer"),
+        },
+        {
+          id: "procedures",
+          label: t("sitemap.links.procedures", "Fiches démarches"),
+          href: "/recherche",
+          isExternal: true,
+        },
+        {
+          id: "localDevices",
+          label: t("sitemap.links.localDevices", "Dispositifs locaux"),
+          href: "/publier",
+          isExternal: true,
+        },
+        {
+          id: "act",
+          label: t("sitemap.links.act", "AGIR"),
+          href: "/agir",
+          isExternal: false,
+        },
+        {
+          id: "missionImpact",
+          label: t("sitemap.links.missionImpact", "Mission et impact"),
+          href: "/mission-impact",
+          isExternal: false,
+        },
+        {
+          id: "freeResources",
+          label: t("sitemap.links.freeResources", "Ressources gratuites"),
+          href: "https://kit.refugies.info/",
+          isExternal: true,
+          children: [
+            {
+              id: "communicationKit",
+              label: t("sitemap.links.communicationKit", "Kit de communication"),
+              href: "https://kit.refugies.info/flyers/",
+              isExternal: true,
+            },
+            {
+              id: "orderPosters",
+              label: t("sitemap.links.orderPosters", "Commander des affiches et dépliants"),
+              href: "https://kit.refugies.info/presse/",
+              isExternal: true,
+            },
+            {
+              id: "forPress",
+              label: t("sitemap.links.forPress", "Pour la presse"),
+              href: "https://kit.refugies.info/presse/",
+              isExternal: true,
+            },
+            {
+              id: "forAmbassadors",
+              label: t("sitemap.links.forAmbassadors", "Pour les ambassadeurs"),
+              href: "https://kit.refugies.info/ambassadeurs/",
+              isExternal: true,
+            },
+          ],
+        },
+        {
+          id: "installApp",
+          label: t("sitemap.links.installApp", "Installer l'application"),
+          href: "#application",
+          isExternal: true,
+        },
+        {
+          id: "helpCenter",
+          label: t("sitemap.links.helpCenter", "Centre d'aide"),
+          href: "/faq",
+          isExternal: false,
+        },
+      ],
+    },
+    {
+      id: "quickLinks",
+      title: t("sitemap.sections.quickLinks", "Liens d'accès rapide"),
+      links: [
+        {
+          id: "accessibility",
+          label: t("sitemap.links.accessibility", "Déclaration d'accessibilité"),
+          href: "/accessibilite",
+        },
+        {
+          id: "legalNotice",
+          label: t("sitemap.links.legalNotice", "Mentions légales"),
+          href: "/mentions-legales",
+        },
+        {
+          id: "personalData",
+          label: t("sitemap.links.personalData", "Données personnelles"),
+          href: "/donnees-personnelles",
+        },
+        {
+          id: "statistics",
+          label: t("sitemap.links.statistics", "Statistiques"),
+          href: "/statistiques",
+        },
+      ],
+    },
+    {
+      id: "socialNetworks",
+      title: t("sitemap.sections.socialNetworks", "Réseaux sociaux"),
+      links: [
+        {
+          id: "youtube",
+          label: t("sitemap.links.youtube", "Chaîne YouTube"),
+          href: "https://www.youtube.com/refugiesinfo",
+          isExternal: true,
+        },
+        {
+          id: "facebook",
+          label: t("sitemap.links.facebook", "Facebook"),
+          href: "https://www.facebook.com/refugies.info",
+          isExternal: true,
+        },
+        {
+          id: "linkedin",
+          label: t("sitemap.links.linkedin", "LinkedIn"),
+          href: "https://www.linkedin.com/company/refugies-info",
+          isExternal: true,
+        },
+        {
+          id: "instagram",
+          label: t("sitemap.links.instagram", "Instagram"),
+          href: "https://www.instagram.com/refugies_info/",
+          isExternal: true,
+        },
+      ],
+    },
+  ];
+
+  const renderLink = (link: SitemapLink) => {
+    const linkContent = (
+      <span className="text-tokens-lighttextdefault-grey hover:text-tokens-lighttexttitle-grey hover:underline">
+        {link.label}
+      </span>
+    );
+
+    return (
+      <Link
+        href={link.href}
+        onClick={link.onClick}
+        className="fr-link hover:underline"
+        prefetch={link.isExternal ? false : undefined}
+        {...(link.isExternal ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      >
+        {linkContent}
+      </Link>
+    );
+  };
+
   return (
-    <div className="flex w-full flex-col justify-center">
-      <HelpNotice />
-      <div className={styles.legal_pages + " animated fadeIn texte-small"}>
-        <SEO title="Plan du site" />
-        <h1>Plan du site</h1>
-        <ul>
-          <li>
-            <Link href={getPath("/", locale)}>Accueil</Link>
-          </li>
-          <li>
-            <Link href={getPath("/recherche", locale)} prefetch={false}>
-              {t("Toolbar.find_information", "Trouver de l'information")}
-            </Link>
-          </li>
-          <li>
-            <Link href={getPath("/publier", locale)} prefetch={false}>
-              {t("Toolbar.Publier une fiche", "Publier une fiche")}
-            </Link>
-          </li>
-          <li>
-            <Link href={getPath("/traduire", locale)} prefetch={false}>
-              {t("Toolbar.Traduire", "Traduire")}
-            </Link>
-          </li>
-          <li>
-            {t("Toolbar.Parler de nous", "Parler de nous")}
-            <ul>
-              <li>
-                <a href="https://kit.refugies.info/" target="_blank">
-                  {t("Toolbar.Kit de communication", "Kit de communication")}
-                </a>
-              </li>
-              <li>
-                <a href="https://kit.refugies.info/flyers/" target="_blank">
-                  {t("Toolbar.posters_leaflets", "Affiches et dépliants")}
-                </a>
-              </li>
-              <li>
-                <a href="https://kit.refugies.info/presse/" target="_blank">
-                  {t("Toolbar.Pour la presse", "Pour la presse")}
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li>
-            <a href="https://parrainage.refugies.info/" target="_blank">
-              {t("Toolbar.for_ukraine", "Pour l'Ukraine")}
-            </a>
-          </li>
-          <li>
-            <Link href="/#application">{t("MobileAppModal.download")}</Link>
-          </li>
-          <li>
-            <Link href={getPath("/auth", "fr")} prefetch={false} onClick={() => Event("AUTH", "start", "footer")}>
-              {t("Toolbar.Inscription", "Inscription")}
-            </Link>
-          </li>
-          <li>
-            <Link href={getPath("/auth", "fr")} prefetch={false} onClick={() => Event("AUTH", "start", "footer")}>
-              {t("Toolbar.Connexion", "Connexion")}
-            </Link>
-          </li>
-        </ul>
-      </div>
+    <div className="fr-container w-full">
+      <SEO title={t("sitemap.title", "Plan du site")} />
+      <Breadcrumb className="w-full" segments={[]} currentPageLabel={t("sitemap.title", "Plan du site")} />
+      <main className="mx-auto mb-10 w-full max-w-3xl">
+        <h1 className="mb-8 md:mb-20">{t("sitemap.title", "Plan du site")}</h1>
+
+        <div className="space-y-10 md:space-y-20">
+          {sitemapData.map((section) => (
+            <div key={section.id} className="border-default-grey border p-4 md:p-10">
+              <h2>{section.title}</h2>
+
+              <ul className="space-y-2">
+                {section.links.map((link) => (
+                  <li key={link.id} className="text-base">
+                    {renderLink(link)}
+                    {link.children && (
+                      <ul className="mb-0 space-y-2">
+                        {link.children.map((childLink) => (
+                          <li key={childLink.id} className="text-base">
+                            {renderLink(childLink)}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      </main>
     </div>
   );
 };

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import { ReactElement } from "react";
+import { ReactElement, ReactNode } from "react";
 import LegalPagesLayout from "~/components/Layout/LegalPagesLayout";
-import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import { Event } from "~/lib/tracking";
 
@@ -22,7 +21,6 @@ interface SitemapSection {
 }
 
 const PlanDuSite = () => {
-  const locale = useLocale();
   const { t } = useTranslation();
 
   const sitemapData: SitemapSection[] = [
@@ -64,7 +62,7 @@ const PlanDuSite = () => {
         {
           id: "localDevices",
           label: t("sitemap.links.localDevices", "Dispositifs locaux"),
-          href: "/publier",
+          href: "/recherche?type=dispositif",
           isExternal: true,
         },
         {
@@ -94,7 +92,7 @@ const PlanDuSite = () => {
             {
               id: "orderPosters",
               label: t("sitemap.links.orderPosters", "Commander des affiches et dépliants"),
-              href: "https://kit.refugies.info/presse/",
+              href: "https://kit.refugies.info/flyers/",
               isExternal: true,
             },
             {
@@ -235,21 +233,19 @@ const PlanDuSite = () => {
   );
 };
 
-PlanDuSite.getLayout = (page: ReactElement) => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+/**
+ * Dedicated layout component that handles translations and page title.
+ * Separated from main component to ensure proper hook usage and improve maintainability.
+ * This pattern is used because Next.js page components require special handling for hooks in getLayout.
+ */
+const PlanDuSiteLayout = ({ children }: { children: ReactNode }) => {
   const { t } = useTranslation();
-
-  return (
-    <LegalPagesLayout
-      BreadcrumbProps={{
-        segments: [],
-        currentPageLabel: t("sitemap.title", "Plan du site"),
-      }}
-    >
-      {page}
-    </LegalPagesLayout>
-  );
+  return <LegalPagesLayout title={t("sitemap.title", "Plan du site")}>{children}</LegalPagesLayout>;
 };
+
+// Using Next.js layout pattern with a separate component to avoid hook usage in static method
+// This ensures proper React hooks behavior and server-side rendering compatibility
+PlanDuSite.getLayout = (page: ReactElement) => <PlanDuSiteLayout>{page}</PlanDuSiteLayout>;
 
 export const getStaticProps = defaultStaticProps;
 

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -130,22 +130,26 @@ const PlanDuSite = () => {
         {
           id: "accessibility",
           label: t("sitemap.links.accessibility", "Déclaration d'accessibilité"),
-          href: "/accessibilite",
+          href: "/declaration-accessibilite",
+          isExternal: true,
         },
         {
           id: "legalNotice",
           label: t("sitemap.links.legalNotice", "Mentions légales"),
           href: "/mentions-legales",
+          isExternal: true,
         },
         {
-          id: "personalData",
-          label: t("sitemap.links.personalData", "Données personnelles"),
-          href: "/donnees-personnelles",
+          id: "privacyPolicy",
+          label: t("sitemap.links.privacyPolicy", "Politique de confidentialité"),
+          href: "/politique-de-confidentialite",
+          isExternal: true,
         },
         {
           id: "statistics",
           label: t("sitemap.links.statistics", "Statistiques"),
-          href: "/statistiques",
+          href: "https://kit.refugies.info/stats/",
+          isExternal: true,
         },
       ],
     },
@@ -156,7 +160,7 @@ const PlanDuSite = () => {
         {
           id: "youtube",
           label: t("sitemap.links.youtube", "Chaîne YouTube"),
-          href: "https://www.youtube.com/refugiesinfo",
+          href: "https://www.youtube.com/channel/UCdj-KP_whcRiS5XWoAa8HXw",
           isExternal: true,
         },
         {
@@ -168,13 +172,13 @@ const PlanDuSite = () => {
         {
           id: "linkedin",
           label: t("sitemap.links.linkedin", "LinkedIn"),
-          href: "https://www.linkedin.com/company/refugies-info",
+          href: "https://www.linkedin.com/showcase/r%C3%A9fugi%C3%A9s-info/",
           isExternal: true,
         },
         {
           id: "instagram",
           label: t("sitemap.links.instagram", "Instagram"),
-          href: "https://www.instagram.com/refugies_info/",
+          href: "https://www.instagram.com/refugies.info",
           isExternal: true,
         },
       ],

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -1,7 +1,7 @@
-import { Breadcrumb } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
-import SEO from "~/components/Seo";
+import { ReactElement } from "react";
+import LegalPagesLayout from "~/components/Layout/LegalPagesLayout";
 import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import { Event } from "~/lib/tracking";
@@ -204,38 +204,50 @@ const PlanDuSite = () => {
   };
 
   return (
-    <div className="fr-container w-full">
-      <SEO title={t("sitemap.title", "Plan du site")} />
-      <Breadcrumb className="w-full" segments={[]} currentPageLabel={t("sitemap.title", "Plan du site")} />
-      <main className="mx-auto mb-10 w-full max-w-3xl">
-        <h1 className="mb-8 md:mb-20">{t("sitemap.title", "Plan du site")}</h1>
+    <>
+      <h1 className="mb-8 md:mb-20">{t("sitemap.title", "Plan du site")}</h1>
 
-        <div className="space-y-10 md:space-y-20">
-          {sitemapData.map((section) => (
-            <div key={section.id} className="border-default-grey border p-4 md:p-10">
-              <h2>{section.title}</h2>
+      <div className="space-y-10 md:space-y-20">
+        {sitemapData.map((section) => (
+          <div key={section.id} className="border-default-grey border p-4 md:p-10">
+            <h2>{section.title}</h2>
 
-              <ul className="space-y-2">
-                {section.links.map((link) => (
-                  <li key={link.id} className="text-base">
-                    {renderLink(link)}
-                    {link.children && (
-                      <ul className="mb-0 space-y-2">
-                        {link.children.map((childLink) => (
-                          <li key={childLink.id} className="text-base">
-                            {renderLink(childLink)}
-                          </li>
-                        ))}
-                      </ul>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            </div>
-          ))}
-        </div>
-      </main>
-    </div>
+            <ul className="space-y-2">
+              {section.links.map((link) => (
+                <li key={link.id} className="text-base">
+                  {renderLink(link)}
+                  {link.children && (
+                    <ul className="mb-0 space-y-2">
+                      {link.children.map((childLink) => (
+                        <li key={childLink.id} className="text-base">
+                          {renderLink(childLink)}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+};
+
+PlanDuSite.getLayout = (page: ReactElement) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { t } = useTranslation();
+
+  return (
+    <LegalPagesLayout
+      BreadcrumbProps={{
+        segments: [],
+        currentPageLabel: t("sitemap.title", "Plan du site"),
+      }}
+    >
+      {page}
+    </LegalPagesLayout>
   );
 };
 

--- a/apps/client/src/pages/politique-de-confidentialite.tsx
+++ b/apps/client/src/pages/politique-de-confidentialite.tsx
@@ -104,18 +104,9 @@ const PolitiqueConfidentialite = () => {
   );
 };
 
-PolitiqueConfidentialite.getLayout = (page: ReactElement) => {
-  return (
-    <LegalPagesLayout
-      BreadcrumbProps={{
-        segments: [],
-        currentPageLabel: "Politique de confidentialité",
-      }}
-    >
-      {page}
-    </LegalPagesLayout>
-  );
-};
+PolitiqueConfidentialite.getLayout = (page: ReactElement) => (
+  <LegalPagesLayout title="Politique de confidentialité">{page}</LegalPagesLayout>
+);
 export const getStaticProps = defaultStaticProps;
 
 export default PolitiqueConfidentialite;

--- a/apps/client/src/pages/politique-de-confidentialite.tsx
+++ b/apps/client/src/pages/politique-de-confidentialite.tsx
@@ -1,20 +1,19 @@
 import Link from "next/link";
+import { ReactElement } from "react";
 import { getPath } from "routes";
-import { HelpNotice } from "~/components/Pages/recherche/HelpNotice/HelpNotice";
+import LegalPagesLayout from "~/components/Layout/LegalPagesLayout";
 import SEO from "~/components/Seo";
 import { useLocale } from "~/hooks";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
-import styles from "~/scss/pages/legal-pages.module.scss";
 
 const PolitiqueConfidentialite = () => {
   const locale = useLocale();
 
   return (
     <div className="w-full">
-      <HelpNotice />
-      <div className={styles.legal_pages + " animated fadeIn texte-small"}>
+      <div className={"animated fadeIn texte-small"}>
         <SEO title="Politique de confidentialité" />
-        <h1>Politique de confidentialité</h1>
+        <h1 className="mb-8 md:mb-20">Politique de confidentialité</h1>
         <h2>Qui sommes-nous ?</h2>
         <p>
           Ce site est édité par <strong>Refugies.info</strong>. Visitez la page{" "}
@@ -105,6 +104,18 @@ const PolitiqueConfidentialite = () => {
   );
 };
 
+PolitiqueConfidentialite.getLayout = (page: ReactElement) => {
+  return (
+    <LegalPagesLayout
+      BreadcrumbProps={{
+        segments: [],
+        currentPageLabel: "Politique de confidentialité",
+      }}
+    >
+      {page}
+    </LegalPagesLayout>
+  );
+};
 export const getStaticProps = defaultStaticProps;
 
 export default PolitiqueConfidentialite;

--- a/apps/storybook/src/stories/ui/Breadcrumb.stories.tsx
+++ b/apps/storybook/src/stories/ui/Breadcrumb.stories.tsx
@@ -1,0 +1,84 @@
+import { Breadcrumb } from "@refugies-info/ui";
+import type { Meta, StoryObj } from "@storybook/react";
+
+/**
+ * The Breadcrumb component provides navigation context by showing the current location within the site hierarchy.
+ * It automatically includes a home icon as the first item and wraps the DSFR Breadcrumb component.
+ */
+const meta: Meta<typeof Breadcrumb> = {
+  title: "UI/Composites/Breadcrumb",
+  component: Breadcrumb,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "A navigation component that displays the current location within the site hierarchy with an automatic home icon.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    segments: {
+      control: "object",
+      description: "Array of breadcrumb segments to display",
+    },
+    currentPageLabel: {
+      control: "text",
+      description: "Label for the current page (not clickable)",
+    },
+    homeLabel: {
+      control: "text",
+      description: "Accessible label for the home icon (default: 'Accueil')",
+    },
+    className: {
+      control: "text",
+      description: "Additional CSS class names",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    segments: [
+      {
+        label: "Page d'accueil",
+        linkProps: { href: "/" },
+      },
+      {
+        label: "Documentation",
+        linkProps: { href: "/docs" },
+      },
+    ],
+    currentPageLabel: "Guide d'utilisation",
+    homeLabel: "Accueil",
+  },
+};
+
+export const WithCustomHome: Story = {
+  args: {
+    segments: [
+      {
+        label: "Tableau de bord",
+        linkProps: { href: "/dashboard" },
+      },
+      {
+        label: "Paramètres",
+        linkProps: { href: "/dashboard/settings" },
+      },
+    ],
+    currentPageLabel: "Profil",
+    homeLabel: "Tableau de bord",
+  },
+};
+
+export const SingleLevel: Story = {
+  args: {
+    segments: [],
+    currentPageLabel: "Tableau de bord",
+    homeLabel: "Accueil",
+  },
+};

--- a/packages/ui/src/components/composites/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/src/components/composites/Breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,40 @@
+import { Breadcrumb as DsfrBreadcrumb } from "@codegouvfr/react-dsfr/Breadcrumb";
+import { type ReactNode } from "react";
+
+export type BreadcrumbSegment = {
+  label: ReactNode;
+  linkProps: {
+    href: string;
+    className?: string;
+    [key: string]: any;
+  };
+};
+
+export interface BreadcrumbProps {
+  segments: BreadcrumbSegment[];
+  currentPageLabel: string;
+  className?: string;
+  homeLabel?: string;
+}
+
+export const Breadcrumb = ({
+  segments = [],
+  currentPageLabel,
+  className = "w-full",
+  homeLabel = "Accueil",
+}: BreadcrumbProps) => {
+  const homeSegment: BreadcrumbSegment = {
+    label: (
+      <span className="relative inline-flex gap-2" aria-label={homeLabel}>
+        <i className="ri-home-4-line" />
+      </span>
+    ),
+    linkProps: { href: "/", className: "bg-none" },
+  };
+
+  const allSegments = [homeSegment, ...segments];
+
+  return <DsfrBreadcrumb className={className} segments={allSegments} currentPageLabel={currentPageLabel} />;
+};
+
+export default Breadcrumb;

--- a/packages/ui/src/components/composites/Breadcrumb/Breadcrumb.tsx
+++ b/packages/ui/src/components/composites/Breadcrumb/Breadcrumb.tsx
@@ -6,7 +6,7 @@ export type BreadcrumbSegment = {
   linkProps: {
     href: string;
     className?: string;
-    [key: string]: any;
+    [key: string]: string | undefined;
   };
 };
 

--- a/packages/ui/src/components/composites/Breadcrumb/index.ts
+++ b/packages/ui/src/components/composites/Breadcrumb/index.ts
@@ -1,0 +1,2 @@
+export * from "./Breadcrumb";
+export type { BreadcrumbProps, BreadcrumbSegment } from "./Breadcrumb";

--- a/packages/ui/src/components/composites/index.ts
+++ b/packages/ui/src/components/composites/index.ts
@@ -1,4 +1,5 @@
 export * from "./annotations-overlay";
+export * from "./Breadcrumb";
 export * from "./carrousel";
 export * from "./Map";
 export * from "./MetaData";


### PR DESCRIPTION
# 🌟 From Sitemap to Super Layout: The Legal Pages Makeover

Hi @kaaloo, this started as a simple sitemap page quickly turned into a legal pages revamp! 
As we missed the Breadcrumbs on all the Legal page screens I made shared layout system and a shiny new `Breadcrumb` component to make these pages more consistent and accessible

## The Good Stuff ✨

### 1. 🎨 Shared Layout for Legal Pages
- Created a sleek `LegalPagesLayout` component that brings consistency to all legal pages
- Migrated mentions-legales, plan-du-site, and politique-de-confidentialite to use the new layout
- No more duplicated layout code - DRY forever :)

### 2. **Breadcrumb Helper**
   - Simple wrapper around DSFR's Breadcrumb
   - Handles home icon implementation in one place
   - Keeps page code clean and maintainable

### 3. 🗺️ Sitemap 2.0
- Completely rebuilt the sitemap with organized sections
- Added proper structure for main navigation, quick links, and social networks
- Improved accessibility and user experience

## How to Test 

Navigate between legal pages and admire the consistent layout :)