### PR TITLE
feat: improve accessibility for carousels and homepage components

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -39,7 +39,8 @@
     "ressourcesImgAlt": "Capture d'écran du kit de communication de Réfugiés.info. L'interface affiche un site web avec une vidéo de présentation, un message d'accueil expliquant l'objectif du kit et une section d'accès rapide contenant des boutons vers différentes ressources. À droite, une série de flyers multilingues est disposée en éventail, représentant les supports physiques disponibles pour informer sur le projet.",
     "resourcesCTA": "Voir les outils",
     "webinaireCTA": "Participer à un webinaire",
-    "StructuresLogosText": "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !"
+    "StructuresLogosText": "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !",
+    "StructuresLogosVocalisation": "Nos partenaires :"
   },
   "Recherche": {
     "pageTitle": "Recherche",
@@ -283,7 +284,9 @@
     "freeApp": "Application gratuite",
     "downloadAppButton": "Télécharger",
     "more_1_year": "Mise à jour il y a plus d’un an",
-    "toastShareCopied": "Lien copié !"
+    "toastShareCopied": "Lien copié !",
+    "themeName": "Thématique {{title}}",
+    "themeOthers": "et {{count}} autres thématiques"
   },
   "Infocards": {
     "availability": "Disponibilité demandée",
@@ -826,8 +829,9 @@
   },
   "ui": {
     "carrouselSeemore": "Voir tout",
-    "carrouselPrev": "Faire défiler à gauche",
-    "carrouselNext": "Faire défiler à droite",
+    "carrouselPrev": "Faire défiler la liste à gauche",
+    "carrouselNext": "Faire défiler la liste à droite",
+    "countSeparator": "sur",
     "northStar_title": "Cette page est-elle utile ? ✨",
     "northStar_no": "Non",
     "northStar_yes": "Oui",

--- a/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
@@ -445,36 +445,46 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
       class="cards"
     >
       <div>
-        <div
-          class="wrapper"
+        <article
+          aria-labelledby="id1"
+          class="[object Object]"
         >
+          <a
+            class="absolute inset-0"
+            href="/dispositif/id1"
+          >
+            tinfo1
+          </a>
+          <p
+            class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
+            id="fr-badge-:r0:"
+          >
+            Lieu d'action
+          </p>
           <div
-            class="fr-card fr-enlarge-link container"
+            class="[object Object]"
           >
             <div
-              class="fr-card__body body"
+              class="[object Object]"
             >
               <div
-                class="fr-card__content content"
+                class="[object Object]"
               >
                 <div
                   class="text"
                 >
                   <h3
                     class="fr-card__title"
+                    id="id1"
                   >
-                    <a
-                      href="/dispositif/id1"
+                    <span
+                      class="[object Object]"
                     >
-                      <span
-                        class="title three_lines"
-                      >
-                        tinfo1
-                      </span>
-                    </a>
+                      tinfo1
+                    </span>
                   </h3>
                   <p
-                    class="fr-card__desc desc"
+                    class="[object Object]"
                   >
                     abstract1
                   </p>
@@ -501,19 +511,19 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                   <div
                     class="mb-2 flex gap-2"
                   >
-                    <div
+                    <span
                       class="container theme-badge"
                       style="background-color: rgb(214, 205, 228);"
                     >
                       Français
-                    </div>
+                    </span>
                   </div>
                 </div>
                 <div
                   class="end"
                 >
                   <div
-                    class="info flex gap-2"
+                    class="[object Object]"
                   />
                   <i
                     class="fr-icon-arrow-right-line"
@@ -540,65 +550,51 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                   width="280"
                 />
               </div>
-              <ul
-                class="fr-badges-group"
-              >
-                <li>
-                  <p
-                    class="fr-badge fr-badge--sm fr-badge--no-icon badge_department"
-                    id="fr-badge-:r0:"
-                  >
-                    Lieu d'action
-                  </p>
-                </li>
-              </ul>
             </div>
           </div>
-          <button
-            class="btn active favorite btn btn-secondary"
-            title="Dispositif.removeFromFavorites"
-            type="button"
-          >
-            <i
-              class="fr-icon-star-fill"
-            />
-            <span>
-              Dispositif.removeFromFavorites
-            </span>
-          </button>
-        </div>
+        </article>
       </div>
       <div>
-        <div
-          class="wrapper"
+        <article
+          aria-labelledby="id2"
+          class="[object Object]"
         >
+          <a
+            class="absolute inset-0"
+            href="/dispositif/id2"
+          >
+            tinfo2
+          </a>
+          <p
+            class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
+            id="fr-badge-:r1:"
+          >
+            Lieu d'action
+          </p>
           <div
-            class="fr-card fr-enlarge-link container"
+            class="[object Object]"
           >
             <div
-              class="fr-card__body body"
+              class="[object Object]"
             >
               <div
-                class="fr-card__content content"
+                class="[object Object]"
               >
                 <div
                   class="text"
                 >
                   <h3
                     class="fr-card__title"
+                    id="id2"
                   >
-                    <a
-                      href="/dispositif/id2"
+                    <span
+                      class="[object Object]"
                     >
-                      <span
-                        class="title three_lines"
-                      >
-                        tinfo2
-                      </span>
-                    </a>
+                      tinfo2
+                    </span>
                   </h3>
                   <p
-                    class="fr-card__desc desc"
+                    class="[object Object]"
                   >
                     abstract2
                   </p>
@@ -625,19 +621,19 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                   <div
                     class="mb-2 flex gap-2"
                   >
-                    <div
+                    <span
                       class="container theme-badge"
                       style="background-color: rgb(202, 190, 187);"
                     >
                       Administratif
-                    </div>
+                    </span>
                   </div>
                 </div>
                 <div
                   class="end"
                 >
                   <div
-                    class="info flex gap-2"
+                    class="[object Object]"
                   />
                   <i
                     class="fr-icon-arrow-right-line"
@@ -664,65 +660,51 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                   width="280"
                 />
               </div>
-              <ul
-                class="fr-badges-group"
-              >
-                <li>
-                  <p
-                    class="fr-badge fr-badge--sm fr-badge--no-icon badge_department"
-                    id="fr-badge-:r1:"
-                  >
-                    Lieu d'action
-                  </p>
-                </li>
-              </ul>
             </div>
           </div>
-          <button
-            class="btn active favorite btn btn-secondary"
-            title="Dispositif.removeFromFavorites"
-            type="button"
-          >
-            <i
-              class="fr-icon-star-fill"
-            />
-            <span>
-              Dispositif.removeFromFavorites
-            </span>
-          </button>
-        </div>
+        </article>
       </div>
       <div>
-        <div
-          class="wrapper"
+        <article
+          aria-labelledby="id3"
+          class="[object Object]"
         >
+          <a
+            class="absolute inset-0"
+            href="/demarche/id3"
+          >
+            tinfo3
+          </a>
+          <p
+            class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
+            id="fr-badge-:r2:"
+          >
+            Dispositif.demarche
+          </p>
           <div
-            class="fr-card fr-enlarge-link container"
+            class="[object Object]"
           >
             <div
-              class="fr-card__body body"
+              class="[object Object]"
             >
               <div
-                class="fr-card__content content"
+                class="[object Object]"
               >
                 <div
                   class="text"
                 >
                   <h3
                     class="fr-card__title"
+                    id="id3"
                   >
-                    <a
-                      href="/demarche/id3"
+                    <span
+                      class="[object Object]"
                     >
-                      <span
-                        class="title three_lines"
-                      >
-                        tinfo3
-                      </span>
-                    </a>
+                      tinfo3
+                    </span>
                   </h3>
                   <p
-                    class="fr-card__desc desc"
+                    class="[object Object]"
                   >
                     abstract3
                   </p>
@@ -749,12 +731,12 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                   <div
                     class="mb-2 flex gap-2"
                   >
-                    <div
+                    <span
                       class="container theme-badge"
                       style="background-color: rgb(193, 227, 242);"
                     >
                       Logement
-                    </div>
+                    </span>
                   </div>
                 </div>
                 <div
@@ -785,33 +767,9 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                   width="280"
                 />
               </div>
-              <ul
-                class="fr-badges-group"
-              >
-                <li>
-                  <p
-                    class="fr-badge fr-badge--sm fr-badge--no-icon badge_demarche"
-                    id="fr-badge-:r2:"
-                  >
-                    Dispositif.demarche
-                  </p>
-                </li>
-              </ul>
             </div>
           </div>
-          <button
-            class="btn active favorite btn btn-secondary"
-            title="Dispositif.removeFromFavorites"
-            type="button"
-          >
-            <i
-              class="fr-icon-star-fill"
-            />
-            <span>
-              Dispositif.removeFromFavorites
-            </span>
-          </button>
-        </div>
+        </article>
       </div>
     </div>
   </div>

--- a/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
@@ -449,12 +449,6 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
           aria-labelledby="id1"
           class="[object Object]"
         >
-          <a
-            class="absolute inset-0"
-            href="/dispositif/id1"
-          >
-            tinfo1
-          </a>
           <p
             class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
             id="fr-badge-:r0:"
@@ -477,11 +471,15 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                     class="fr-card__title"
                     id="id1"
                   >
-                    <span
-                      class="[object Object]"
+                    <a
+                      href="/dispositif/id1"
                     >
-                      tinfo1
-                    </span>
+                      <span
+                        class="[object Object]"
+                      >
+                        tinfo1
+                      </span>
+                    </a>
                   </h3>
                   <p
                     class="[object Object]"
@@ -559,12 +557,6 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
           aria-labelledby="id2"
           class="[object Object]"
         >
-          <a
-            class="absolute inset-0"
-            href="/dispositif/id2"
-          >
-            tinfo2
-          </a>
           <p
             class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
             id="fr-badge-:r1:"
@@ -587,11 +579,15 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                     class="fr-card__title"
                     id="id2"
                   >
-                    <span
-                      class="[object Object]"
+                    <a
+                      href="/dispositif/id2"
                     >
-                      tinfo2
-                    </span>
+                      <span
+                        class="[object Object]"
+                      >
+                        tinfo2
+                      </span>
+                    </a>
                   </h3>
                   <p
                     class="[object Object]"
@@ -669,12 +665,6 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
           aria-labelledby="id3"
           class="[object Object]"
         >
-          <a
-            class="absolute inset-0"
-            href="/demarche/id3"
-          >
-            tinfo3
-          </a>
           <p
             class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
             id="fr-badge-:r2:"
@@ -697,11 +687,15 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
                     class="fr-card__title"
                     id="id3"
                   >
-                    <span
-                      class="[object Object]"
+                    <a
+                      href="/demarche/id3"
                     >
-                      tinfo3
-                    </span>
+                      <span
+                        class="[object Object]"
+                      >
+                        tinfo3
+                      </span>
+                    </a>
                   </h3>
                   <p
                     class="[object Object]"

--- a/apps/client/src/components/Pages/homepage/Sections/Hero/WhiteWave.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/Hero/WhiteWave.tsx
@@ -6,6 +6,7 @@ function WhiteWave({ className }: { className: string }) {
       fill="none"
       className={className}
       xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
     >
       <path
         filter="url(#drop-shadow)"

--- a/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
@@ -15,45 +15,55 @@ import { useTranslation } from "next-i18next";
 
 const StructuresLogos = () => {
   const { t } = useTranslation();
-  const logos: { image: StaticImageData; alt: string }[] = [
+  const logos: { image: StaticImageData; alt: string; title: string }[] = [
     {
       image: FTDA,
+      title: "France Terre d'Asile",
       alt: "",
     },
     {
       image: SOS,
+      title: "Groupe SOS",
       alt: "",
     },
     {
       image: FranceTravail,
+      title: "France Travail",
       alt: "",
     },
     {
       image: COS,
+      title: "Fondation COS",
       alt: "",
     },
     {
       image: FH,
+      title: "France Horizon",
       alt: "",
     },
     {
       image: Coallia,
+      title: "Coallia",
       alt: "",
     },
     {
       image: PierreValdo,
+      title: "Entraide Pierre Valdo",
       alt: "",
     },
     {
       image: HIS,
+      title: "GIP Habitat et Interventions Sociales",
       alt: "",
     },
     {
       image: ForumRefugie,
+      title: "Forum Refugiés",
       alt: "",
     },
     {
       image: FederationActeurs,
+      title: "Fédération des Acteurs de la Solidarité",
       alt: "",
     },
   ];
@@ -70,6 +80,9 @@ const StructuresLogos = () => {
           "Homepage.StructuresLogosText",
           "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !",
         )}
+      </p>
+      <p className="sr-only">
+        {t("Homepage.StructuresLogosVocalisation", "Nos partenaires :")} {logos.map((logo) => logo.title).join(", ")}
       </p>
     </section>
   );

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -71,23 +71,8 @@ const DispositifCard = (props: Props) => {
   return (
     <article
       aria-labelledby={props.dispositif._id.toString()}
-      className={cn(styles.wrapper, props.className, "relative")}
+      className={cn(styles.wrapper, props.className, "fr-card fr-card--sm fr-enlarge-link")}
     >
-      <Link
-        className="absolute inset-0"
-        target={props.targetBlank ? "_blank" : undefined}
-        rel={props.targetBlank ? "noopener noreferrer" : undefined}
-        href={
-          props.demoCard
-            ? "#"
-            : {
-                pathname: getPath(`/${props.dispositif.typeContenu}/[id]`, locale),
-                query: { id: props.dispositif._id.toString(), ...utmParams },
-              }
-        }
-      >
-        {safeTitreInformatif}
-      </Link>
       <Badge small className={cn(badge.className, "absolute top-2 left-2 z-20")}>
         {isOnline && <i className="ri-at-line me-1"></i>}
         {badge.text}
@@ -97,10 +82,24 @@ const DispositifCard = (props: Props) => {
           <div className={cn("fr-card__content", styles.content)}>
             <div className={styles.text}>
               <h3 className="fr-card__title" id={props.dispositif._id.toString()}>
-                <span
-                  className={cn(styles.title, styles.three_lines)}
-                  dangerouslySetInnerHTML={{ __html: safeTitreInformatif }}
-                ></span>
+                <Link
+                  // className="absolute inset-0"
+                  target={props.targetBlank ? "_blank" : undefined}
+                  rel={props.targetBlank ? "noopener noreferrer" : undefined}
+                  href={
+                    props.demoCard
+                      ? "#"
+                      : {
+                          pathname: getPath(`/${props.dispositif.typeContenu}/[id]`, locale),
+                          query: { id: props.dispositif._id.toString(), ...utmParams },
+                        }
+                  }
+                >
+                  <span
+                    className={cn(styles.title, styles.three_lines)}
+                    dangerouslySetInnerHTML={{ __html: safeTitreInformatif }}
+                  ></span>
+                </Link>
               </h3>
               <p className={cn("fr-card__desc", styles.desc)} dangerouslySetInnerHTML={{ __html: safeAbstract }} />
             </div>

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -83,7 +83,6 @@ const DispositifCard = (props: Props) => {
             <div className={styles.text}>
               <h3 className="fr-card__title" id={props.dispositif._id.toString()}>
                 <Link
-                  // className="absolute inset-0"
                   target={props.targetBlank ? "_blank" : undefined}
                   rel={props.targetBlank ? "noopener noreferrer" : undefined}
                   href={

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -1,17 +1,16 @@
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import { ContentType, SimpleDispositif } from "@refugies-info/api-types";
+import { cn } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { memo, useMemo } from "react";
 import { useSelector } from "react-redux";
 import defaultStructureImage from "~/assets/recherche/default-structure-image.svg";
 import demarcheIcon from "~/assets/recherche/illu-demarche.svg";
-import FavoriteButton from "~/components/UI/FavoriteButton";
 import Image from "~/components/UI/Image";
 import { useLocale, useSanitizedContent, useUtmz } from "~/hooks";
 import { useCardImageUrl } from "~/hooks/useCardImage";
 import { jsLcfirst, jsUcfirst } from "~/lib";
-import { cls } from "~/lib/classname";
 import { getCommitmentText, getPriceText } from "~/lib/dispositif";
 import { getRelativeTimeString } from "~/lib/getRelativeDate";
 import { getTheme } from "~/lib/getTheme";
@@ -19,7 +18,6 @@ import { getPath } from "~/routes";
 import styles from "~/scss/components/contentCard.module.scss";
 import { themesSelector } from "~/services/Themes/themes.selectors";
 import { NewThemeBadge } from "../NewThemeBadge";
-
 interface Props {
   dispositif: SimpleDispositif;
   selectedDepartment?: string;
@@ -71,31 +69,40 @@ const DispositifCard = (props: Props) => {
   const defaultImage = isDispositif ? defaultStructureImage : demarcheIcon;
 
   return (
-    <div className={cls(styles.wrapper, props.className)}>
-      <div className={cls("fr-card fr-enlarge-link", styles.container)}>
-        <div className={cls("fr-card__body", styles.body)}>
-          <div className={cls("fr-card__content", styles.content)}>
+    <article
+      aria-labelledby={props.dispositif._id.toString()}
+      className={cn(styles.wrapper, props.className, "relative")}
+    >
+      <Link
+        className="absolute inset-0"
+        target={props.targetBlank ? "_blank" : undefined}
+        rel={props.targetBlank ? "noopener noreferrer" : undefined}
+        href={
+          props.demoCard
+            ? "#"
+            : {
+                pathname: getPath(`/${props.dispositif.typeContenu}/[id]`, locale),
+                query: { id: props.dispositif._id.toString(), ...utmParams },
+              }
+        }
+      >
+        {safeTitreInformatif}
+      </Link>
+      <Badge small className={cn(badge.className, "absolute top-2 left-2 z-20")}>
+        {isOnline && <i className="ri-at-line me-1"></i>}
+        {badge.text}
+      </Badge>
+      <div className={cn("fr-card", styles.container)}>
+        <div className={cn("fr-card__body", styles.body)}>
+          <div className={cn("fr-card__content", styles.content)}>
             <div className={styles.text}>
-              <h3 className="fr-card__title">
-                <Link
-                  target={props.targetBlank ? "_blank" : undefined}
-                  rel={props.targetBlank ? "noopener noreferrer" : undefined}
-                  href={
-                    props.demoCard
-                      ? "#"
-                      : {
-                          pathname: getPath(`/${props.dispositif.typeContenu}/[id]`, locale),
-                          query: { id: props.dispositif._id.toString(), ...utmParams },
-                        }
-                  }
-                >
-                  <span
-                    className={cls(styles.title, styles.three_lines)}
-                    dangerouslySetInnerHTML={{ __html: safeTitreInformatif }}
-                  ></span>
-                </Link>
+              <h3 className="fr-card__title" id={props.dispositif._id.toString()}>
+                <span
+                  className={cn(styles.title, styles.three_lines)}
+                  dangerouslySetInnerHTML={{ __html: safeTitreInformatif }}
+                ></span>
               </h3>
-              <p className={cls("fr-card__desc", styles.desc)} dangerouslySetInnerHTML={{ __html: safeAbstract }} />
+              <p className={cn("fr-card__desc", styles.desc)} dangerouslySetInnerHTML={{ __html: safeAbstract }} />
             </div>
 
             <div className="fr-card__start relative">
@@ -128,7 +135,7 @@ const DispositifCard = (props: Props) => {
             <div className={styles.end}>
               {isDispositif ? (
                 <>
-                  <div className={cls(styles.info, "flex gap-2")}>
+                  <div className={cn(styles.info, "flex gap-2")}>
                     {price && (
                       <span className="shrink-0">
                         <i className="fr-icon-money-euro-circle-line me-2" />
@@ -146,7 +153,7 @@ const DispositifCard = (props: Props) => {
               ) : (
                 <>
                   {props.dispositif.lastModificationDate && (
-                    <div className={styles.info}>
+                    <div className={cn(styles.info)}>
                       <span className="shrink">
                         <i className="fr-icon-time-line me-2" />
                         <span>{getRelativeTimeString(new Date(props.dispositif.lastModificationDate), locale, t)}</span>
@@ -174,19 +181,9 @@ const DispositifCard = (props: Props) => {
               <div className={styles.placeholder_img}></div>
             )}
           </div>
-          <ul className="fr-badges-group">
-            <li>
-              <Badge small className={badge.className}>
-                {isOnline && <i className="ri-at-line me-1"></i>}
-                {badge.text}
-              </Badge>
-            </li>
-          </ul>
         </div>
       </div>
-
-      {!props.demoCard && <FavoriteButton contentId={props.dispositif._id} className={styles.favorite} />}
-    </div>
+    </article>
   );
 };
 

--- a/apps/client/src/components/UI/NewThemeBadge/NewThemeBadge.tsx
+++ b/apps/client/src/components/UI/NewThemeBadge/NewThemeBadge.tsx
@@ -1,33 +1,30 @@
 import { GetThemeResponse } from "@refugies-info/api-types";
 import useLocale from "hooks/useLocale";
-import { cls } from "lib/classname";
-import { useMemo } from "react";
+import { cn } from "lib/classname";
+import React, { useMemo } from "react";
 import styles from "./NewThemeBadge.module.scss";
 
-interface Props {
+interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   theme: GetThemeResponse | number; // theme or number for "+X" badge
-  className?: any;
 }
 
-export const NewThemeBadge = (props: Props) => {
+export const NewThemeBadge = ({ theme, className, ...props }: Props) => {
   const locale = useLocale();
 
-  const isPlusTag = useMemo(() => typeof props.theme === "number", [props.theme]);
+  const isPlusTag = useMemo(() => typeof theme === "number", [theme]);
   const themeText = useMemo(
-    () => (isPlusTag ? `+${props.theme}` : (props.theme as GetThemeResponse).short[locale] || ""),
-    [isPlusTag, props.theme, locale],
+    () => (isPlusTag ? `+${theme}` : (theme as GetThemeResponse).short[locale] || ""),
+    [isPlusTag, theme, locale],
   );
-  const background = useMemo(
-    () => (isPlusTag ? null : (props.theme as GetThemeResponse).colors.color40),
-    [isPlusTag, props.theme],
-  );
+  const background = useMemo(() => (isPlusTag ? null : (theme as GetThemeResponse).colors.color40), [isPlusTag, theme]);
 
   return (
-    <div
-      className={cls(styles.container, props.className, "theme-badge")}
+    <span
+      className={cn(styles.container, className, "theme-badge")}
       style={background ? { backgroundColor: background } : undefined}
+      {...props}
     >
       {themeText}
-    </div>
+    </span>
   );
 };

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -5,7 +5,7 @@ import {
   SimpleDispositif,
   TranslationStatisticsResponse,
 } from "@refugies-info/api-types";
-import { Carrousel } from "@refugies-info/ui";
+import { Carrousel, isInBrowser, useWindowSize } from "@refugies-info/ui";
 import { logger } from "logger";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -21,9 +21,7 @@ import WorkTogether from "~/components/Pages/staticPages/common/WorkTogether";
 import SEO from "~/components/Seo";
 import DispositifCard from "~/components/UI/DispositifCard";
 import { useRTL } from "~/hooks";
-import { useWindowSize } from "@refugies-info/ui";
 import { getLanguageFromLocale } from "~/lib/getLanguageFromLocale";
-import { isInBrowser } from "@refugies-info/ui";
 import { Event } from "~/lib/tracking";
 import commonStyles from "~/scss/components/staticPages.module.scss";
 import { wrapper } from "~/services/configureStore";
@@ -93,8 +91,9 @@ const Homepage = (props: Props) => {
             count: props.contentStatistics.nbDemarches || 0,
           }),
           seeMore: t("Homepage.demarcheSeeAll", "Voir toutes les démarches"),
-          prev: t("ui.carrouselPrev", "Faire défiler à gauche"),
-          next: t("ui.carrouselNext", "Faire défiler à droite"),
+          prev: t("ui.carrouselPrev", "Faire défiler à gauche", { type: "demarche" }),
+          next: t("ui.carrouselNext", "Faire défiler à droite", { type: "demarche" }),
+          countSeparator: t("ui.countSeparator", "sur"),
         }}
         seeMoreUrl="/recherche?search=&sort=default&type=demarche"
       >
@@ -113,6 +112,7 @@ const Homepage = (props: Props) => {
           seeMore: t("Homepage.dispositifSeeAll", "Voir tous les dispositifs"),
           prev: t("ui.carrouselPrev", "Faire défiler à gauche"),
           next: t("ui.carrouselNext", "Faire défiler à droite"),
+          countSeparator: t("ui.countSeparator", "sur"),
         }}
         seeMoreUrl="/recherche?search=&sort=default&type=dispositif"
       >

--- a/packages/ui/src/components/composites/carrousel/Carrousel.tsx
+++ b/packages/ui/src/components/composites/carrousel/Carrousel.tsx
@@ -1,13 +1,22 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { cn } from "@refugies-info/ui";
-import React, { forwardRef, useCallback, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from "react";
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 type CarrouselTexts = {
   title?: string | null;
   seeMore?: string;
   prev?: string;
   next?: string;
+  countSeparator?: string;
 };
 
 const defaultTexts: Required<CarrouselTexts> = {
@@ -15,6 +24,7 @@ const defaultTexts: Required<CarrouselTexts> = {
   seeMore: "Voir plus",
   prev: "Faire défiler à gauche",
   next: "Faire défiler à droite",
+  countSeparator: "sur",
 };
 
 type CarrouselProps = {
@@ -51,8 +61,8 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
     }: CarrouselProps,
     ref,
   ) => {
-    const scrollContainerRef = useRef<HTMLDivElement>(null);
-    const slideRefs = useRef<(HTMLDivElement | null)[]>([]);
+    const scrollContainerRef = useRef<HTMLUListElement>(null);
+    const slideRefs = useRef<(HTMLLIElement | null)[]>([]);
     const [currentSlide, setCurrentSlide] = useState(0);
     const [canScrollNext, setCanScrollNext] = useState(true);
     const [canScrollPrev, setCanScrollPrev] = useState(false);
@@ -187,53 +197,6 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
       [currentSlide, childrenArray.length, scrollToSlide],
     );
 
-    // Use ref to track if scroll animation is in progress
-    const isScrollingRef = useRef<boolean>(false);
-
-    const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
-        // Prevent navigation if a scroll animation is already in progress
-        if (isScrollingRef.current) {
-          e.preventDefault();
-          return;
-        }
-
-        switch (e.key) {
-          case "ArrowLeft":
-            e.preventDefault();
-            if (currentSlide > 0) {
-              // Set scrolling flag to true
-              isScrollingRef.current = true;
-
-              // Use smooth scrolling for better UX
-              scrollToSlide(currentSlide - 1, true);
-
-              // Reset the scrolling flag after animation completes
-              setTimeout(() => {
-                isScrollingRef.current = false;
-              }, 300); // Matches typical scroll animation duration
-            }
-            break;
-          case "ArrowRight":
-            e.preventDefault();
-            if (currentSlide < childrenArray.length - 1) {
-              // Set scrolling flag to true
-              isScrollingRef.current = true;
-
-              // Use smooth scrolling for better UX
-              scrollToSlide(currentSlide + 1, true);
-
-              // Reset the scrolling flag after animation completes
-              setTimeout(() => {
-                isScrollingRef.current = false;
-              }, 300); // Matches typical scroll animation duration
-            }
-            break;
-        }
-      },
-      [currentSlide, childrenArray.length, scrollToSlide],
-    );
-
     useEffect(() => {
       const container = scrollContainerRef.current;
       if (!container) return;
@@ -298,16 +261,18 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
       <section
         className={cn("relative w-full max-md:pb-14", className)}
         role="region"
-        aria-roledescription="carousel"
-        aria-label={t.title || "Carousel de contenu"}
-        onKeyDown={handleKeyDown}
+        aria-labelledby={componentId}
         dir={dir}
       >
         <div className="container mx-auto mb-8 flex w-full gap-4 lg:justify-between">
-          {t.title && <h2 className="!mb-0 w-full !text-2xl font-bold max-sm:pe-[30%]">{t.title}</h2>}
-          <nav className="z-10 flex items-center gap-2 max-md:absolute max-md:right-4 max-md:bottom-0">
+          {t.title && (
+            <h2 id={componentId} className="!mb-0 w-full !text-2xl font-bold max-sm:pe-[30%]">
+              {t.title}
+            </h2>
+          )}
+          <div className="z-10 flex items-center gap-2 max-md:absolute max-md:right-4 max-md:bottom-0">
             <Button
-              aria-label={`${t.prev} (${prevSlide + 1} / ${childrenArray.length}`}
+              aria-label={`${t.prev} (${prevSlide + 1} ${t.countSeparator} ${childrenArray.length})`}
               onClick={handlePrevClick}
               priority="tertiary"
               iconId={dir === "rtl" ? "fr-icon-arrow-right-line" : "fr-icon-arrow-left-line"}
@@ -315,7 +280,7 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
               disabled={!canScrollPrev}
             />
             <Button
-              aria-label={`${t.next} (${nextSlide + 1} / ${childrenArray.length}`}
+              aria-label={`${t.next} (${nextSlide + 1} ${t.countSeparator} ${childrenArray.length})`}
               onClick={handleNextClick}
               disabled={!canScrollNext}
               priority="tertiary"
@@ -327,50 +292,44 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
                 {t.seeMore}
               </Button>
             )}
-          </nav>
+          </div>
         </div>
 
-        <div
+        <ul
           ref={scrollContainerRef}
           className={cn(
-            "carrousel noscrollbar m-auto flex gap-4",
+            "carrousel noscrollbar m-auto flex list-none gap-4 p-0",
             "snap-x snap-mandatory overflow-x-auto scroll-smooth",
             "scrollbar-hide [-ms-overflow-style:none] [scrollbar-width:none] [&::WebkitScrollbar]:hidden",
             enableContainerPadding &&
               "scroll-ps-[max(1rem,calc((100vw-76rem)/2))] ps-[max(1rem,calc((100vw-76rem)/2))]",
             "ltr:pr-4 rtl:pl-4",
-            "cursor-grab active:cursor-grabbing",
             containerClassName,
           )}
-          aria-live="polite"
-          aria-atomic="true"
           style={{
             scrollbarWidth: "none",
             msOverflowStyle: "none",
             WebkitOverflowScrolling: "touch",
-            willChange: "transform",
             scrollBehavior: "smooth",
             overscrollBehaviorX: "contain",
-            direction: dir, // Set the direction explicitly
+            direction: dir,
           }}
+          aria-labelledby={componentId}
+          role="list"
         >
           {React.Children.map(children, (child, index) => (
-            <div
+            <li
               ref={(el) => {
                 slideRefs.current[index] = el;
               }}
               id={`slide-${componentId}-${index}`}
               className="min-w-max shrink-0 snap-start"
-              role="group"
-              aria-roledescription="slide"
-              aria-label={`Slide ${index + 1} sur ${childrenArray.length}`}
-              tabIndex={0}
-              aria-current={currentSlide === index ? "true" : undefined}
+              role="listitem"
             >
               {child}
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </section>
     );
   },


### PR DESCRIPTION
# feat(a11y): our homepage now whispers sweet nothings to screen readers

- TL;DR: Carousels got brains, logos got voices, cards got manners. Vive l’accessibilité.

## What changed
- Logos: SR-only list so partners aren’t just pretty faces.
- Carrousel: proper ARIA, semantic `ul/li`, and “Slide X of Y” like a polite tour guide.
- DispositifCard: semantic `article` + heading; no more double-announcing drama.
- i18n (FR): added labels and tiny words that make a big difference.

## Why
- Screen readers deserve love too. Also, DSFR approves.

## How to test
- Logos section: SR-only sentence lists all partners.
- Tab around the carousel; buttons say what they do.
- With a screen reader, hear each card title once (not twice, not thrice).

Merci pour votre attention (and your ears).