### PR TITLE
fix: increase Node.js memory limit for server build process

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -41,6 +41,9 @@ FROM tools AS installer
   # Set working directory
   WORKDIR /app
 
+  # Set Node.js memory limit for build process
+  ENV NODE_OPTIONS="--max-old-space-size=4096"
+
   # First install the dependencies (as they change less often)
   COPY --from=builder /app/out/json/ .
 

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "dist/index.js",
   "scripts": {
-    "build": "pnpm gen:tsoa && ncc build src/server.ts -o dist",
+    "build": "pnpm gen:tsoa && node --max-old-space-size=4096 ../../node_modules/.bin/ncc build src/server.ts -o dist",
     "build:dev": "pnpm gen:tsoa && tsc",
     "check:types": "pnpm gen:tsoa && tsc --noEmit",
     "dev": "pnpm build:dev && concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",


### PR DESCRIPTION
- Added NODE_OPTIONS environment variable in Dockerfile to allocate 4GB heap memory
- Updated build script to explicitly set max-old-space-size for ncc bundling to prevent out-of-memory errors