### PR TITLE
Security: Fix validator.js URL validation bypass vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "unrs-resolver"
     ],
     "overrides": {
+      "@codegouvfr/react-dsfr": "1.20.2",
       "debug": "4.4.1",
       "expo-dev-menu": "6.0.21",
       "form-data": ">=4.0.4",
@@ -35,7 +36,7 @@
       "stylus": "npm:noop3@^1000.0.0",
       "tmp": ">=0.2.4",
       "undici": ">=6.21.2",
-      "@codegouvfr/react-dsfr": "1.20.2"
+      "validator": ">=13.15.20"
     },
     "patchedDependencies": {
       "@codegouvfr/react-dsfr@1.20.2": "patches/@codegouvfr__react-dsfr@1.20.2.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@codegouvfr/react-dsfr': 1.20.2
   debug: 4.4.1
   expo-dev-menu: 6.0.21
   form-data: '>=4.0.4'
@@ -14,7 +15,7 @@ overrides:
   stylus: npm:noop3@^1000.0.0
   tmp: '>=0.2.4'
   undici: '>=6.21.2'
-  '@codegouvfr/react-dsfr': 1.20.2
+  validator: '>=13.15.20'
 
 patchedDependencies:
   '@codegouvfr/react-dsfr@1.20.2':
@@ -12790,8 +12791,8 @@ packages:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  validator@13.15.15:
-    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+  validator@13.15.23:
+    resolution: {integrity: sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==}
     engines: {node: '>= 0.10'}
 
   value-equal@1.0.1:
@@ -18504,7 +18505,7 @@ snapshots:
       minimatch: 9.0.5
       ts-deepmerge: 7.0.3
       typescript: 5.9.2
-      validator: 13.15.15
+      validator: 13.15.23
       yaml: 2.8.1
       yargs: 17.7.2
     transitivePeerDependencies:
@@ -18518,7 +18519,7 @@ snapshots:
       '@types/multer': 1.4.13
       express: 4.21.2
       reflect-metadata: 0.2.2
-      validator: 13.15.15
+      validator: 13.15.23
     transitivePeerDependencies:
       - supports-color
 
@@ -28242,7 +28243,7 @@ snapshots:
 
   validate-npm-package-name@5.0.1: {}
 
-  validator@13.15.15: {}
+  validator@13.15.23: {}
 
   value-equal@1.0.1: {}
 


### PR DESCRIPTION
Fixes URL validation bypass vulnerability in validator.js prior to version 13.15.20.

## Security Issue
The isURL() function in validator.js uses '://' as a delimiter to parse protocols, while browsers use ':' as the delimiter. This parsing difference allows attackers to bypass protocol and domain validation by crafting URLs leading to XSS and Open Redirect attacks.

## Fix
Updated validator.js to version 13.15.20 or higher, which contains the security fix for this vulnerability.

## Changes
- Added pnpm override to ensure validator.js >= 13.15.20 is used across the monorepo

## Impact
- Prevents potential XSS and Open Redirect attacks through URL validation bypass
- No breaking changes to existing functionality
- Transitive dependency update only