### PR TITLE
refactor: improve accessibility for theme menu checkboxes and remove redundant aria-labels

### DIFF
--- a/apps/client/src/components/Pages/recherche/ThemeMenu/NeedItem.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/NeedItem.tsx
@@ -1,11 +1,8 @@
 import { GetNeedResponse } from "@refugies-info/api-types";
 import { cn } from "@refugies-info/ui";
-import { useTranslation } from "next-i18next";
 import React, { useContext } from "react";
-import { useSelector } from "react-redux";
 import { ThemeMenuContext } from "~/components/Pages/recherche/ThemeMenu/ThemeMenuContext";
 import { useLocale } from "~/hooks";
-import { themesSelector } from "~/services/Themes/themes.selectors";
 import styles from "./NeedItem.module.css";
 
 interface Props {
@@ -16,26 +13,17 @@ interface Props {
 
 const NeedItem: React.FC<Props> = ({ need, label, count: customCount }) => {
   const locale = useLocale();
-  const { nbDispositifsByNeed, selectedThemeId } = useContext(ThemeMenuContext);
-  const { t } = useTranslation();
-  const themes = useSelector(themesSelector);
+  const { nbDispositifsByNeed } = useContext(ThemeMenuContext);
 
   const displayLabel = label || (need ? need[locale]?.text || "" : "");
   const displayCount = customCount !== undefined ? customCount : need ? nbDispositifsByNeed[need._id.toString()] : "";
-  const countNumber = typeof displayCount === "string" ? parseInt(displayCount, 10) || 0 : displayCount;
-
-  const selectedTheme = themes.find((theme) => theme._id === selectedThemeId);
-  const themeName = selectedTheme?.short?.[locale] || selectedTheme?.name?.[locale] || "";
-
-  const ariaLabel =
-    displayLabel === "Tous"
-      ? t("Recherche.needAllSheets", { count: countNumber, theme: themeName })
-      : `${displayLabel} ${t("Recherche.needSheetsCount", { count: countNumber })}`;
 
   return (
-    <span className={cn("space-between flex w-full")} aria-label={ariaLabel}>
+    <span className={cn("space-between flex w-full")}>
       <span className={styles.label}>{displayLabel}</span>{" "}
-      <span className={cn("ms-auto", styles.count)}>{displayCount}</span>
+      <span className={cn("ms-auto", styles.count)} aria-hidden="true">
+        {displayCount}
+      </span>
     </span>
   );
 };

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
@@ -123,7 +123,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
       >
         <Checkbox
           legend={t("Recherche.theme", "Thème")}
-          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b [&_legend]:sr-only"
+          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b [&_legend]:sr-only [&_legend]:hidden"
           options={[
             {
               label: (
@@ -133,8 +133,10 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
                 />
               ),
               nativeInputProps: {
-                checked: allNeedsSelected,
-                onChange: toggleAllNeeds,
+                "checked": allNeedsSelected,
+                "onChange": toggleAllNeeds,
+                "className": "!border",
+                "aria-label": `${t("Recherche.all", "Tous")} ${selectedThemeId ? nbDispositifsByTheme[selectedThemeId.toString()] : ""} ${t("Recherche.fiches", "fiches")}`,
               },
             },
             ...displayedNeeds.map((need) => {
@@ -143,8 +145,10 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
               return {
                 label: <NeedItem need={need} />,
                 nativeInputProps: {
-                  checked: selected,
-                  onChange: () => selectNeed(need._id),
+                  "checked": selected,
+                  "onChange": () => selectNeed(need._id),
+                  "className": "!border",
+                  "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")})`,
                 },
               };
             }),

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
@@ -122,8 +122,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
         ref={needsContainerRef}
       >
         <Checkbox
-          legend={t("Recherche.theme", "Thème")}
-          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b [&_legend]:sr-only [&_legend]:hidden"
+          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b"
           options={[
             {
               label: (
@@ -148,7 +147,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
                   "checked": selected,
                   "onChange": () => selectNeed(need._id),
                   "className": "!border",
-                  "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")})`,
+                  "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")}`,
                 },
               };
             }),

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.module.css
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.module.css
@@ -29,3 +29,12 @@
   align-items: flex-start;
   align-self: stretch;
 }
+
+@layer base {
+  .needs fieldset legend:global(.fr-text--regular) {
+    font:
+      700 1rem/1.5rem Marianne,
+      arial,
+      sans-serif !important;
+  }
+}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
@@ -66,7 +66,7 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
     <div className={styles.container}>
       <div
         className={cn(
-          "w-full px-2 [&_div]:m-0 [&_fieldset]:m-0 [&_fieldset]:w-full",
+          "w-full px-2 [&_div]:m-0 [&_fieldset]:m-0 [&_fieldset]:w-full [&_fieldset_legend]:px-0 [&_fieldset_legend]:py-4 [&_fieldset_legend]:pb-2",
           styles.needs,
           needs.length === 0 && styles.needsEmpty,
         )}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
@@ -2,7 +2,7 @@ import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { GetNeedResponse, GetThemeResponse, Id } from "@refugies-info/api-types";
 import { cn } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
-import React from "react";
+import React, { useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import { useLocale, useSearchEventName } from "~/hooks";
@@ -15,6 +15,7 @@ import { addToQueryActionCreator } from "~/services/SearchResults/searchResults.
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
 import NeedItem from "./NeedItem";
 import styles from "./ResultsSection.module.css";
+import { ThemeMenuContext } from "./ThemeMenuContext";
 
 interface Props {
   theme: GetThemeResponse;
@@ -30,13 +31,7 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
   const { t } = useTranslation();
   const announce = useAnnounce();
   const dispositifs = useSelector(activeDispositifsSelector);
-
-  // Calculate count of dispositifs for each need
-  const nbDispositifsByNeed: Record<string, number> = {};
-  needs.forEach((need) => {
-    const results = queryDispositifs({ ...query, needs: [need._id], themes: [] }, dispositifs, allNeeds);
-    nbDispositifsByNeed[need._id.toString()] = results.matches.length;
-  });
+  const { nbDispositifsByNeed } = useContext(ThemeMenuContext);
 
   const selectNeed = (id: Id) => {
     let allSelectedNeeds: Id[] = [...query.needs, ...getNeedsFromThemes(query.themes, allNeeds)];

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
@@ -31,6 +31,13 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
   const announce = useAnnounce();
   const dispositifs = useSelector(activeDispositifsSelector);
 
+  // Calculate count of dispositifs for each need
+  const nbDispositifsByNeed: Record<string, number> = {};
+  needs.forEach((need) => {
+    const results = queryDispositifs({ ...query, needs: [need._id], themes: [] }, dispositifs, allNeeds);
+    nbDispositifsByNeed[need._id.toString()] = results.matches.length;
+  });
+
   const selectNeed = (id: Id) => {
     let allSelectedNeeds: Id[] = [...query.needs, ...getNeedsFromThemes(query.themes, allNeeds)];
 
@@ -62,7 +69,6 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.theme}>{theme.short[locale]}</div>
       <div
         className={cn(
           "w-full px-2 [&_div]:m-0 [&_fieldset]:m-0 [&_fieldset]:w-full",
@@ -72,15 +78,15 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
       >
         <Checkbox
           legend={theme.short[locale]}
-          className="[&_legend]:sr-only"
           options={needs.map((need) => {
             const selected = query.needs.includes(need._id) || query.themes.includes(need.theme._id);
 
             return {
               label: <NeedItem need={need} />,
               nativeInputProps: {
-                checked: selected,
-                onChange: () => selectNeed(need._id),
+                "checked": selected,
+                "onChange": () => selectNeed(need._id),
+                "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")}`,
               },
             };
           })}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.tsx
@@ -35,11 +35,12 @@ const ThemeItem: React.FC<ThemeItemProps> = ({ color, id, label, needCount, sele
       aria-controls={`tabpanel-${id}`}
       id={`tab-${id}`}
       tabIndex={selected ? 0 : isFirst ? 0 : -1}
+      aria-label={ariaLabel}
     >
-      <div className={styles.zone} aria-label={ariaLabel}>
+      <div className={styles.zone}>
         <span className={styles.label}>{label}</span>
         {needCount && needCount > 0 && (
-          <div className={styles.countContainer}>
+          <div className={styles.countContainer} aria-hidden="true">
             <span
               style={{
                 color: selected ? color : "white",


### PR DESCRIPTION
- Removed unused imports and variables from NeedItem component
- Simplified NeedItem by removing complex aria-label generation logic
- Added aria-label directly to checkbox native inputs in Needs and ResultsSection components
- Moved aria-label from wrapper div to button element in ThemeItem
- Added aria-hidden to count displays to prevent screen reader duplication
- Removed redundant theme title display in Result