### PR TITLE
chore(workspace): document project rules and tooling

### DIFF
--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,26 +1,25 @@
 # Refugies.info Project Rules & Context
 
 ## 🧠 Project Architecture
+
 - **Type:** Turborepo Monorepo.
 - **Stack:** Next.js, React, TypeScript, Tailwind CSS, Node.js 22.x (LTS).
-- **Principles:** 1. Accessibility First
-  2. Multilingual by Design
-  3. Progressive Migration Strategy
-  4. Monorepo Consistency
-  5. Government Standards (DSFR) Compliance.
+- **Principles:** 1. Accessibility First 2. Multilingual by Design 3. Progressive Migration Strategy 4. Monorepo Consistency 5. Government Standards (DSFR) Compliance.
 
 ## 🔧 Strict Configuration Enforcements
-- **Package Manager:** - EXCLUSIVELY use `pnpm`. Never suggest `npm` or `yarn`.
+
+- **Package Manager:** EXCLUSIVELY use `pnpm`. Never suggest `npm` or `yarn`.
   - Use `pnpm clean:modules` for deep cleaning.
   - Use `pnpm.overrides` in package.json for dependency resolutions.
-- **Imports:** - ALWAYS use static imports (performance/types).
+- **Imports:** ALWAYS use static imports (performance/types).
   - ALWAYS use the `~` alias (e.g., `~/lib/utils`) defined in `tsconfig.json`.
   - NEVER use deep relative paths (e.g., `../../../lib`).
-- **Formatting:** - Strictly follow `.prettierrc` (printWidth 120, no semi, etc.).
+- **Formatting:** Strictly follow `.prettierrc` (printWidth 120, no semi, etc.).
   - Consult the file directly if unsure about specific syntax styles.
 
 ## 🎨 Styling Standards
-- **Tailwind First:** - Use Tailwind CSS utility classes for 95% of styling.
+
+- **Tailwind First:** Use Tailwind CSS utility classes for 95% of styling.
   - Use the `!` modifier (e.g., `!mt-0`) to resolve precedence issues before adding complex logic.
 - **SCSS/CSS Constraints:**
   - Only use SCSS for complex animations or global styles that Tailwind cannot handle.
@@ -28,20 +27,23 @@
   - **Selectors:** Avoid fragile selectors like `ol li[value="2"]`. Use generic classes.
 
 ## 🧪 Testing & Quality
+
 - **Strategy:** Prefer state-based "narrow integration tests" over heavy mocking.
-  - *Pattern:* Setup real state (e.g., test DB) -> Run function -> Assert resulting state.
+  - _Pattern:_ Setup real state (e.g., test DB) -> Run function -> Assert resulting state.
 - **Reference:** See `dispositif.service.additional.tests.ts` for the canonical example.
 
 ## 🛠️ Tooling & Scripts
-- **Feature Creation:** - Script: `.specify/scripts/bash/create-new-feature.sh`
+
+- **Feature Creation:** Script: `.specify/scripts/bash/create-new-feature.sh`
   - Usage: `... --json --short-name <short-name> "<description>"`
   - Format: `short-name` must be 2–4 hyphen-separated words.
 - **Database (MongoDB):**
   - Queries generated must be formatted for direct copy-paste into MongoDB Atlas web console.
   - Tooling: Use MongoDB MCP tool with database `heroku_wbj38s57` to inspect collections.
-- **Migrations:** - Create via: `pnpm migrate new --name <migration_name>` (saves to `/migrations`).
+- **Migrations:** Create via: `pnpm migrate new --name <migration_name>` (saves to `/migrations`).
 
 ## 📦 Git & Commits
+
 - **Convention:** Conventional Commits v1.0.0.
 - **Allowed Scopes:** `api-types`, `client`, `server`, `mobile`, `storybook`, `ui`, `workspace`.
 - **Types:** `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,1 +1,49 @@
-1. Follow the formatting rules established in .prettierrc when generating code.
+# Workspace Rules
+
+## Tech Stack & Standards
+
+- **Framework:** Next.js / React / Turborepo Monorepo.
+- **Styling:** - Use Tailwind CSS utility classes by default.
+  - Use `!` modifier for precedence conflicts before complex logic.
+  - Only use SCSS/CSS for complex animations or global styles not possible with Tailwind.
+  - Avoid fragile CSS selectors (e.g., `ol li[value="2"]`).
+- **Testing:** - Prefer state-based "narrow integration tests" over heavy mocks.
+  - Setup real state (e.g., test DB), run function, assert resulting state.
+- **Commits:** Follow Conventional Commits v1.0.0. Scopes: `api-types`, `client`, `server`, `mobile`, `storybook`, `ui`, `workspace`.
+
+## 🔧 Strict Configuration Enforcements
+
+- **Import Aliases:** - **Rule:** ALWAYS use the `~` alias (e.g., `~/lib/utils`) for internal imports.
+  - **Constraint:** NEVER use deep relative paths (e.g., `../../../lib`).
+  - **Reference:** See `compilerOptions.paths` in `tsconfig.json` for valid mappings.
+
+- **Package Management:**
+  - **Rule:** EXCLUSIVELY use `pnpm` for all package operations.
+  - **Constraint:** Do not suggest `npm` or `yarn` commands.
+  - **Reference:** Enforced by `pnpm-lock.yaml` and `package.json` engines.
+
+- **Code Formatting:**
+  - **Rule:** All generated code must strictly adhere to Prettier standards.
+  - **Constraint:** Do not rely on default formatting; check specific overrides (e.g., semi, quotes).
+  - **Reference:** Consult `.prettierrc` for the exact configuration before generating large code blocks.
+
+- **Monorepo Structure:**
+  - **Rule:** Respect the Turborepo boundaries. Shared UI goes in `packages/ui`, apps in `apps/*`.
+  - **Reference:** See `turbo.json` and `pnpm-workspace.yaml` for the dependency graph.
+
+## Development Workflow
+
+- **Imports:** Use static imports by default for performance and type safety.
+- **Migrations:** Manage via `pnpm migrate`. Create new: `pnpm migrate new --name <name>`.
+- **Database:** When generating MongoDB queries, format them for direct copy-paste into MongoDB Atlas.
+- **Tooling:** - Use `pnpm clean:modules` to wipe node_modules.
+  - Use `pnpm.overrides` for dependency resolution conflicts.
+  - To inspect MongoDB collections, use the MongoDB MCP tool with db `heroku_wbj38s57`.
+
+## Project Principles
+
+1. Accessibility First
+2. Multilingual by Design
+3. Progressive Migration Strategy
+4. Monorepo Consistency
+5. Government Standards (DSFR) Compliance

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,49 +1,47 @@
-# Workspace Rules
+# Refugies.info Project Rules & Context
 
-## Tech Stack & Standards
-
-- **Framework:** Next.js / React / Turborepo Monorepo.
-- **Styling:** - Use Tailwind CSS utility classes by default.
-  - Use `!` modifier for precedence conflicts before complex logic.
-  - Only use SCSS/CSS for complex animations or global styles not possible with Tailwind.
-  - Avoid fragile CSS selectors (e.g., `ol li[value="2"]`).
-- **Testing:** - Prefer state-based "narrow integration tests" over heavy mocks.
-  - Setup real state (e.g., test DB), run function, assert resulting state.
-- **Commits:** Follow Conventional Commits v1.0.0. Scopes: `api-types`, `client`, `server`, `mobile`, `storybook`, `ui`, `workspace`.
+## 🧠 Project Architecture
+- **Type:** Turborepo Monorepo.
+- **Stack:** Next.js, React, TypeScript, Tailwind CSS, Node.js 22.x (LTS).
+- **Principles:** 1. Accessibility First
+  2. Multilingual by Design
+  3. Progressive Migration Strategy
+  4. Monorepo Consistency
+  5. Government Standards (DSFR) Compliance.
 
 ## 🔧 Strict Configuration Enforcements
+- **Package Manager:** - EXCLUSIVELY use `pnpm`. Never suggest `npm` or `yarn`.
+  - Use `pnpm clean:modules` for deep cleaning.
+  - Use `pnpm.overrides` in package.json for dependency resolutions.
+- **Imports:** - ALWAYS use static imports (performance/types).
+  - ALWAYS use the `~` alias (e.g., `~/lib/utils`) defined in `tsconfig.json`.
+  - NEVER use deep relative paths (e.g., `../../../lib`).
+- **Formatting:** - Strictly follow `.prettierrc` (printWidth 120, no semi, etc.).
+  - Consult the file directly if unsure about specific syntax styles.
 
-- **Import Aliases:** - **Rule:** ALWAYS use the `~` alias (e.g., `~/lib/utils`) for internal imports.
-  - **Constraint:** NEVER use deep relative paths (e.g., `../../../lib`).
-  - **Reference:** See `compilerOptions.paths` in `tsconfig.json` for valid mappings.
+## 🎨 Styling Standards
+- **Tailwind First:** - Use Tailwind CSS utility classes for 95% of styling.
+  - Use the `!` modifier (e.g., `!mt-0`) to resolve precedence issues before adding complex logic.
+- **SCSS/CSS Constraints:**
+  - Only use SCSS for complex animations or global styles that Tailwind cannot handle.
+  - **Spacing:** The `u()` SCSS function converts units to pixels: `u(1)=4px`, `u(4)=16px`.
+  - **Selectors:** Avoid fragile selectors like `ol li[value="2"]`. Use generic classes.
 
-- **Package Management:**
-  - **Rule:** EXCLUSIVELY use `pnpm` for all package operations.
-  - **Constraint:** Do not suggest `npm` or `yarn` commands.
-  - **Reference:** Enforced by `pnpm-lock.yaml` and `package.json` engines.
+## 🧪 Testing & Quality
+- **Strategy:** Prefer state-based "narrow integration tests" over heavy mocking.
+  - *Pattern:* Setup real state (e.g., test DB) -> Run function -> Assert resulting state.
+- **Reference:** See `dispositif.service.additional.tests.ts` for the canonical example.
 
-- **Code Formatting:**
-  - **Rule:** All generated code must strictly adhere to Prettier standards.
-  - **Constraint:** Do not rely on default formatting; check specific overrides (e.g., semi, quotes).
-  - **Reference:** Consult `.prettierrc` for the exact configuration before generating large code blocks.
+## 🛠️ Tooling & Scripts
+- **Feature Creation:** - Script: `.specify/scripts/bash/create-new-feature.sh`
+  - Usage: `... --json --short-name <short-name> "<description>"`
+  - Format: `short-name` must be 2–4 hyphen-separated words.
+- **Database (MongoDB):**
+  - Queries generated must be formatted for direct copy-paste into MongoDB Atlas web console.
+  - Tooling: Use MongoDB MCP tool with database `heroku_wbj38s57` to inspect collections.
+- **Migrations:** - Create via: `pnpm migrate new --name <migration_name>` (saves to `/migrations`).
 
-- **Monorepo Structure:**
-  - **Rule:** Respect the Turborepo boundaries. Shared UI goes in `packages/ui`, apps in `apps/*`.
-  - **Reference:** See `turbo.json` and `pnpm-workspace.yaml` for the dependency graph.
-
-## Development Workflow
-
-- **Imports:** Use static imports by default for performance and type safety.
-- **Migrations:** Manage via `pnpm migrate`. Create new: `pnpm migrate new --name <name>`.
-- **Database:** When generating MongoDB queries, format them for direct copy-paste into MongoDB Atlas.
-- **Tooling:** - Use `pnpm clean:modules` to wipe node_modules.
-  - Use `pnpm.overrides` for dependency resolution conflicts.
-  - To inspect MongoDB collections, use the MongoDB MCP tool with db `heroku_wbj38s57`.
-
-## Project Principles
-
-1. Accessibility First
-2. Multilingual by Design
-3. Progressive Migration Strategy
-4. Monorepo Consistency
-5. Government Standards (DSFR) Compliance
+## 📦 Git & Commits
+- **Convention:** Conventional Commits v1.0.0.
+- **Allowed Scopes:** `api-types`, `client`, `server`, `mobile`, `storybook`, `ui`, `workspace`.
+- **Types:** `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -46,4 +46,4 @@
 
 - **Convention:** Conventional Commits v1.0.0.
 - **Allowed Scopes:** `api-types`, `client`, `server`, `mobile`, `storybook`, `ui`, `workspace`.
-- **Types:** `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
+- **Types:** `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`, ...


### PR DESCRIPTION
## Summary
- capture the project architecture, configuration, styling, tooling, and git/commit rules in `.windsurfrules`
- surface the pnpm-only workflow, import conventions, DSFR/Tailwind styling notes, and MongoDB tooling reminders

## Testing
- Not run (docs-only change)
