### PR TITLE
chore: add Gemini Code Review config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,17 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+have_fun: true
+memory_config:
+  disabled: false
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true
+ignore_patterns:
+  - ".specify/**"
+  - ".windsurf/**"
+  - ".gemini/**"


### PR DESCRIPTION
## Summary
- add `.gemini/config.yaml` to configure Gemini Code Assist
- ignore `.specify`, `.windsurf`, and `.gemini` directories during reviews
- keep default review behaviour while enabling fun mode

## Testing
- not applicable