### PR TITLE
feat(client): improve mobile app section accessibility

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -1,4 +1,10 @@
 {
+  "404": {
+    "title": "Erreur 404",
+    "text1": "Oups, un problème est survenu.",
+    "text2": "Le lien est peut-être incorrect ou la page a été déplacée.",
+    "cta": "Retour à la page d’accueil"
+  },
   "Header": {
     "serviceName": "Réfugiés.info",
     "serviceTagline": "L'information pour les réfugiés en France",
@@ -633,7 +639,11 @@
     "AnnotationsLangsimple": "Langage clair",
     "AnnotationsEasyfrench": "Français facile",
     "AnnotationsVocalize": "Vocalisation des contenus",
-    "AnnotationsListen": "Écoute"
+    "AnnotationsListen": "Écoute",
+    "appStoreBadge": "Télécharger sur l'app store apple",
+    "playStoreBadge": "Télécharger sur Google Play",
+    "description": "Téléchargez l'application mobile pour accéder à toutes les fonctionnalités de partage, de changement de langue, de langage clair et de vocalisation centralisées dans une seule application.",
+    "sectionLabel": "Section application mobile"
   },
   "WorkTogether": {
     "title": "Travaillons ensemble ! Vous êtes... ? ",
@@ -794,12 +804,6 @@
     "navbarItem7": "Les moments clés",
     "navbarItem8": "Voir les statistiques",
     "join_title": "Travaillons ensemble ! Vous êtes... ? "
-  },
-  "404": {
-    "title": "Erreur 404",
-    "text1": "Oups, un problème est survenu.",
-    "text2": "Le lien est peut-être incorrect ou la page a été déplacée.",
-    "cta": "Retour à la page d’accueil"
   },
   "sitemap": {
     "title": "Plan du site",

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -1,5 +1,5 @@
 import Button from "@codegouvfr/react-dsfr/Button";
-import { AnnotationsOverlay } from "@refugies-info/ui";
+import { AnnotationsOverlay, useWindowSize } from "@refugies-info/ui";
 import { androidStoreLink, iosStoreLink } from "data/storeLinks";
 import { useTranslation } from "next-i18next";
 import { useMemo } from "react";
@@ -8,7 +8,6 @@ import { assetsOnServer } from "~/assets/assetsOnServer";
 import application from "~/assets/homepage/application.png";
 import Image from "~/components/UI/Image";
 import { useLocale } from "~/hooks";
-import { useWindowSize } from "@refugies-info/ui";
 import { cn } from "~/lib/classname";
 import MobileAppSmsForm from "./MobileAppSmsForm";
 
@@ -23,16 +22,23 @@ const MobileApp = () => {
 
   const storeLinks = useMemo(
     () => (
-      <p className="mb-0 flex w-full max-w-lg justify-center gap-4 xl:justify-start xl:pl-4">
-        <a href={iosStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-30">
-          <Image src={appStoreBadge} alt="Get it on App Store" fill />
-        </a>
-        <a href={androidStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-32">
-          <Image src={playStoreBadge} width={128} height={40} alt="Get it on Play Store" />
-        </a>
-      </p>
+      <>
+        <p className="mb-0 flex w-full max-w-lg justify-center gap-4 xl:justify-start xl:pl-4">
+          <a href={iosStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-30">
+            <Image src={appStoreBadge} alt={t("MobileApp.appStoreBadge", "Télécharger sur l'app store apple")} fill />
+          </a>
+          <a href={androidStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-32">
+            <Image
+              src={playStoreBadge}
+              width={128}
+              height={40}
+              alt={t("MobileApp.playStoreBadge", "Télécharger sur Google Play")}
+            />
+          </a>
+        </p>
+      </>
     ),
-    [appStoreBadge, playStoreBadge],
+    [appStoreBadge, playStoreBadge, t],
   );
 
   const handleOpenStoreLink = (storelink: string) => {
@@ -43,6 +49,8 @@ const MobileApp = () => {
     <section
       id="application"
       className="container flex flex-col gap-10 py-10 md:grid md:grid-cols-2 lg:py-20 2xl:gap-20"
+      role="region"
+      aria-label={t("MobileApp.sectionLabel", "Section application mobile")}
     >
       <div className="flex h-full flex-col items-center justify-center gap-10">
         <AnnotationsOverlay
@@ -69,6 +77,13 @@ const MobileApp = () => {
         >
           <Image src={application} fill className="object-contain" alt="" />
         </AnnotationsOverlay>
+        <p className="sr-only">
+          {t(
+            "MobileApp.description",
+            "Téléchargez l'application mobile pour accéder à toutes les fonctionnalités de partage, de changement de langue, de langage clair et de vocalisation centralisées dans une seule application.",
+          )}
+        </p>
+
         {storeLinks}
       </div>
       <div className="">

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -22,21 +22,19 @@ const MobileApp = () => {
 
   const storeLinks = useMemo(
     () => (
-      <>
-        <p className="mb-0 flex w-full max-w-lg justify-center gap-4 xl:justify-start xl:pl-4">
-          <a href={iosStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-30">
-            <Image src={appStoreBadge} alt={t("MobileApp.appStoreBadge", "Télécharger sur l'app store apple")} fill />
-          </a>
-          <a href={androidStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-32">
-            <Image
-              src={playStoreBadge}
-              width={128}
-              height={40}
-              alt={t("MobileApp.playStoreBadge", "Télécharger sur Google Play")}
-            />
-          </a>
-        </p>
-      </>
+      <p className="mb-0 flex w-full max-w-lg justify-center gap-4 xl:justify-start xl:pl-4">
+        <a href={iosStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-30">
+          <Image src={appStoreBadge} alt={t("MobileApp.appStoreBadge", "Télécharger sur l'app store apple")} fill />
+        </a>
+        <a href={androidStoreLink} rel="noopener noreferrer" target="_blank" className="relative h-10 w-32">
+          <Image
+            src={playStoreBadge}
+            width={128}
+            height={40}
+            alt={t("MobileApp.playStoreBadge", "Télécharger sur Google Play")}
+          />
+        </a>
+      </p>
     ),
     [appStoreBadge, playStoreBadge, t],
   );

--- a/packages/ui/src/components/composites/annotations-overlay/AnnotationsOverlay.tsx
+++ b/packages/ui/src/components/composites/annotations-overlay/AnnotationsOverlay.tsx
@@ -16,7 +16,7 @@ export const AnnotationsOverlay = ({ children, className, annotations }: Annotat
   const uid = useId();
 
   return (
-    <figure className={cn("relative", className)}>
+    <figure className={cn("relative", className)} aria-hidden="true">
       {React.cloneElement(children, { "aria-describedby": `${uid}-annotations` } as React.HTMLAttributes<HTMLElement>)}
       <figcaption id={`${uid}-annotations`}>
         {annotations.map(({ text, className }) => (


### PR DESCRIPTION
feat(client): improve mobile app section accessibility

- Add ARIA region role and label to mobile app section
- Add screen reader description for mobile app features
- Add alt text for App Store and Play Store badges
- Mark decorative annotations overlay as aria-hidden
- Move 404 translations to top of common.json for better organization
- Add missing translation keys for mobile app badges and description

Fixes RI-958
Fixes RI-957