### PR TITLE
Adapt MO/BO for RCO Origin

### DIFF
--- a/apps/client/src/__fixtures__/getDispositifs.ts
+++ b/apps/client/src/__fixtures__/getDispositifs.ts
@@ -1,4 +1,4 @@
-import { ContentType, DispositifStatus, SimpleDispositif } from "@refugies-info/api-types";
+import { ContentType, DispositifOrigin, DispositifStatus, SimpleDispositif } from "@refugies-info/api-types";
 
 export const lastDemarches: SimpleDispositif[] = [
   {
@@ -35,7 +35,7 @@ export const lastDemarches: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "63972dcb98b670cc4bae76e6",
@@ -70,7 +70,7 @@ export const lastDemarches: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "5e1c8c0e0742580052a33972",
@@ -100,7 +100,7 @@ export const lastDemarches: SimpleDispositif[] = [
     theme: "63286a015d31b2c0cad9960b",
     titreMarque: "",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "637781c6896812af208f3495",
@@ -130,7 +130,7 @@ export const lastDemarches: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "6123a82c6bf6bc00148a5176",
@@ -161,7 +161,7 @@ export const lastDemarches: SimpleDispositif[] = [
     theme: "63286a015d31b2c0cad9960c",
     titreMarque: "",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "5dd7c4b06f0ac0004c87c88d",
@@ -191,7 +191,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: [],
     theme: "63286a015d31b2c0cad9960b",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "63528e00976acb4f7bcd37ad",
@@ -222,7 +222,7 @@ export const lastDemarches: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "63401d8783f485a025e88388",
@@ -253,7 +253,7 @@ export const lastDemarches: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "630337ddf2087e2b25ac7609",
@@ -284,7 +284,7 @@ export const lastDemarches: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "62f265d81119eede87fb1ae2",
@@ -319,7 +319,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: ["63286a015d31b2c0cad9960b", "63450dd43e23cd7181ba0b26"],
     theme: "63286a015d31b2c0cad9960c",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "62b9809b796009107a932cbc",
@@ -349,7 +349,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: [],
     theme: "63286a015d31b2c0cad9960d",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "62bab2e7b47f6b02fa9783f2",
@@ -379,7 +379,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: ["63286a015d31b2c0cad9960b"],
     theme: "63286a015d31b2c0cad9960c",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "62b5cc16092a73346b4a9a11",
@@ -410,7 +410,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: [],
     theme: "63286a015d31b2c0cad9960d",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "62a897aceece9a373f34ee49",
@@ -441,7 +441,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: [],
     theme: "63286a015d31b2c0cad9960d",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "62a8ae34eece9a373f350351",
@@ -471,7 +471,7 @@ export const lastDemarches: SimpleDispositif[] = [
     secondaryThemes: [],
     theme: "63286a015d31b2c0cad9960d",
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
 ];
 
@@ -504,7 +504,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "638dcbbaf0b1a31177cf9602",
@@ -539,7 +539,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "638613c54730d143903ca9ca",
@@ -575,7 +575,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "63873a586fd089c3dad298f2",
@@ -605,7 +605,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "635a71c8d43c4d1a3f25227f",
@@ -641,7 +641,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "6376470705f74970c5342371",
@@ -671,7 +671,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "634d28bd9d3bda3be5cfd979",
@@ -701,7 +701,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "6332c0e6a36f411314ba4ca3",
@@ -731,7 +731,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "636cd4572c725bfbf72d6302",
@@ -769,7 +769,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "63231e68d585c0849a9bb2b1",
@@ -799,7 +799,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "634e7269313f6183f3510709",
@@ -835,7 +835,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "634fba2814dbd7acb5c4f759",
@@ -865,7 +865,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "6317495572a7091286cfbd68",
@@ -902,7 +902,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "6336f551bf68aaed7fe0f8b4",
@@ -932,7 +932,7 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
   {
     _id: "63623b16a2a5bf7006723347",
@@ -968,6 +968,6 @@ export const lastDispositifs: SimpleDispositif[] = [
     availableLanguages: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: "RI",
+    origin: DispositifOrigin.RI,
   },
 ];

--- a/apps/client/src/components/Backend/screens/UserContributions/__tests__/functions.test.ts
+++ b/apps/client/src/components/Backend/screens/UserContributions/__tests__/functions.test.ts
@@ -1,5 +1,6 @@
 import {
   ContentType,
+  DispositifOrigin,
   DispositifStatus,
   GetStructureDispositifResponse,
   GetUserContributionsResponse,
@@ -17,6 +18,7 @@ const userContrib1: GetUserContributionsResponse = {
   nbVues: 0,
   status: DispositifStatus.DRAFT,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const formattedUserContrib1: FormattedUserContribution = {
@@ -31,6 +33,7 @@ const formattedUserContrib1: FormattedUserContribution = {
   responsabilite: "Moi",
   isAuthorizedToDelete: true,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userContrib2: GetUserContributionsResponse = {
@@ -43,6 +46,7 @@ const userContrib2: GetUserContributionsResponse = {
   nbVues: 0,
   status: DispositifStatus.ACTIVE,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 const formattedUserContrib2: FormattedUserContribution = {
   _id: "id2",
@@ -56,6 +60,7 @@ const formattedUserContrib2: FormattedUserContribution = {
   isAuthorizedToDelete: true,
   titreMarque: "marque",
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userContrib3: GetUserContributionsResponse = {
@@ -68,6 +73,7 @@ const userContrib3: GetUserContributionsResponse = {
   nbVues: 0,
   status: DispositifStatus.WAITING_ADMIN,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 const formattedUserContrib3: FormattedUserContribution = {
   _id: "id3",
@@ -81,6 +87,7 @@ const formattedUserContrib3: FormattedUserContribution = {
   responsabilite: "structure",
   isAuthorizedToDelete: true,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userContrib4: GetUserContributionsResponse = {
@@ -93,6 +100,7 @@ const userContrib4: GetUserContributionsResponse = {
   nbVues: 0,
   status: DispositifStatus.KO_STRUCTURE,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 const formattedUserContrib4: FormattedUserContribution = {
   _id: "id4",
@@ -106,6 +114,7 @@ const formattedUserContrib4: FormattedUserContribution = {
   responsabilite: "Moi",
   isAuthorizedToDelete: true,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userContrib5: GetUserContributionsResponse = {
@@ -118,6 +127,7 @@ const userContrib5: GetUserContributionsResponse = {
   nbVues: 0,
   status: DispositifStatus.WAITING_STRUCTURE,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 const formattedUserContrib5: FormattedUserContribution = {
   _id: "id5",
@@ -131,6 +141,7 @@ const formattedUserContrib5: FormattedUserContribution = {
   responsabilite: "Moi",
   isAuthorizedToDelete: true,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userContrib6: GetUserContributionsResponse = {
@@ -143,6 +154,7 @@ const userContrib6: GetUserContributionsResponse = {
   nbVues: 0,
   status: DispositifStatus.ACTIVE,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 const formattedUserContrib6: FormattedUserContribution = {
   _id: "id6",
@@ -156,6 +168,7 @@ const formattedUserContrib6: FormattedUserContribution = {
   responsabilite: "structure",
   isAuthorizedToDelete: false,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userContribs = [userContrib1, userContrib2, userContrib3, userContrib4, userContrib5, userContrib6];
@@ -179,7 +192,7 @@ const userStructureContrib1: GetStructureDispositifResponse = {
   availableLanguages: [],
   hasDraftVersion: false,
   themeSortIndex: 0,
-  origin: "RI",
+  origin: DispositifOrigin.RI,
 };
 
 const formattedUserStructureContrib1: FormattedUserContribution = {
@@ -194,6 +207,7 @@ const formattedUserStructureContrib1: FormattedUserContribution = {
   responsabilite: "structure",
   isAuthorizedToDelete: true,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userStructureContrib2: GetStructureDispositifResponse = {
@@ -212,7 +226,7 @@ const userStructureContrib2: GetStructureDispositifResponse = {
   availableLanguages: [],
   hasDraftVersion: false,
   themeSortIndex: 0,
-  origin: "RI",
+  origin: DispositifOrigin.RI,
 };
 
 const userStructureContrib3: GetStructureDispositifResponse = {
@@ -231,7 +245,7 @@ const userStructureContrib3: GetStructureDispositifResponse = {
   availableLanguages: [],
   hasDraftVersion: false,
   themeSortIndex: 0,
-  origin: "RI",
+  origin: DispositifOrigin.RI,
 };
 
 const userStructureContrib4: GetStructureDispositifResponse = {
@@ -250,7 +264,7 @@ const userStructureContrib4: GetStructureDispositifResponse = {
   availableLanguages: [],
   hasDraftVersion: false,
   themeSortIndex: 0,
-  origin: "RI",
+  origin: DispositifOrigin.RI,
 };
 
 const formattedUserStructureContrib4: FormattedUserContribution = {
@@ -265,6 +279,7 @@ const formattedUserStructureContrib4: FormattedUserContribution = {
   responsabilite: "structure",
   isAuthorizedToDelete: true,
   hasDraftVersion: false,
+  origin: DispositifOrigin.RI,
 };
 
 const userStructureContrib5: GetStructureDispositifResponse = {
@@ -283,7 +298,7 @@ const userStructureContrib5: GetStructureDispositifResponse = {
   availableLanguages: [],
   hasDraftVersion: false,
   themeSortIndex: 0,
-  origin: "RI",
+  origin: DispositifOrigin.RI,
 };
 
 const userStructureContrib = [

--- a/apps/client/src/components/Backend/screens/UserContributions/functions.ts
+++ b/apps/client/src/components/Backend/screens/UserContributions/functions.ts
@@ -106,6 +106,7 @@ export const formatContributions = (
             nom: userStructure.nom || "",
           },
           hasDraftVersion: dispositif.hasDraftVersion,
+          origin: dispositif.origin,
         });
       });
   }

--- a/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/functions.ts
+++ b/apps/client/src/components/Pages/dispositif/Edition/Modals/ModalAbstract/functions.ts
@@ -1,4 +1,10 @@
-import { ContentType, CreateDispositifRequest, DispositifStatus, SimpleDispositif } from "@refugies-info/api-types";
+import {
+  ContentType,
+  CreateDispositifRequest,
+  DispositifOrigin,
+  DispositifStatus,
+  SimpleDispositif,
+} from "@refugies-info/api-types";
 import { DeepPartialSkipArrayKey } from "react-hook-form";
 
 export const getDefaultDispositif = (
@@ -37,6 +43,6 @@ export const getDefaultDispositif = (
     needs: [],
     hasDraftVersion: false,
     themeSortIndex: 0,
-    origin: formValues?.origin || "RI",
+    origin: formValues?.origin || DispositifOrigin.RI,
   };
 };

--- a/apps/client/src/services/AllDispositifs/__tests__/allDispositifs.saga.test.ts
+++ b/apps/client/src/services/AllDispositifs/__tests__/allDispositifs.saga.test.ts
@@ -19,8 +19,26 @@ describe("[Saga] All dispositifs", () => {
         .put(startLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
         .next()
         .call(API.getAllDispositifs)
-        .next([{ id: "id" }])
-        .put(setAllDispositifsActionsCreator([{ id: "id" }]))
+        .next([{ id: "id", origin: "RI" }])
+        .put(setAllDispositifsActionsCreator([{ id: "id", origin: "RI" }]))
+        .next()
+        .put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
+        .next()
+        .isDone();
+    });
+
+    it("should filter out RCO dispositifs", () => {
+      const mockData = [
+        { id: "id1", origin: "RI" },
+        { id: "id2", origin: "RCO" },
+      ];
+      testSaga(fetchAllDispositifs)
+        .next()
+        .put(startLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
+        .next()
+        .call(API.getAllDispositifs)
+        .next(mockData)
+        .put(setAllDispositifsActionsCreator([{ id: "id1", origin: "RI" }]))
         .next()
         .put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
         .next()

--- a/apps/client/src/services/AllDispositifs/__tests__/allDispositifs.saga.test.ts
+++ b/apps/client/src/services/AllDispositifs/__tests__/allDispositifs.saga.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { DispositifOrigin } from "@refugies-info/api-types";
 import { testSaga } from "redux-saga-test-plan";
 import API from "../../../utils/API";
 import { LoadingStatusKey, finishLoading, startLoading } from "../../LoadingStatus/loadingStatus.actions";
@@ -19,8 +20,8 @@ describe("[Saga] All dispositifs", () => {
         .put(startLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
         .next()
         .call(API.getAllDispositifs)
-        .next([{ id: "id", origin: "RI" }])
-        .put(setAllDispositifsActionsCreator([{ id: "id", origin: "RI" }]))
+        .next([{ id: "id", origin: DispositifOrigin.RI }])
+        .put(setAllDispositifsActionsCreator([{ id: "id", origin: DispositifOrigin.RI }]))
         .next()
         .put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
         .next()
@@ -29,8 +30,8 @@ describe("[Saga] All dispositifs", () => {
 
     it("should filter out RCO dispositifs", () => {
       const mockData = [
-        { id: "id1", origin: "RI" },
-        { id: "id2", origin: "RCO" },
+        { id: "id1", origin: DispositifOrigin.RI },
+        { id: "id2", origin: DispositifOrigin.RCO },
       ];
       testSaga(fetchAllDispositifs)
         .next()
@@ -38,7 +39,7 @@ describe("[Saga] All dispositifs", () => {
         .next()
         .call(API.getAllDispositifs)
         .next(mockData)
-        .put(setAllDispositifsActionsCreator([{ id: "id1", origin: "RI" }]))
+        .put(setAllDispositifsActionsCreator([{ id: "id1", origin: DispositifOrigin.RI }]))
         .next()
         .put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS))
         .next()

--- a/apps/client/src/services/AllDispositifs/allDispositifs.saga.ts
+++ b/apps/client/src/services/AllDispositifs/allDispositifs.saga.ts
@@ -12,7 +12,8 @@ export function* fetchAllDispositifs(): SagaIterator {
     logger.info("[fetchAllDispositifs saga]");
     yield put(startLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS));
     const data: GetAllDispositifsResponse[] = yield call(API.getAllDispositifs);
-    yield put(setAllDispositifsActionsCreator(data));
+    const filteredData = data.filter((d) => d.origin === "RI");
+    yield put(setAllDispositifsActionsCreator(filteredData));
     yield put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS));
   } catch (error) {
     logger.error("[fetchAllDispositifs saga] Error while fetching dispositifs", { error });

--- a/apps/client/src/services/AllDispositifs/allDispositifs.saga.ts
+++ b/apps/client/src/services/AllDispositifs/allDispositifs.saga.ts
@@ -1,29 +1,26 @@
-import { GetAllDispositifsResponse } from "@refugies-info/api-types";
+import { DispositifOrigin, GetAllDispositifsResponse } from "@refugies-info/api-types";
 import { SagaIterator } from "redux-saga";
 import { call, put, takeLatest } from "redux-saga/effects";
-import { logger } from "../../logger";
-import API from "../../utils/API";
+import { logger } from "~/logger";
+import API from "~/utils/API";
 import { LoadingStatusKey, finishLoading, startLoading } from "../LoadingStatus/loadingStatus.actions";
-import { FETCH_ALL_DISPOSITIFS } from "./allDispositifs.actionTypes";
 import { setAllDispositifsActionsCreator } from "./allDispositifs.actions";
 
 export function* fetchAllDispositifs(): SagaIterator {
   try {
-    logger.info("[fetchAllDispositifs saga]");
+    logger.info("[fetchAllDispositifs] saga");
     yield put(startLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS));
     const data: GetAllDispositifsResponse[] = yield call(API.getAllDispositifs);
-    const filteredData = data.filter((d) => d.origin === "RI");
+    const filteredData = data.filter((d) => d.origin === DispositifOrigin.RI);
     yield put(setAllDispositifsActionsCreator(filteredData));
     yield put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS));
-  } catch (error) {
-    logger.error("[fetchAllDispositifs saga] Error while fetching dispositifs", { error });
+  } catch (e) {
+    logger.error("[fetchAllDispositifs] saga", e);
     yield put(setAllDispositifsActionsCreator([]));
     yield put(finishLoading(LoadingStatusKey.FETCH_ALL_DISPOSITIFS));
   }
 }
 
-function* latestActionsSaga() {
-  yield takeLatest(FETCH_ALL_DISPOSITIFS, fetchAllDispositifs);
+export default function* allDispositifsSaga(): SagaIterator {
+  yield takeLatest("FETCH_ALL_DISPOSITIFS", fetchAllDispositifs);
 }
-
-export default latestActionsSaga;

--- a/apps/client/src/services/UserContributions/__tests__/userContributions.saga.test.ts
+++ b/apps/client/src/services/UserContributions/__tests__/userContributions.saga.test.ts
@@ -26,8 +26,26 @@ describe("[Saga] UserContributions", () => {
         .put(startLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
         .next()
         .call(API.getUserContributions)
-        .next([{ _id: "id" }])
-        .put(setUserContributionsActionCreator([{ _id: "id" }]))
+        .next([{ _id: "id", origin: "RI" }])
+        .put(setUserContributionsActionCreator([{ _id: "id", origin: "RI" }]))
+        .next()
+        .put(finishLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
+        .next()
+        .isDone();
+    });
+
+    it("should filter out RCO contributions", () => {
+      const mockData = [
+        { _id: "id1", origin: "RI" },
+        { _id: "id2", origin: "RCO" },
+      ];
+      testSaga(fetchUserContributions)
+        .next()
+        .put(startLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
+        .next()
+        .call(API.getUserContributions)
+        .next(mockData)
+        .put(setUserContributionsActionCreator([{ _id: "id1", origin: "RI" }]))
         .next()
         .put(finishLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
         .next()

--- a/apps/client/src/services/UserContributions/__tests__/userContributions.saga.test.ts
+++ b/apps/client/src/services/UserContributions/__tests__/userContributions.saga.test.ts
@@ -1,4 +1,5 @@
 //@ts-nocheck
+import { DispositifOrigin } from "@refugies-info/api-types";
 import { testSaga } from "redux-saga-test-plan";
 import API from "../../../utils/API";
 import { LoadingStatusKey, finishLoading, startLoading } from "../../LoadingStatus/loadingStatus.actions";
@@ -26,8 +27,8 @@ describe("[Saga] UserContributions", () => {
         .put(startLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
         .next()
         .call(API.getUserContributions)
-        .next([{ _id: "id", origin: "RI" }])
-        .put(setUserContributionsActionCreator([{ _id: "id", origin: "RI" }]))
+        .next([{ _id: "id", origin: DispositifOrigin.RI }])
+        .put(setUserContributionsActionCreator([{ _id: "id", origin: DispositifOrigin.RI }]))
         .next()
         .put(finishLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
         .next()
@@ -36,8 +37,8 @@ describe("[Saga] UserContributions", () => {
 
     it("should filter out RCO contributions", () => {
       const mockData = [
-        { _id: "id1", origin: "RI" },
-        { _id: "id2", origin: "RCO" },
+        { _id: "id1", origin: DispositifOrigin.RI },
+        { _id: "id2", origin: DispositifOrigin.RCO },
       ];
       testSaga(fetchUserContributions)
         .next()
@@ -45,7 +46,7 @@ describe("[Saga] UserContributions", () => {
         .next()
         .call(API.getUserContributions)
         .next(mockData)
-        .put(setUserContributionsActionCreator([{ _id: "id1", origin: "RI" }]))
+        .put(setUserContributionsActionCreator([{ _id: "id1", origin: DispositifOrigin.RI }]))
         .next()
         .put(finishLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS))
         .next()

--- a/apps/client/src/services/UserContributions/userContributions.saga.ts
+++ b/apps/client/src/services/UserContributions/userContributions.saga.ts
@@ -16,7 +16,8 @@ export function* fetchUserContributions(): SagaIterator {
     logger.info("[fetchUserContributions] saga");
     yield put(startLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS));
     const data: GetUserContributionsResponse[] = yield call(API.getUserContributions);
-    yield put(setUserContributionsActionCreator(data));
+    const filteredData = data.filter((d) => ((d as any).dispositif || d).origin === "RI");
+    yield put(setUserContributionsActionCreator(filteredData));
     yield put(finishLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS));
   } catch (error) {
     logger.error("[fetchUserContributions] saga error", { error });

--- a/apps/client/src/services/UserContributions/userContributions.saga.ts
+++ b/apps/client/src/services/UserContributions/userContributions.saga.ts
@@ -1,8 +1,8 @@
-import { GetUserContributionsResponse } from "@refugies-info/api-types";
+import { DispositifOrigin, GetUserContributionsResponse } from "@refugies-info/api-types";
 import { SagaIterator } from "redux-saga";
 import { call, put, takeLatest } from "redux-saga/effects";
-import { logger } from "../../logger";
-import API from "../../utils/API";
+import { logger } from "~/logger";
+import API from "~/utils/API";
 import { LoadingStatusKey, finishLoading, startLoading } from "../LoadingStatus/loadingStatus.actions";
 import { DELETE_DISPOSITIF, FETCH_USER_CONTRIBUTIONS } from "./userContributions.actionTypes";
 import {
@@ -16,7 +16,7 @@ export function* fetchUserContributions(): SagaIterator {
     logger.info("[fetchUserContributions] saga");
     yield put(startLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS));
     const data: GetUserContributionsResponse[] = yield call(API.getUserContributions);
-    const filteredData = data.filter((d) => ((d as any).dispositif || d).origin === "RI");
+    const filteredData = data.filter((d) => d.origin === DispositifOrigin.RI);
     yield put(setUserContributionsActionCreator(filteredData));
     yield put(finishLoading(LoadingStatusKey.FETCH_USER_CONTRIBUTIONS));
   } catch (error) {

--- a/apps/client/src/services/UserStructure/__tests__/userStructure.saga.test.ts
+++ b/apps/client/src/services/UserStructure/__tests__/userStructure.saga.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import { DispositifOrigin } from "@refugies-info/api-types";
 import mockRouter from "next-router-mock";
 import { testSaga } from "redux-saga-test-plan";
 import API from "../../../utils/API";
@@ -129,6 +130,36 @@ describe("[Saga] Structures", () => {
         .next()
         .select(userSelector)
         .next({ userId: "id" })
+        .put(finishLoading(LoadingStatusKey.FETCH_USER_STRUCTURE))
+        .next()
+        .isDone();
+    });
+    it("should filter out RCO dispositifsAssocies", () => {
+      const mockData = {
+        membres: [],
+        dispositifsAssocies: [
+          { _id: "id1", origin: DispositifOrigin.RI },
+          { _id: "id2", origin: DispositifOrigin.RCO },
+        ],
+      };
+      testSaga(fetchUserStructure, {
+        type: FETCH_USER_STRUCTURE,
+        payload: { structureId: "id", shouldRedirect: false },
+      })
+        .next()
+        .put(startLoading(LoadingStatusKey.FETCH_USER_STRUCTURE))
+        .next()
+        .call(API.getStructureById, "id", "fr")
+        .next(mockData)
+        .put(
+          setUserStructureActionCreator({
+            membres: [],
+            dispositifsAssocies: [{ _id: "id1", origin: DispositifOrigin.RI }],
+          }),
+        )
+        .next()
+        .select(userSelector)
+        .next({ userId: "userId" })
         .put(finishLoading(LoadingStatusKey.FETCH_USER_STRUCTURE))
         .next()
         .isDone();

--- a/apps/client/src/services/UserStructure/userStructure.saga.ts
+++ b/apps/client/src/services/UserStructure/userStructure.saga.ts
@@ -23,6 +23,9 @@ export function* fetchUserStructure(action: ReturnType<typeof fetchUserStructure
     const { structureId, shouldRedirect } = action.payload;
     if (!structureId) return;
     const data: GetStructureResponse = yield call(API.getStructureById, structureId.toString(), "fr");
+    if (data && data.dispositifsAssocies) {
+      data.dispositifsAssocies = data.dispositifsAssocies.filter((d) => (d as any).origin === "RI");
+    }
     yield put(setUserStructureActionCreator(data));
     const user: UserState = yield select(userSelector);
     const userId = user.userId;

--- a/apps/client/src/services/UserStructure/userStructure.saga.ts
+++ b/apps/client/src/services/UserStructure/userStructure.saga.ts
@@ -1,4 +1,9 @@
-import { GetStructureResponse, PatchStructureRequest, PatchStructureRolesRequest } from "@refugies-info/api-types";
+import {
+  DispositifOrigin,
+  GetStructureResponse,
+  PatchStructureRequest,
+  PatchStructureRolesRequest,
+} from "@refugies-info/api-types";
 import pick from "lodash/pick";
 import Router from "next/router";
 import { SagaIterator } from "redux-saga";
@@ -24,7 +29,7 @@ export function* fetchUserStructure(action: ReturnType<typeof fetchUserStructure
     if (!structureId) return;
     const data: GetStructureResponse = yield call(API.getStructureById, structureId.toString(), "fr");
     if (data && data.dispositifsAssocies) {
-      data.dispositifsAssocies = data.dispositifsAssocies.filter((d) => (d as any).origin === "RI");
+      data.dispositifsAssocies = data.dispositifsAssocies.filter((d) => d.origin === DispositifOrigin.RI);
     }
     yield put(setUserStructureActionCreator(data));
     const user: UserState = yield select(userSelector);

--- a/apps/server/src/modules/dispositif/__tests__/dispositif.origin.test.ts
+++ b/apps/server/src/modules/dispositif/__tests__/dispositif.origin.test.ts
@@ -1,4 +1,4 @@
-import { ContentType, DispositifStatus, RoleName } from "@refugies-info/api-types";
+import { ContentType, DispositifOrigin, DispositifStatus, RoleName } from "@refugies-info/api-types";
 import { fixtures } from "~/__fixtures__";
 import { getDispositifById } from "~/modules/dispositif/dispositif.repository";
 import { DispositifModel, RoleModel, UserModel } from "~/typegoose";
@@ -35,12 +35,12 @@ describe("Dispositif Origin", () => {
       {
         typeContenu: ContentType.DISPOSITIF,
         titreInformatif: "Test Dispositif RCO",
-        origin: "RCO",
+        origin: DispositifOrigin.RCO,
       },
       user._id,
     );
 
-    expect(result.data.origin).toBe("RCO");
+    expect(result.data.origin).toBe(DispositifOrigin.RCO);
 
     const dispositif = await DispositifModel.findById(result.data.id);
     expect(dispositif?.origin).toBe("RCO");
@@ -73,7 +73,7 @@ describe("Dispositif Origin", () => {
       {
         typeContenu: ContentType.DISPOSITIF,
         titreInformatif: "Test Dispositif",
-        origin: "RI",
+        origin: DispositifOrigin.RI,
       },
       user._id,
     );
@@ -81,13 +81,13 @@ describe("Dispositif Origin", () => {
     await updateDispositif(
       createResult.data.id.toString(),
       {
-        origin: "RCO",
+        origin: DispositifOrigin.RCO,
       },
       user,
     );
 
     const dispositif = await DispositifModel.findById(createResult.data.id);
-    expect(dispositif?.origin).toBe("RI");
+    expect(dispositif?.origin).toBe(DispositifOrigin.RI);
   });
 
   it("should default missing origin to RI in API responses", async () => {
@@ -108,6 +108,6 @@ describe("Dispositif Origin", () => {
     const foundDispositif = await getDispositifById(dispositif._id.toString());
 
     // The origin should default to "RI" in the serialization
-    expect(foundDispositif?.origin).toBe("RI");
+    expect(foundDispositif?.origin).toBe(DispositifOrigin.RI);
   });
 });

--- a/apps/server/src/typegoose/Dispositif.ts
+++ b/apps/server/src/typegoose/Dispositif.ts
@@ -217,6 +217,7 @@ export class Dispositif extends Base {
 
   @prop({
     enum: DispositifOrigin,
+    type: String,
     default: "RI",
     required: true,
     immutable: true,

--- a/apps/server/src/typegoose/Dispositif.ts
+++ b/apps/server/src/typegoose/Dispositif.ts
@@ -3,6 +3,7 @@ import {
   commitmentDetailsType,
   conditionType,
   ContentType,
+  DispositifOrigin,
   DispositifStatus,
   frenchLevelType,
   frequencyDetailsType,
@@ -215,12 +216,12 @@ export class Dispositif extends Base {
   updatedAt?: Date;
 
   @prop({
-    enum: ["RI", "RCO"],
+    enum: DispositifOrigin,
     default: "RI",
     required: true,
     immutable: true,
   })
-  public origin!: "RI" | "RCO";
+  public origin!: DispositifOrigin;
 
   @prop({ ref: () => Structure })
   public mainSponsor?: Ref<Structure, StructureId>;

--- a/apps/server/src/workflows/dispositif/getUserContributions/getUserContributions.ts
+++ b/apps/server/src/workflows/dispositif/getUserContributions/getUserContributions.ts
@@ -22,7 +22,7 @@ export const getUserContributions = async (userId: UserId): ResponseWithData<Get
   const dispositifs = await getDispositifsWithCreatorId(userId, neededFields);
 
   const res: GetUserContributionsResponse[] = dispositifs.map((d) => ({
-    ...pick(d, ["_id", "typeContenu", "status", "mainSponsor", "nbVues"]),
+    ...pick(d, ["_id", "typeContenu", "status", "mainSponsor", "nbVues", "origin"]),
     ...pick(d.translations.fr.content, ["titreInformatif", "titreMarque"]),
     nbMercis: d.merci.length,
     hasDraftVersion: !!d.hasDraftVersion,

--- a/packages/api-types/src/generics.ts
+++ b/packages/api-types/src/generics.ts
@@ -155,7 +155,10 @@ export enum DispositifStatus {
 }
 
 // Dispositif origin type for distinguishing editorial vs AI-generated content
-export type DispositifOrigin = "RI" | "RCO";
+export enum DispositifOrigin {
+  RI = "RI",
+  RCO = "RCO",
+}
 
 export interface InfoSection {
   title: string;

--- a/packages/api-types/src/modules/dispositif.ts
+++ b/packages/api-types/src/modules/dispositif.ts
@@ -280,6 +280,7 @@ export interface GetUserContributionsResponse {
   status: DispositifStatus;
   hasDraftVersion: boolean;
   // TODO: add administration?
+  origin: DispositifOrigin;
 }
 
 /**


### PR DESCRIPTION
This PR adapts the Mise en Oeuvre (MO) and Back Office (BO) functionalities to filter out items with 'RCO' origin.
It centralizes the filtering logic in the Redux Sagas (`allDispositifs.saga.ts`, `userContributions.saga.ts`, `userStructure.saga.ts`) to ensure RCO items are excluded at the data fetching level.
This prevents RCO items from being displayed in the user dashboard ('Mes fiches') and the admin content table ('Contenus'), effectively blocking their editorial process in these contexts.

Updates:
- Added unit tests in `userContributions.saga.test.ts` and `allDispositifs.saga.test.ts` to verify that RCO items are correctly filtered out.