### PR TITLE
feat(client): improve language selector accessibility with role attribute support

### DIFF
--- a/apps/client/public/locales/ar/common.json
+++ b/apps/client/public/locales/ar/common.json
@@ -571,11 +571,11 @@
     "carrouselSeemore": "مشاهدة الكل",
     "carrouselPrev": "اظهار النتائج على اليسار",
     "carrouselNext": "اظهار النتائج على اليمين",
-    "northStar_title": "هل رأيت أن الصفحة مفيدة ؟ ✨",
+    "northStar_title": "هل رأيت أن الصفحة مفيدة ؟ ",
     "northStar_no": "لا",
     "northStar_yes": "نعم",
     "northStar_notUseful": "غير مفيدة",
     "northStar_useful": "هل ذلك مفيد ؟ ✨",
-    "northStar_thanks": "شكراً لك لرأيك 😊"
+    "northStar_thanks": "شكراً لك لرأيك"
   }
 }

--- a/apps/client/public/locales/en/common.json
+++ b/apps/client/public/locales/en/common.json
@@ -572,11 +572,11 @@
     "carrouselSeemore": "View all",
     "carrouselPrev": "Scroll left",
     "carrouselNext": "Scroll right",
-    "northStar_title": "Is this page useful? ✨",
+    "northStar_title": "Is this page useful?",
     "northStar_no": "No",
     "northStar_yes": "Yes",
     "northStar_notUseful": "Not useful",
     "northStar_useful": "Is it useful? ✨",
-    "northStar_thanks": "Thank you for your feedback 😊"
+    "northStar_thanks": "Thank you for your feedback"
   }
 }

--- a/apps/client/public/locales/fa/common.json
+++ b/apps/client/public/locales/fa/common.json
@@ -572,11 +572,11 @@
     "carrouselSeemore": "مشاهده همه",
     "carrouselPrev": "پیمایش به چپ",
     "carrouselNext": "پیمایش به راست",
-    "northStar_title": "آیا این صفحه برایتان مفید بود؟ ✨",
+    "northStar_title": "آیا این صفحه برایتان مفید بود؟",
     "northStar_no": "خیر",
     "northStar_yes": "بله",
     "northStar_notUseful": "مفید نبود",
     "northStar_useful": "آیا مفید بود؟ ✨",
-    "northStar_thanks": "از نظر شما سپاسگزاریم 😊"
+    "northStar_thanks": "از نظر شما سپاسگزاریم"
   }
 }

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -850,12 +850,13 @@
     "carrouselPrev": "Faire défiler la liste à gauche",
     "carrouselNext": "Faire défiler la liste à droite",
     "countSeparator": "sur",
-    "northStar_title": "Cette page est-elle utile ? ✨",
+    "northStar_title": "Cette page est-elle utile ?",
     "northStar_no": "Non",
     "northStar_yes": "Oui",
     "northStar_notUseful": "Pas utile",
     "northStar_useful": "C'est utile ? ✨",
-    "northStar_thanks": "Merci pour votre retour 😊",
-    "northStar_error": "Une erreur est survenue lors de la soumission de votre avis"
+    "northStar_thanks": "Merci pour votre retour",
+    "northStar_error": "Une erreur est survenue lors de la soumission de votre avis",
+    "northStar_vote_cancelled": "Votre vote a été retiré"
   }
 }

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -858,5 +858,6 @@
     "northStar_thanks": "Merci pour votre retour",
     "northStar_error": "Une erreur est survenue lors de la soumission de votre avis",
     "northStar_vote_cancelled": "Votre vote a été retiré"
-  }
+  },
+  "breadcrumbs": "Fil d'Ariane"
 }

--- a/apps/client/public/locales/ps/common.json
+++ b/apps/client/public/locales/ps/common.json
@@ -572,11 +572,11 @@
     "carrouselSeemore": "ټول کتل",
     "carrouselPrev": "کیڼ اړخ ته سکرول کول",
     "carrouselNext": "ښي خوا ته سکرول کول",
-    "northStar_title": "ایا دا پاڼه ګټوره ده ؟ ✨",
+    "northStar_title": "ایا دا پاڼه ګټوره ده ؟",
     "northStar_no": "نه",
     "northStar_yes": "هو",
     "northStar_notUseful": "ګټوره نه ده",
     "northStar_useful": "ایا دا ګټور دی؟",
-    "northStar_thanks": "ستاسو د نظر ورکول څخه مننه 😊"
+    "northStar_thanks": "ستاسو د نظر ورکول څخه مننه "
   }
 }

--- a/apps/client/public/locales/ru/common.json
+++ b/apps/client/public/locales/ru/common.json
@@ -572,11 +572,11 @@
     "carrouselSeemore": "Посмотреть все",
     "carrouselPrev": "Листать влево",
     "carrouselNext": "Листать вправо",
-    "northStar_title": "Была ли эта страница полезна? ✨",
+    "northStar_title": "Была ли эта страница полезна?",
     "northStar_no": "Нет",
     "northStar_yes": "Да",
     "northStar_notUseful": "Бесполезна",
     "northStar_useful": "Это полезно? ✨",
-    "northStar_thanks": "Спасибо за ваш отзыв 😊"
+    "northStar_thanks": "Спасибо за ваш отзыв"
   }
 }

--- a/apps/client/public/locales/ti/common.json
+++ b/apps/client/public/locales/ti/common.json
@@ -572,11 +572,11 @@
     "carrouselSeemore": "ኩሉ ርአዩ",
     "carrouselPrev": "ንጸጋም ስክሮል ግበሩ",
     "carrouselNext": "ንየማን ስክሮል ግበሩ",
-    "northStar_title": "እዚ ሓበሬታ እዚ ኣገዳሲ ድዩ ? ✨",
+    "northStar_title": "እዚ ሓበሬታ እዚ ኣገዳሲ ድዩ ?",
     "northStar_no": "ኣይፋሉን",
     "northStar_yes": "እወ",
     "northStar_notUseful": "ጠቓሚ ኣይኮነን",
     "northStar_useful": "ጠቓሚ ድዩ  ? ✨",
-    "northStar_thanks": "ንርእይቶኹም ኣዚና ነመስግን 😊"
+    "northStar_thanks": "ንርእይቶኹም ኣዚና ነመስግን"
   }
 }

--- a/apps/client/public/locales/uk/common.json
+++ b/apps/client/public/locales/uk/common.json
@@ -572,11 +572,11 @@
     "carrouselSeemore": "Переглянути все",
     "carrouselPrev": "Прогорнути вліво",
     "carrouselNext": "Прогорнути вправо",
-    "northStar_title": "Чи була ця сторінка для вас корисною? ✨",
+    "northStar_title": "Чи була ця сторінка для вас корисною?",
     "northStar_no": "Ні",
     "northStar_yes": "Так",
     "northStar_notUseful": "Не корисна",
     "northStar_useful": "Чи це для вас корисно? ✨",
-    "northStar_thanks": "Дякуємо за ваш відгук 😊"
+    "northStar_thanks": "Дякуємо за ваш відгук"
   }
 }

--- a/apps/client/src/components/Accessibility/ScreenReaderAnnouncer.tsx
+++ b/apps/client/src/components/Accessibility/ScreenReaderAnnouncer.tsx
@@ -122,8 +122,14 @@ export const ScreenReaderAnnouncerProvider = ({ children }: { children: ReactNod
             "color: #666",
           );
         }
-        // Use single ZWSP to handle duplicate messages
-        setAssertiveCurrent(`${message}\u200B`);
+        // Handle duplicate messages by toggling ZWSP
+        setAssertiveCurrent((prev) => {
+          const cleanPrev = prev.replace(/\u200B$/, "");
+          if (cleanPrev === message) {
+            return prev.endsWith("\u200B") ? message : `${message}\u200B`;
+          }
+          return `${message}\u200B`;
+        });
       } else {
         setPoliteQueue((prev) => {
           queueLengthRef.current = prev.length + 1;
@@ -149,7 +155,13 @@ export const ScreenReaderAnnouncerProvider = ({ children }: { children: ReactNod
     const readTime = calculateReadTime(first.message);
 
     const delayTimer = setTimeout(() => {
-      setPoliteCurrent(`${first.message}\u200B`);
+      setPoliteCurrent((prev) => {
+        const cleanPrev = prev.replace(/\u200B$/, "");
+        if (cleanPrev === first.message) {
+          return prev.endsWith("\u200B") ? first.message : `${first.message}\u200B`;
+        }
+        return `${first.message}\u200B`;
+      });
     }, first.delay);
 
     if (debug) {

--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -259,9 +259,9 @@ const Layout = (props: Props) => {
       {!showLangModal && <ConsentBannerAndConsentManagement />}
       <DownloadAppBanner />
       <Navbar />
-      <div id="contenu" className={styles.main}>
-        <main className={cn(styles.content, props.className)}>{props.children}</main>
-      </div>
+      <main id="contenu" className={cn(styles.content, props.className)}>
+        {props.children}
+      </main>
       <Footer />
       <AutoAddFavorite />
 

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
@@ -114,6 +114,7 @@ const LanguageMenu = ({
               type={languageSelectorType}
               availableLanguages={availableLanguages}
               itemsDesign={itemsDesign}
+              role="presentation"
             />
           </DropdownContent>
         </DropdownRoot>

--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
@@ -1,5 +1,5 @@
 import { ContentType, GetDispositifResponse } from "@refugies-info/api-types";
-import { cn } from "@refugies-info/ui";
+import { cn, useWindowSize } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import Link from "next/link";
 import { useMemo, useState } from "react";
@@ -10,7 +10,6 @@ import { buildUrlQuery } from "~/lib/recherche/buildUrlQuery";
 import { needSelector } from "~/services/Needs/needs.selectors";
 import { themeSelector } from "~/services/Themes/themes.selectors";
 import { getDepartments } from "./functions";
-import { useWindowSize } from "@refugies-info/ui";
 
 interface Props {
   dispositif: GetDispositifResponse;
@@ -44,55 +43,80 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
         </button>
       )}
       {(!isTablet || showBreadcrumb) && (
-        <div className="">
-          <Link href={getPath("/", "fr")} className="" title={t("homepage")}>
-            <i className="ri-home-4-line text-mention-grey !bg-transparent !bg-none text-xs [&::before]:![--icon-size:1.25rem]" />
-          </Link>
-
-          {chevron}
-
-          <Link
-            href={getPath("/recherche", "fr", `?${buildUrlQuery({ type: dispositif.typeContenu })}`)}
-            className="text-mention-grey !bg-transparent !bg-none underline decoration-current underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
-          >
-            {dispositif.typeContenu === ContentType.DISPOSITIF ? t("Dispositif.dispositif") : t("Dispositif.demarche")}
-          </Link>
-
-          {chevron}
-
-          {theme && (
-            <>
-              <Link
-                href={getPath("/recherche", "fr", `?${buildUrlQuery({ themes: [theme._id] })}`)}
-                className="text-mention-grey !bg-transparent !bg-none underline decoration-solid decoration-auto underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
-              >
-                {theme.short[locale] || theme.short.fr}
+        <nav aria-label={t("breadcrumbs", "Fil d'Ariane")}>
+          <ol className="!m-0 flex !list-none flex-wrap items-center !p-0 [&>li]:!list-none [&>li]:before:!content-none [&>li::marker]:!content-none">
+            <li>
+              <Link href={getPath("/", "fr")} className="" title={t("homepage")}>
+                <i className="ri-home-4-line text-mention-grey !bg-transparent !bg-none text-xs [&::before]:![--icon-size:1.25rem]" />
+                <span className="sr-only">{t("homepage")}</span>
               </Link>
-              {chevron}
-            </>
-          )}
+            </li>
 
-          {dispositif.needs.length === 1 && need && (
-            <>
+            <li aria-hidden="true" className="mx-1 select-none">
+              {chevron}
+            </li>
+
+            <li>
               <Link
-                href={getPath("/recherche", "fr", `?${buildUrlQuery({ needs: [need._id] })}`)}
-                className="text-mention-grey !bg-transparent !bg-none underline decoration-solid decoration-auto underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
+                href={getPath("/recherche", "fr", `?${buildUrlQuery({ type: dispositif.typeContenu })}`)}
+                className="text-mention-grey !bg-transparent !bg-none underline decoration-current underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
               >
-                {need[locale]?.text || need.fr.text}
+                {dispositif.typeContenu === ContentType.DISPOSITIF
+                  ? t("Dispositif.dispositif")
+                  : t("Dispositif.demarche")}
               </Link>
-              {chevron}
-            </>
-          )}
+            </li>
 
-          {dispositif.typeContenu === ContentType.DISPOSITIF && (
-            <span className="text-active-grey">
-              {`${dispositif.titreMarque || ""} ${getDepartments(dispositif.metadatas.location, t)}`}
-            </span>
-          )}
-          {dispositif.typeContenu === ContentType.DEMARCHE && (
-            <span className="text-active-grey">{dispositif.titreInformatif}</span>
-          )}
-        </div>
+            <li aria-hidden="true" className="mx-1 select-none">
+              {chevron}
+            </li>
+
+            {theme && (
+              <>
+                <li>
+                  <Link
+                    href={getPath("/recherche", "fr", `?${buildUrlQuery({ themes: [theme._id] })}`)}
+                    className="text-mention-grey !bg-transparent !bg-none underline decoration-solid decoration-auto underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
+                  >
+                    {theme.short[locale] || theme.short.fr}
+                  </Link>
+                </li>
+                <li aria-hidden="true" className="mx-1 select-none">
+                  {chevron}
+                </li>
+              </>
+            )}
+
+            {dispositif.needs.length === 1 && need && (
+              <>
+                <li>
+                  <Link
+                    href={getPath("/recherche", "fr", `?${buildUrlQuery({ needs: [need._id] })}`)}
+                    className="text-mention-grey !bg-transparent !bg-none underline decoration-solid decoration-auto underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
+                  >
+                    {need[locale]?.text || need.fr.text}
+                  </Link>
+                </li>
+                <li aria-hidden="true" className="mx-1 select-none">
+                  {chevron}
+                </li>
+              </>
+            )}
+
+            <li>
+              {dispositif.typeContenu === ContentType.DISPOSITIF && (
+                <span className="text-active-grey" aria-current="page">
+                  {`${dispositif.titreMarque || ""} ${getDepartments(dispositif.metadatas.location, t)}`}
+                </span>
+              )}
+              {dispositif.typeContenu === ContentType.DEMARCHE && (
+                <span className="text-active-grey" aria-current="page">
+                  {dispositif.titreInformatif}
+                </span>
+              )}
+            </li>
+          </ol>
+        </nav>
       )}
     </div>
   );

--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
@@ -46,7 +46,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
         <nav aria-label={t("breadcrumbs", "Fil d'Ariane")}>
           <ol className="!m-0 flex !list-none flex-wrap items-center !p-0 [&>li]:!list-none [&>li]:before:!content-none [&>li::marker]:!content-none">
             <li>
-              <Link href={getPath("/", "fr")} className="" title={t("homepage")}>
+              <Link href={getPath("/", locale)} className="" title={t("homepage")}>
                 <i className="ri-home-4-line text-mention-grey !bg-transparent !bg-none text-xs [&::before]:![--icon-size:1.25rem]" />
                 <span className="sr-only">{t("homepage")}</span>
               </Link>
@@ -58,7 +58,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
 
             <li>
               <Link
-                href={getPath("/recherche", "fr", `?${buildUrlQuery({ type: dispositif.typeContenu })}`)}
+                href={getPath("/recherche", locale, `?${buildUrlQuery({ type: dispositif.typeContenu })}`)}
                 className="text-mention-grey !bg-transparent !bg-none underline decoration-current underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
               >
                 {dispositif.typeContenu === ContentType.DISPOSITIF
@@ -75,7 +75,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
               <>
                 <li>
                   <Link
-                    href={getPath("/recherche", "fr", `?${buildUrlQuery({ themes: [theme._id] })}`)}
+                    href={getPath("/recherche", locale, `?${buildUrlQuery({ themes: [theme._id] })}`)}
                     className="text-mention-grey !bg-transparent !bg-none underline decoration-solid decoration-auto underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
                   >
                     {theme.short[locale] || theme.short.fr}
@@ -91,7 +91,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
               <>
                 <li>
                   <Link
-                    href={getPath("/recherche", "fr", `?${buildUrlQuery({ needs: [need._id] })}`)}
+                    href={getPath("/recherche", locale, `?${buildUrlQuery({ needs: [need._id] })}`)}
                     className="text-mention-grey !bg-transparent !bg-none underline decoration-solid decoration-auto underline-offset-[0.125rem] [text-decoration-skip-ink:auto]"
                   >
                     {need[locale]?.text || need.fr.text}

--- a/apps/client/src/components/Pages/dispositif/Header/Header.tsx
+++ b/apps/client/src/components/Pages/dispositif/Header/Header.tsx
@@ -1,4 +1,5 @@
 import Button from "@codegouvfr/react-dsfr/Button";
+import { useWindowSize } from "@refugies-info/ui";
 import moment from "moment";
 import "moment/locale/ar";
 import "moment/locale/en-gb";
@@ -20,7 +21,6 @@ import { Event } from "~/lib/tracking";
 import { selectedDispositifSelector } from "~/services/SelectedDispositif/selectedDispositif.selector";
 import PageContext from "~/utils/pageContext";
 import Title from "../Title";
-import { useWindowSize } from "@refugies-info/ui";
 
 interface Props {
   typeContenu: string;
@@ -31,7 +31,6 @@ const Header = (props: Props) => {
   const dispositif = useSelector(selectedDispositifSelector);
   const { isMobile } = useWindowSize();
   const [navigatorShareSupported, setNavigatorShareSupported] = useState(false);
-
 
   // Check for Web Share API support when component mounts
   useEffect(() => {
@@ -97,13 +96,7 @@ const Header = (props: Props) => {
         <div className="flex items-center gap-3 text-sm">
           {dispositif?.mainSponsor?.picture?.secure_url && (
             <span className="border-default-grey relative inline-grid aspect-square h-14 w-14 items-center justify-center border p-1">
-              <Image
-                src={dispositif?.mainSponsor?.picture?.secure_url}
-                width={150}
-                height={150}
-                alt={dispositif?.mainSponsor?.nom || ""}
-                className=""
-              />
+              <Image src={dispositif?.mainSponsor?.picture?.secure_url} width={150} height={150} alt="" />
             </span>
           )}
 
@@ -123,12 +116,12 @@ const Header = (props: Props) => {
       {isViewMode && (
         <div className="border-default-grey my-8 flex items-center justify-between border-y py-1 rtl:flex-row-reverse print:hidden">
           <SaveBookmark />
-          
-          {navigatorShareSupported && 
+
+          {navigatorShareSupported && (
             <Button priority="tertiary no outline" onClick={handleShare} iconId="ri-share-forward-line">
               {t("Dispositif.shareShort", "Partager")}
             </Button>
-          }
+          )}
 
           <LanguageMenu
             mobileMode="modal"

--- a/apps/client/src/components/Pages/dispositif/NorthStar/NorthStar.tsx
+++ b/apps/client/src/components/Pages/dispositif/NorthStar/NorthStar.tsx
@@ -106,7 +106,10 @@ const NorthStar = () => {
 
   const onCancel = () => {
     if (!dispositif) return;
-    API.deleteDispositifAvis(dispositif._id.toString())
+    API.deleteDispositifAvis(dispositif._id.toString(), {
+      anonymousUserId: anonymousUserId || undefined,
+      userId: userId || undefined,
+    })
       .then(() => {
         sendTrackEvent(null);
         setDidVote(false);

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/NeedItem.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/NeedItem.tsx
@@ -1,11 +1,8 @@
 import { GetNeedResponse } from "@refugies-info/api-types";
 import { cn } from "@refugies-info/ui";
-import { useTranslation } from "next-i18next";
 import React, { useContext } from "react";
-import { useSelector } from "react-redux";
 import { ThemeMenuContext } from "~/components/Pages/recherche/ThemeMenu/ThemeMenuContext";
 import { useLocale } from "~/hooks";
-import { themesSelector } from "~/services/Themes/themes.selectors";
 import styles from "./NeedItem.module.css";
 
 interface Props {
@@ -16,26 +13,17 @@ interface Props {
 
 const NeedItem: React.FC<Props> = ({ need, label, count: customCount }) => {
   const locale = useLocale();
-  const { nbDispositifsByNeed, selectedThemeId } = useContext(ThemeMenuContext);
-  const { t } = useTranslation();
-  const themes = useSelector(themesSelector);
+  const { nbDispositifsByNeed } = useContext(ThemeMenuContext);
 
   const displayLabel = label || (need ? need[locale]?.text || "" : "");
   const displayCount = customCount !== undefined ? customCount : need ? nbDispositifsByNeed[need._id.toString()] : "";
-  const countNumber = typeof displayCount === "string" ? parseInt(displayCount, 10) || 0 : displayCount;
-
-  const selectedTheme = themes.find((theme) => theme._id === selectedThemeId);
-  const themeName = selectedTheme?.short?.[locale] || selectedTheme?.name?.[locale] || "";
-
-  const ariaLabel =
-    displayLabel === "Tous"
-      ? t("Recherche.needAllSheets", { count: countNumber, theme: themeName })
-      : `${displayLabel} ${t("Recherche.needSheetsCount", { count: countNumber })}`;
 
   return (
-    <span className={cn("space-between flex w-full")} aria-label={ariaLabel}>
+    <span className={cn("space-between flex w-full")}>
       <span className={styles.label}>{displayLabel}</span>{" "}
-      <span className={cn("ms-auto", styles.count)}>{displayCount}</span>
+      <span className={cn("ms-auto", styles.count)} aria-hidden="true">
+        {displayCount}
+      </span>
     </span>
   );
 };

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
@@ -123,7 +123,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
       >
         <Checkbox
           legend={t("Recherche.theme", "Thème")}
-          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b [&_legend]:sr-only"
+          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b [&_legend]:sr-only [&_legend]:hidden"
           options={[
             {
               label: (
@@ -133,8 +133,10 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
                 />
               ),
               nativeInputProps: {
-                checked: allNeedsSelected,
-                onChange: toggleAllNeeds,
+                "checked": allNeedsSelected,
+                "onChange": toggleAllNeeds,
+                "className": "!border",
+                "aria-label": `${t("Recherche.all", "Tous")} ${selectedThemeId ? nbDispositifsByTheme[selectedThemeId.toString()] : ""} ${t("Recherche.fiches", "fiches")}`,
               },
             },
             ...displayedNeeds.map((need) => {
@@ -143,8 +145,10 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
               return {
                 label: <NeedItem need={need} />,
                 nativeInputProps: {
-                  checked: selected,
-                  onChange: () => selectNeed(need._id),
+                  "checked": selected,
+                  "onChange": () => selectNeed(need._id),
+                  "className": "!border",
+                  "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")})`,
                 },
               };
             }),

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
@@ -122,8 +122,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
         ref={needsContainerRef}
       >
         <Checkbox
-          legend={t("Recherche.theme", "Thème")}
-          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b [&_legend]:sr-only [&_legend]:hidden"
+          className="[&_.fr-checkbox-group:first-child]:border-default-grey [&_.fr-checkbox-group:first-child]:border-b"
           options={[
             {
               label: (
@@ -148,7 +147,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
                   "checked": selected,
                   "onChange": () => selectNeed(need._id),
                   "className": "!border",
-                  "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")})`,
+                  "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")}`,
                 },
               };
             }),

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.module.css
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.module.css
@@ -29,3 +29,12 @@
   align-items: flex-start;
   align-self: stretch;
 }
+
+@layer base {
+  .needs fieldset legend:global(.fr-text--regular) {
+    font:
+      700 1rem/1.5rem Marianne,
+      arial,
+      sans-serif !important;
+  }
+}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
@@ -66,7 +66,7 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
     <div className={styles.container}>
       <div
         className={cn(
-          "w-full px-2 [&_div]:m-0 [&_fieldset]:m-0 [&_fieldset]:w-full",
+          "w-full px-2 [&_div]:m-0 [&_fieldset]:m-0 [&_fieldset]:w-full [&_fieldset_legend]:px-0 [&_fieldset_legend]:py-4 [&_fieldset_legend]:pb-2",
           styles.needs,
           needs.length === 0 && styles.needsEmpty,
         )}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
@@ -2,7 +2,7 @@ import Checkbox from "@codegouvfr/react-dsfr/Checkbox";
 import { GetNeedResponse, GetThemeResponse, Id } from "@refugies-info/api-types";
 import { cn } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
-import React from "react";
+import React, { useContext } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import { useLocale, useSearchEventName } from "~/hooks";
@@ -15,6 +15,7 @@ import { addToQueryActionCreator } from "~/services/SearchResults/searchResults.
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
 import NeedItem from "./NeedItem";
 import styles from "./ResultsSection.module.css";
+import { ThemeMenuContext } from "./ThemeMenuContext";
 
 interface Props {
   theme: GetThemeResponse;
@@ -30,13 +31,7 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
   const { t } = useTranslation();
   const announce = useAnnounce();
   const dispositifs = useSelector(activeDispositifsSelector);
-
-  // Calculate count of dispositifs for each need
-  const nbDispositifsByNeed: Record<string, number> = {};
-  needs.forEach((need) => {
-    const results = queryDispositifs({ ...query, needs: [need._id], themes: [] }, dispositifs, allNeeds);
-    nbDispositifsByNeed[need._id.toString()] = results.matches.length;
-  });
+  const { nbDispositifsByNeed } = useContext(ThemeMenuContext);
 
   const selectNeed = (id: Id) => {
     let allSelectedNeeds: Id[] = [...query.needs, ...getNeedsFromThemes(query.themes, allNeeds)];

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ResultsSection.tsx
@@ -31,6 +31,13 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
   const announce = useAnnounce();
   const dispositifs = useSelector(activeDispositifsSelector);
 
+  // Calculate count of dispositifs for each need
+  const nbDispositifsByNeed: Record<string, number> = {};
+  needs.forEach((need) => {
+    const results = queryDispositifs({ ...query, needs: [need._id], themes: [] }, dispositifs, allNeeds);
+    nbDispositifsByNeed[need._id.toString()] = results.matches.length;
+  });
+
   const selectNeed = (id: Id) => {
     let allSelectedNeeds: Id[] = [...query.needs, ...getNeedsFromThemes(query.themes, allNeeds)];
 
@@ -62,7 +69,6 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
 
   return (
     <div className={styles.container}>
-      <div className={styles.theme}>{theme.short[locale]}</div>
       <div
         className={cn(
           "w-full px-2 [&_div]:m-0 [&_fieldset]:m-0 [&_fieldset]:w-full",
@@ -72,15 +78,15 @@ const ResultsSection: React.FC<Props> = ({ theme, needs }) => {
       >
         <Checkbox
           legend={theme.short[locale]}
-          className="[&_legend]:sr-only"
           options={needs.map((need) => {
             const selected = query.needs.includes(need._id) || query.themes.includes(need.theme._id);
 
             return {
               label: <NeedItem need={need} />,
               nativeInputProps: {
-                checked: selected,
-                onChange: () => selectNeed(need._id),
+                "checked": selected,
+                "onChange": () => selectNeed(need._id),
+                "aria-label": `${need[locale]?.text || ""} ${nbDispositifsByNeed[need._id.toString()] || 0} ${t("Recherche.fiches", "fiches")}`,
               },
             };
           })}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.tsx
@@ -35,11 +35,12 @@ const ThemeItem: React.FC<ThemeItemProps> = ({ color, id, label, needCount, sele
       aria-controls={`tabpanel-${id}`}
       id={`tab-${id}`}
       tabIndex={selected ? 0 : isFirst ? 0 : -1}
+      aria-label={ariaLabel}
     >
-      <div className={styles.zone} aria-label={ariaLabel}>
+      <div className={styles.zone}>
         <span className={styles.label}>{label}</span>
         {needCount && needCount > 0 && (
-          <div className={styles.countContainer}>
+          <div className={styles.countContainer} aria-hidden="true">
             <span
               style={{
                 color: selected ? color : "white",

--- a/apps/client/src/components/UI/AccessibleNavigation/AccessibleNavigation.tsx
+++ b/apps/client/src/components/UI/AccessibleNavigation/AccessibleNavigation.tsx
@@ -31,11 +31,12 @@ const AccessibleNavigationContext = createContext<AccessibleNavigationContextPro
 
 const AccessibleNavigation = forwardRef<HTMLDivElement, AccessibleNavigationProps>(
   (
-    { children, orientation = "vertical", className, onEscape, onNavigateOut, "aria-label": ariaLabel, ...props },
+    { children, orientation = "vertical", className, onEscape, onNavigateOut, "aria-label": ariaLabel, role, ...props },
     ref,
   ) => {
     const navRef = useRef<HTMLDivElement | null>(null);
     const [activeIndex, setActiveIndex] = useState(0);
+    const isPresentation = role === "presentation" || role === "none";
 
     // Here we can't use ref directly if we want the querySelector to work
     useImperativeHandle(ref, () => navRef.current as HTMLDivElement);
@@ -108,9 +109,9 @@ const AccessibleNavigation = forwardRef<HTMLDivElement, AccessibleNavigationProp
       <AccessibleNavigationContext.Provider value={contextValue}>
         <div
           ref={navRef}
-          role="menubar"
-          aria-orientation={orientation}
-          aria-label={ariaLabel}
+          role={role || "menubar"}
+          aria-orientation={isPresentation ? undefined : orientation}
+          aria-label={isPresentation ? undefined : ariaLabel}
           className={className}
           onKeyDown={handleKeyDown}
           {...props}

--- a/apps/client/src/components/UI/LanguageSelector/LanguageSelector.tsx
+++ b/apps/client/src/components/UI/LanguageSelector/LanguageSelector.tsx
@@ -1,5 +1,5 @@
 import { activatedLanguages } from "data/activatedLanguages";
-import { forwardRef, useEffect, useRef } from "react";
+import { HTMLAttributes, forwardRef, useEffect, useRef } from "react";
 import {
   AccessibleNavigation,
   AccessibleNavigationItem,
@@ -7,7 +7,7 @@ import {
 import { LanguageItem } from "~/components/UI/LanguageSelector/LanguageItem";
 import { useLocale } from "~/hooks";
 
-interface LanguageSelectProps {
+interface LanguageSelectProps extends HTMLAttributes<HTMLDivElement> {
   onChangeLang?: () => void;
   type?: "global" | "page";
   itemsDesign?: "radio" | "default";

--- a/apps/client/src/hooks/useScrollToAnchor.ts
+++ b/apps/client/src/hooks/useScrollToAnchor.ts
@@ -21,12 +21,24 @@ const useScrollToAnchor = () => {
    * @param {string} hash - The target element's ID.
    */
   const scrollToHash = useCallback((hash: string) => {
-    setTimeout(() => {
-      const element = document.getElementById(hash);
-      if (element) {
-        element.scrollIntoView({ behavior: "smooth" });
+    const element = document.getElementById(hash);
+    if (element) {
+      // Calculate position with offset for header
+      const headerOffset = 0;
+      const elementPosition = element.getBoundingClientRect().top;
+      const offsetPosition = elementPosition + window.scrollY - headerOffset;
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: "smooth",
+      });
+
+      // Manage focus
+      if (!element.hasAttribute("tabIndex")) {
+        element.setAttribute("tabIndex", "-1");
       }
-    }, 50);
+      element.focus({ preventScroll: true });
+    }
   }, []);
 
   /**
@@ -43,7 +55,7 @@ const useScrollToAnchor = () => {
       const href = anchor.getAttribute("href");
       if (!href) return;
 
-      const isInternal = href.startsWith("/") || href.startsWith(window.location.origin);
+      const isInternal = href.startsWith("/") || href.startsWith(window.location.origin) || href.startsWith("#");
       const isAnchor = href.includes("#");
 
       if (isInternal && isAnchor) {

--- a/apps/client/src/pages/_document.tsx
+++ b/apps/client/src/pages/_document.tsx
@@ -6,7 +6,7 @@ const { getColorSchemeHtmlAttributes, augmentDocumentForDsfr } = dsfrDocumentApi
 
 export default function Document(props: DocumentProps) {
   return (
-    <Html {...getColorSchemeHtmlAttributes(props)} className={`scroll-smooth ${caveat.variable}`}>
+    <Html {...getColorSchemeHtmlAttributes(props)} className={caveat.variable}>
       <Head>
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="manifest" href="/manifest.json" />

--- a/apps/client/src/utils/API.ts
+++ b/apps/client/src/utils/API.ts
@@ -93,9 +93,9 @@ import {
   UpdateUserResponse,
   WidgetRequest,
 } from "@refugies-info/api-types";
+import { isInBrowser } from "@refugies-info/ui";
 import axios, { Canceler } from "axios";
 import Swal from "sweetalert2";
-import { isInBrowser } from "@refugies-info/ui";
 import { APIResponse } from "~/types/interface";
 import { getAuthToken, removeAuthToken } from "~/utils/authToken";
 import { logger } from "../logger";
@@ -367,9 +367,9 @@ const API = {
     const headers = getHeaders();
     return instance.patch<any, null>(`/dispositifs/${id}/avis`, body, { headers }).then(() => null);
   },
-  deleteDispositifAvis: (id: string): Promise<null> => {
+  deleteDispositifAvis: (id: string, body: { anonymousUserId?: string; userId?: Id } = {}): Promise<null> => {
     const headers = getHeaders();
-    return instance.delete<any, null>(`/dispositifs/${id}/avis`, { headers }).then(() => null);
+    return instance.delete<any, null>(`/dispositifs/${id}/avis`, { headers, data: body }).then(() => null);
   },
   addDispositifSuggestion: (id: string, body: AddSuggestionDispositifRequest): Promise<null> => {
     const headers = getHeaders();

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
       "@codegouvfr/react-dsfr": "1.20.2",
       "debug": "4.4.1",
       "form-data": ">=4.0.4",
+      "mongo-migrate-ts>glob": ">=10.5.0",
+      "rimraf>glob": ">=11.1.0",
       "image-size": "^1.2.1",
       "pbkdf2": ">=3.1.3",
       "sha.js": ">=2.4.12",

--- a/packages/ui/src/components/composites/vote/Vote.tsx
+++ b/packages/ui/src/components/composites/vote/Vote.tsx
@@ -6,6 +6,11 @@ import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } f
 import VoteLayoutStandard from "./VoteLayoutStandard";
 import VoteLayoutSticky from "./VoteLayoutSticky";
 
+type AnnounceOptions = {
+  priority?: "interrupt" | "normal";
+  delay?: number;
+};
+
 type VoteProps = {
   className?: string;
   currentVote?: boolean | null;
@@ -15,7 +20,7 @@ type VoteProps = {
   onCancelYes?: () => void;
   onCancelNo?: () => void;
   onVoteUpdate?: (vote: boolean) => void;
-  onVoteAnnounce?: (message: string) => void;
+  onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
   error?: boolean | null;
 };
 
@@ -137,6 +142,8 @@ export const Vote = forwardRef<VoteRef, VoteProps>(
         handleClickYes={handleClickYes}
         handleClickNo={handleClickNo}
         thumbUpRef={thumbUpRef}
+        hasVoted={!error && hasVoted}
+        onVoteAnnounce={onVoteAnnounce}
       />
     ) : (
       <VoteLayoutStandard

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -14,7 +14,7 @@ type VoteLayoutStandardProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
   onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 
@@ -51,7 +51,7 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
                 className={cn("fr-icon-thumb-up-line", vote === true ? "opacity-0" : "opacity-100")}
               ></span>
               <ThumbUpAnimated
-                ref={thumbUpRef}
+                ref={thumbUpRef as React.RefObject<ThumbUpAnimatedRef>}
                 className={cn("absolute bottom-0", vote === true ? "opacity-100" : "opacity-0")}
                 themeId="light"
               />

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -14,7 +14,7 @@ type VoteLayoutStandardProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
   onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -1,7 +1,12 @@
 import Button from "@codegouvfr/react-dsfr/Button";
 import { cn, ThumbUpAnimated, ThumbUpAnimatedRef } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
-import React, { forwardRef, useEffect } from "react";
+import React, { forwardRef, useEffect, useRef } from "react";
+
+type AnnounceOptions = {
+  priority?: "interrupt" | "normal";
+  delay?: number;
+};
 
 type VoteLayoutStandardProps = {
   className?: string;
@@ -9,23 +14,29 @@ type VoteLayoutStandardProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
-  onVoteAnnounce?: (message: string) => void;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
+  onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 
 const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
   ({ className, vote, handleClickYes, handleClickNo, hasVoted, thumbUpRef, onVoteAnnounce }, ref) => {
     const { t } = useTranslation();
+    const prevHasVoted = useRef(hasVoted);
 
     useEffect(() => {
       if (hasVoted && onVoteAnnounce) {
-        onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour 😊"));
+        onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour"), { priority: "interrupt" });
+      } else if (!hasVoted && prevHasVoted.current && onVoteAnnounce) {
+        onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
       }
-    }, [hasVoted, onVoteAnnounce, t]);
+      prevHasVoted.current = hasVoted;
+    }, [hasVoted, vote, onVoteAnnounce, t]);
 
     return (
       <div ref={ref} className={cn("mb-4 flex flex-col gap-2 rounded-sm bg-white p-4 shadow-lg", className)}>
-        <p className="mb-2 text-xl font-bold">{t("ui.northStar_title", "Cette page vous a-t-elle été utile ? ✨")}</p>
+        <p className="mb-2 text-xl font-bold">
+          {t("ui.northStar_title", "Cette page vous a-t-elle été utile ?")} <span aria-hidden="true">✨</span>
+        </p>
 
         <div className="grid grid-cols-2 gap-2">
           <Button
@@ -34,8 +45,11 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
             className={cn("flex h-[1.7rem] w-full items-end gap-2 transition-all")}
             size="small"
           >
-            <div className="relative">
-              <span className={cn("fr-icon-thumb-up-line", vote === true ? "opacity-0" : "opacity-100")}></span>
+            <div className="relative" aria-hidden="true">
+              <span
+                aria-hidden="true"
+                className={cn("fr-icon-thumb-up-line", vote === true ? "opacity-0" : "opacity-100")}
+              ></span>
               <ThumbUpAnimated
                 ref={thumbUpRef}
                 className={cn("absolute bottom-0", vote === true ? "opacity-100" : "opacity-0")}
@@ -60,8 +74,9 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
             hasVoted ? "max-h-[1000px]" : "max-h-0",
             vote === true && "delay-1000",
           )}
+          aria-hidden="true"
         >
-          {t("ui.northStar_thanks", "Merci pour votre retour 😊")}
+          {t("ui.northStar_thanks", "Merci pour votre retour")} ☺️
         </p>
       </div>
     );

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -14,7 +14,7 @@ type VoteLayoutStandardProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
   onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 
@@ -22,9 +22,13 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
   ({ className, vote, handleClickYes, handleClickNo, hasVoted, thumbUpRef, onVoteAnnounce }, ref) => {
     const { t } = useTranslation();
     const prevHasVoted = useRef(hasVoted);
+    const prevHasVoted = useRef(hasVoted);
 
     useEffect(() => {
       if (hasVoted && onVoteAnnounce) {
+        onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour"), { priority: "interrupt" });
+      } else if (!hasVoted && prevHasVoted.current && onVoteAnnounce) {
+        onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
         onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour"), { priority: "interrupt" });
       } else if (!hasVoted && prevHasVoted.current && onVoteAnnounce) {
         onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
@@ -37,6 +41,9 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
         <p className="mb-2 text-xl font-bold">
           {t("ui.northStar_title", "Cette page vous a-t-elle été utile ?")} <span aria-hidden="true">✨</span>
         </p>
+        <p className="mb-2 text-xl font-bold">
+          {t("ui.northStar_title", "Cette page vous a-t-elle été utile ?")} <span aria-hidden="true">✨</span>
+        </p>
 
         <div className="grid grid-cols-2 gap-2">
           <Button
@@ -45,6 +52,11 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
             className={cn("flex h-[1.7rem] w-full items-end gap-2 transition-all")}
             size="small"
           >
+            <div className="relative" aria-hidden="true">
+              <span
+                aria-hidden="true"
+                className={cn("fr-icon-thumb-up-line", vote === true ? "opacity-0" : "opacity-100")}
+              ></span>
             <div className="relative" aria-hidden="true">
               <span
                 aria-hidden="true"
@@ -75,7 +87,9 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
             vote === true && "delay-1000",
           )}
           aria-hidden="true"
+          aria-hidden="true"
         >
+          {t("ui.northStar_thanks", "Merci pour votre retour")} ☺️
           {t("ui.northStar_thanks", "Merci pour votre retour")} ☺️
         </p>
       </div>

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -30,7 +30,7 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
         onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
       }
       prevHasVoted.current = hasVoted;
-    }, [hasVoted, vote, onVoteAnnounce, t]);
+    }, [hasVoted, onVoteAnnounce, t]);
 
     return (
       <div ref={ref} className={cn("mb-4 flex flex-col gap-2 rounded-sm bg-white p-4 shadow-lg", className)}>

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -22,13 +22,9 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
   ({ className, vote, handleClickYes, handleClickNo, hasVoted, thumbUpRef, onVoteAnnounce }, ref) => {
     const { t } = useTranslation();
     const prevHasVoted = useRef(hasVoted);
-    const prevHasVoted = useRef(hasVoted);
 
     useEffect(() => {
       if (hasVoted && onVoteAnnounce) {
-        onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour"), { priority: "interrupt" });
-      } else if (!hasVoted && prevHasVoted.current && onVoteAnnounce) {
-        onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
         onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour"), { priority: "interrupt" });
       } else if (!hasVoted && prevHasVoted.current && onVoteAnnounce) {
         onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
@@ -41,9 +37,6 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
         <p className="mb-2 text-xl font-bold">
           {t("ui.northStar_title", "Cette page vous a-t-elle été utile ?")} <span aria-hidden="true">✨</span>
         </p>
-        <p className="mb-2 text-xl font-bold">
-          {t("ui.northStar_title", "Cette page vous a-t-elle été utile ?")} <span aria-hidden="true">✨</span>
-        </p>
 
         <div className="grid grid-cols-2 gap-2">
           <Button
@@ -52,11 +45,6 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
             className={cn("flex h-[1.7rem] w-full items-end gap-2 transition-all")}
             size="small"
           >
-            <div className="relative" aria-hidden="true">
-              <span
-                aria-hidden="true"
-                className={cn("fr-icon-thumb-up-line", vote === true ? "opacity-0" : "opacity-100")}
-              ></span>
             <div className="relative" aria-hidden="true">
               <span
                 aria-hidden="true"
@@ -87,9 +75,7 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
             vote === true && "delay-1000",
           )}
           aria-hidden="true"
-          aria-hidden="true"
         >
-          {t("ui.northStar_thanks", "Merci pour votre retour")} ☺️
           {t("ui.northStar_thanks", "Merci pour votre retour")} ☺️
         </p>
       </div>

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -14,7 +14,7 @@ type VoteLayoutStickyProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
   onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -30,7 +30,7 @@ const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
         onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
       }
       prevHasVoted.current = hasVoted;
-    }, [hasVoted, vote, onVoteAnnounce, t]);
+    }, [hasVoted, onVoteAnnounce, t]);
 
     return (
       <div

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -3,17 +3,34 @@ import { cn, ThumbUpAnimated, ThumbUpAnimatedRef } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import React, { forwardRef } from "react";
 
+type AnnounceOptions = {
+  priority?: "interrupt" | "normal";
+  delay?: number;
+};
+
 type VoteLayoutStickyProps = {
   className?: string;
   vote?: boolean | null;
   handleClickYes: () => void;
   handleClickNo: () => void;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
+  hasVoted: boolean;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
+  onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 
 const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
-  ({ className, vote, handleClickYes, handleClickNo, thumbUpRef }, ref) => {
+  ({ className, vote, handleClickYes, handleClickNo, hasVoted, thumbUpRef, onVoteAnnounce }, ref) => {
     const { t } = useTranslation();
+    const prevHasVoted = React.useRef(hasVoted);
+
+    React.useEffect(() => {
+      if (hasVoted && onVoteAnnounce) {
+        onVoteAnnounce(t("ui.northStar_thanks", "Merci pour votre retour"), { priority: "interrupt" });
+      } else if (!hasVoted && prevHasVoted.current && onVoteAnnounce) {
+        onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
+      }
+      prevHasVoted.current = hasVoted;
+    }, [hasVoted, vote, onVoteAnnounce, t]);
 
     return (
       <div

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -14,7 +14,7 @@ type VoteLayoutStickyProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
   onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 
@@ -30,7 +30,7 @@ const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
         onVoteAnnounce(t("ui.northStar_vote_cancelled", "Votre vote a été retiré"), { priority: "interrupt" });
       }
       prevHasVoted.current = hasVoted;
-    }, [hasVoted, onVoteAnnounce, t]);
+    }, [hasVoted, vote, onVoteAnnounce, t]);
 
     return (
       <div

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -14,7 +14,7 @@ type VoteLayoutStickyProps = {
   handleClickYes: () => void;
   handleClickNo: () => void;
   hasVoted: boolean;
-  thumbUpRef: React.RefObject<ThumbUpAnimatedRef>;
+  thumbUpRef: React.RefObject<ThumbUpAnimatedRef | null>;
   onVoteAnnounce?: (message: string, options?: AnnounceOptions) => void;
 };
 
@@ -53,7 +53,7 @@ const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
             <div className="relative">
               <span className={cn("fr-icon-thumb-up-line", vote === true ? "opacity-0" : "opacity-100")}></span>
               <ThumbUpAnimated
-                ref={thumbUpRef}
+                ref={thumbUpRef as React.RefObject<ThumbUpAnimatedRef>}
                 className={cn("absolute bottom-0", vote === true ? "opacity-100" : "opacity-0")}
                 themeId="light"
               />

--- a/packages/ui/src/components/primitives/icons/thumb-up-animated/ThumbUpAnimated.tsx
+++ b/packages/ui/src/components/primitives/icons/thumb-up-animated/ThumbUpAnimated.tsx
@@ -71,7 +71,7 @@ export const ThumbUpAnimated = forwardRef<ThumbUpAnimatedRef, ThumbUpAnimatedPro
     };
 
     return (
-      <div className={cn("aspect-[33_/_49] h-auto w-[1.5rem]", className)}>
+      <div className={cn("aspect-[33_/_49] h-auto w-[1.5rem]", className)} aria-hidden="true">
         <DotLottieReact
           src={ThumbUpAnimation}
           autoplay={false}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   '@codegouvfr/react-dsfr': 1.20.2
   debug: 4.4.1
   form-data: '>=4.0.4'
+  mongo-migrate-ts>glob: '>=10.5.0'
+  rimraf>glob: '>=11.1.0'
   image-size: ^1.2.1
   pbkdf2: '>=3.1.3'
   sha.js: '>=2.4.12'
@@ -7691,6 +7693,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  glob@13.0.0:
+    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
+    engines: {node: 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -9405,6 +9411,10 @@ packages:
 
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -21275,6 +21285,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  glob@13.0.0:
+    dependencies:
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      path-scurry: 2.0.0
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -23578,6 +23594,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -23608,7 +23628,7 @@ snapshots:
       commander: 9.5.0
       connection-string: 4.4.0
       date-fns: 2.30.0
-      glob: 10.4.5
+      glob: 11.0.3
       mongodb: 6.20.0(@aws-sdk/credential-providers@3.883.0)(socks@2.8.7)
       ora: 5.4.1
 
@@ -25485,15 +25505,15 @@ snapshots:
 
   rimraf@3.0.2:
     dependencies:
-      glob: 7.2.3
+      glob: 13.0.0
 
   rimraf@5.0.10:
     dependencies:
-      glob: 10.4.5
+      glob: 13.0.0
 
   rimraf@6.0.1:
     dependencies:
-      glob: 11.0.3
+      glob: 13.0.0
       package-json-from-dist: 1.0.1
 
   ripemd160@2.0.1:


### PR DESCRIPTION
FIXES RI-994

- Add role prop to AccessibleNavigation component
- Conditionally apply ARIA attributes when role is "presentation" or "none"
- Pass role="presentation" to LanguageSelector in QuickAccessMenu dropdown
- Remove redundant alt text from sponsor logo (decorative image)
- Fix import order and remove extra whitespace
- Extend LanguageSelectProps with HTMLAttributes for better type safety