### PR TITLE
chore(deps): add glob version overrides for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
       "@codegouvfr/react-dsfr": "1.20.2",
       "debug": "4.4.1",
       "form-data": ">=4.0.4",
+      "mongo-migrate-ts>glob": ">=10.5.0",
+      "rimraf>glob": ">=11.1.0",
       "image-size": "^1.2.1",
       "pbkdf2": ">=3.1.3",
       "sha.js": ">=2.4.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   '@codegouvfr/react-dsfr': 1.20.2
   debug: 4.4.1
   form-data: '>=4.0.4'
+  mongo-migrate-ts>glob: '>=10.5.0'
+  rimraf>glob: '>=11.1.0'
   image-size: ^1.2.1
   pbkdf2: '>=3.1.3'
   sha.js: '>=2.4.12'
@@ -7691,6 +7693,10 @@ packages:
     engines: {node: 20 || >=22}
     hasBin: true
 
+  glob@13.0.0:
+    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
+    engines: {node: 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -9405,6 +9411,10 @@ packages:
 
   minimatch@10.0.3:
     resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+    engines: {node: 20 || >=22}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -21275,6 +21285,12 @@ snapshots:
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.0
 
+  glob@13.0.0:
+    dependencies:
+      minimatch: 10.1.1
+      minipass: 7.1.2
+      path-scurry: 2.0.0
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -23578,6 +23594,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -23608,7 +23628,7 @@ snapshots:
       commander: 9.5.0
       connection-string: 4.4.0
       date-fns: 2.30.0
-      glob: 10.4.5
+      glob: 11.0.3
       mongodb: 6.20.0(@aws-sdk/credential-providers@3.883.0)(socks@2.8.7)
       ora: 5.4.1
 
@@ -25485,15 +25505,15 @@ snapshots:
 
   rimraf@3.0.2:
     dependencies:
-      glob: 7.2.3
+      glob: 13.0.0
 
   rimraf@5.0.10:
     dependencies:
-      glob: 10.4.5
+      glob: 13.0.0
 
   rimraf@6.0.1:
     dependencies:
-      glob: 11.0.3
+      glob: 13.0.0
       package-json-from-dist: 1.0.1
 
   ripemd160@2.0.1:


### PR DESCRIPTION
Add pnpm.overrides for mongo-migrate-ts>glob (>=10.5.0) and rimraf>glob (>=11.1.0) to address security vulnerabilities in transitive dependencies

Fixes: CVE-2025-64756
