### PR TITLE
fix: correct LinkedIn URL encoding in sitemap

### DIFF
--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -172,7 +172,7 @@ const PlanDuSite = () => {
         {
           id: "linkedin",
           label: t("sitemap.links.linkedin", "LinkedIn"),
-          href: "https://www.linkedin.com/showcase/r%C3%A9fugi%C3%A9s-info/",
+          href: "https://www.linkedin.com/showcase/r%C3%A9fugi%C3%A9s.info",
           isExternal: true,
         },
         {


### PR DESCRIPTION
- Updated LinkedIn URL from "r%C3%A9fugi%C3%A9s-info" to "r%C3%A9fugi%C3%A9s.info"
- Fixes incorrect URL encoding that used hyphen instead of period separator