### PR TITLE
docs: add setup-worktree workflow

### DIFF
--- a/.agent/workflows/setup-worktree.md
+++ b/.agent/workflows/setup-worktree.md
@@ -10,9 +10,7 @@ git worktree add .worktrees/<worktree-name> <branch-name>
 2. Copy .env files from the main workspace
 <!-- turbo -->
 ```bash
-cp .env .worktrees/<worktree-name>/.env
-cp apps/client/.env .worktrees/<worktree-name>/apps/client/.env
-cp apps/server/.env .worktrees/<worktree-name>/apps/server/.env
+rsync -R .env apps/client/.env apps/server/.env .worktrees/<worktree-name>/
 ```
 
 3. Install dependencies

--- a/.agent/workflows/setup-worktree.md
+++ b/.agent/workflows/setup-worktree.md
@@ -1,0 +1,22 @@
+---
+description: Setup a new git worktree with .env files
+---
+
+1. Create the worktree
+```bash
+git worktree add .worktrees/<worktree-name> <branch-name>
+```
+
+2. Copy .env files from the main workspace
+// turbo
+```bash
+cp .env .worktrees/<worktree-name>/.env
+cp apps/client/.env .worktrees/<worktree-name>/apps/client/.env
+cp apps/server/.env .worktrees/<worktree-name>/apps/server/.env
+```
+
+3. Install dependencies
+```bash
+cd .worktrees/<worktree-name>
+pnpm install
+```

--- a/.agent/workflows/setup-worktree.md
+++ b/.agent/workflows/setup-worktree.md
@@ -8,7 +8,7 @@ git worktree add .worktrees/<worktree-name> <branch-name>
 ```
 
 2. Copy .env files from the main workspace
-// turbo
+<!-- turbo -->
 ```bash
 cp .env .worktrees/<worktree-name>/.env
 cp apps/client/.env .worktrees/<worktree-name>/apps/client/.env


### PR DESCRIPTION
Adds a new workflow file `.agent/workflows/setup-worktree.md` to help with setting up git worktrees, including copying `.env` files.