### PR TITLE
chore: configure dependabot minimum package age

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Configures Dependabot to respect a 7-day cooldown for new package releases, aligning with pnpm workspace configuration.