### PR TITLE
feat: implement dispositif webhook

### DIFF
--- a/apps/client/src/pages/api/webhook/dispositif.ts
+++ b/apps/client/src/pages/api/webhook/dispositif.ts
@@ -1,4 +1,5 @@
 import { ContentType, DispositifStatus } from "@refugies-info/api-types";
+import crypto from "crypto";
 import mongoose from "mongoose";
 import type { NextApiRequest, NextApiResponse } from "next";
 import dbConnect from "~/lib/db";
@@ -9,7 +10,20 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 
   const secret = req.headers["webhook-secret"];
-  if (secret !== process.env.WEBHOOK_SECRET) {
+  const expectedSecret = process.env.WEBHOOK_SECRET;
+
+  if (!secret || !expectedSecret || typeof secret !== "string") {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  // Use timing-safe comparison to prevent timing attacks
+  const secretBuffer = Buffer.from(secret);
+  const expectedBuffer = Buffer.from(expectedSecret);
+
+  if (
+    secretBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(secretBuffer, expectedBuffer)
+  ) {
     return res.status(401).json({ message: "Unauthorized" });
   }
 

--- a/apps/client/src/pages/api/webhook/dispositif.ts
+++ b/apps/client/src/pages/api/webhook/dispositif.ts
@@ -1,0 +1,76 @@
+import { ContentType, DispositifStatus } from "@refugies-info/api-types";
+import mongoose from "mongoose";
+import type { NextApiRequest, NextApiResponse } from "next";
+import dbConnect from "~/lib/db";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method Not Allowed" });
+  }
+
+  const secret = req.headers["webhook-secret"];
+  if (secret !== process.env.WEBHOOK_SECRET) {
+    return res.status(401).json({ message: "Unauthorized" });
+  }
+
+  const { email, dispositif } = req.body;
+
+  if (!email || !dispositif) {
+    return res.status(400).json({ message: "Missing email or dispositif data" });
+  }
+
+  try {
+    const conn = await dbConnect();
+
+    // User Lookup
+    const User =
+      conn.models.User ||
+      conn.model("User", new mongoose.Schema({}, { strict: false, collection: "users" }));
+    const user = await User.findOne({ email });
+
+    if (!user) {
+      return res.status(404).json({ message: "User not found" });
+    }
+
+    // Dispositif Creation
+    // We use a loose schema as requested to avoid importing from apps/server
+    const Dispositif =
+      conn.models.Dispositif ||
+      conn.model(
+        "Dispositif",
+        new mongoose.Schema({}, { strict: false, collection: "dispositifs" }),
+      );
+
+    // Basic default fields if not present in payload, similar to createDispositif
+    const newDispositif = {
+      ...dispositif,
+      creatorId: user._id,
+      status: DispositifStatus.DRAFT,
+      typeContenu: dispositif.typeContenu || ContentType.DISPOSITIF,
+      created_at: new Date(),
+      lastModificationDate: new Date(),
+      lastModificationAuthor: user._id,
+      // Ensure translations structure exists if partially provided
+      translations: {
+        fr: {
+          content: dispositif.translations?.fr?.content || {},
+          created_at: new Date(),
+          validatorId: user._id,
+        },
+        ...dispositif.translations,
+      },
+    };
+
+    const createdDispositif = await Dispositif.create(newDispositif);
+
+    return res.status(201).json({
+      message: "Dispositif created successfully",
+      id: createdDispositif._id,
+    });
+  } catch (error: any) {
+    console.error("[Webhook] Error creating dispositif:", error);
+    return res.status(500).json({ message: "Internal Server Error", error: error.message });
+  }
+};
+
+export default handler;

--- a/apps/client/src/pages/api/webhook/dispositif.ts
+++ b/apps/client/src/pages/api/webhook/dispositif.ts
@@ -66,12 +66,12 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       lastModificationAuthor: user._id,
       // Ensure translations structure exists if partially provided
       translations: {
+        ...dispositif.translations,
         fr: {
           content: dispositif.translations?.fr?.content || {},
           created_at: new Date(),
           validatorId: user._id,
         },
-        ...dispositif.translations,
       },
     };
 
@@ -81,9 +81,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       message: "Dispositif created successfully",
       id: createdDispositif._id,
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error("[Webhook] Error creating dispositif:", error);
-    return res.status(500).json({ message: "Internal Server Error", error: error.message });
+    const errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
+    return res.status(500).json({ message: "Internal Server Error", error: errorMessage });
   }
 };
 

--- a/apps/server/example-env-file.env
+++ b/apps/server/example-env-file.env
@@ -33,3 +33,4 @@ SENDGRID_API_KEY=demo
 SLACK_WEBHOOK_URL=demo
 SMS_SENDER=demo
 TTS_KEY_1=demo
+WEBHOOK_SECRET=your_secret_here


### PR DESCRIPTION
Implements a secure webhook endpoint for Dispositif ingestion using a shared secret.

## Features

- **Endpoint**: `POST /api/webhook/dispositif` (Frontend API)
- **Security**: Validates `Webhook-Secret` header against `WEBHOOK_SECRET` env var
- **Logic**: 
  - Validates user email
  - Creates Dispositif in Draft status with provided data
  - Links creator and translations
  - Uses loose Mongoose schemas to avoid importing server models

## Verification

Tested with `curl`:
```bash
curl -X POST http://localhost:3000/api/webhook/dispositif \
  -H "Content-Type: application/json" \
  -H "Webhook-Secret: my-secret-token" \
  -d '{
    "email": "user@example.com",
    "dispositif": {
      "typeContenu": "dispositif",
      "translations": {
        "fr": {
          "content": {
            "titreInformatif": "Test Dispositif"
          }
        }
      }
    }
  }'
```