### PR TITLE
fix(client): prevent infinite fetchThemes loop

### DIFF
--- a/apps/client/src/__fixtures__/reduxStore.ts
+++ b/apps/client/src/__fixtures__/reduxStore.ts
@@ -94,6 +94,7 @@ export const initialMockStore = {
   themes: {
     activeThemes: activeThemesMock,
     inactiveThemes: [],
+    hasLoaded: true,
   },
   searchResults: initialMockSearchReults,
 };

--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -28,7 +28,7 @@ import {
   isLoadingSelector,
 } from "~/services/LoadingStatus/loadingStatus.selectors";
 import { fetchThemesActionCreator } from "~/services/Themes/themes.actions";
-import { themesSelector } from "~/services/Themes/themes.selectors";
+import { hasThemesLoadedSelector, themesSelector } from "~/services/Themes/themes.selectors";
 import { toggleSpinner } from "~/services/Tts/tts.actions";
 import { ttsActiveSelector } from "~/services/Tts/tts.selector";
 import { fetchUserActionCreator } from "~/services/User/user.actions";
@@ -207,13 +207,14 @@ const Layout = (props: Props) => {
 
   // THEMES
   const themes = useSelector(themesSelector);
+  const hasThemesLoaded = useSelector(hasThemesLoadedSelector);
   const isThemesLoading = useSelector(isLoadingSelector(LoadingStatusKey.FETCH_THEMES));
   const hasThemesError = useSelector(hasErroredSelector(LoadingStatusKey.FETCH_THEMES));
   useEffect(() => {
-    if (languageLoaded && themes.length === 0 && !isThemesLoading && !hasThemesError) {
+    if (languageLoaded && !hasThemesLoaded && !isThemesLoading && !hasThemesError) {
       dispatch(fetchThemesActionCreator());
     }
-  }, [languageLoaded, themes.length, isThemesLoading, hasThemesError, dispatch]);
+  }, [languageLoaded, hasThemesLoaded, isThemesLoading, hasThemesError, dispatch]);
 
   // LANGUAGES
   const langues = useSelector(allLanguesSelector);

--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -28,7 +28,7 @@ import {
   isLoadingSelector,
 } from "~/services/LoadingStatus/loadingStatus.selectors";
 import { fetchThemesActionCreator } from "~/services/Themes/themes.actions";
-import { hasThemesLoadedSelector, themesSelector } from "~/services/Themes/themes.selectors";
+import { hasThemesLoadedSelector } from "~/services/Themes/themes.selectors";
 import { toggleSpinner } from "~/services/Tts/tts.actions";
 import { ttsActiveSelector } from "~/services/Tts/tts.selector";
 import { fetchUserActionCreator } from "~/services/User/user.actions";

--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -206,7 +206,6 @@ const Layout = (props: Props) => {
   }, [user, isUserLoading, hasUserError, dispatch]);
 
   // THEMES
-  const themes = useSelector(themesSelector);
   const hasThemesLoaded = useSelector(hasThemesLoadedSelector);
   const isThemesLoading = useSelector(isLoadingSelector(LoadingStatusKey.FETCH_THEMES));
   const hasThemesError = useSelector(hasErroredSelector(LoadingStatusKey.FETCH_THEMES));

--- a/apps/client/src/services/Themes/themes.reducer.ts
+++ b/apps/client/src/services/Themes/themes.reducer.ts
@@ -6,11 +6,13 @@ import type { ThemesActions } from "./themes.actions";
 export type ThemesState = {
   activeThemes: GetThemeResponse[];
   inactiveThemes: GetThemeResponse[];
+  hasLoaded: boolean;
 };
 
 const initialThemesState: ThemesState = {
   activeThemes: [],
   inactiveThemes: [],
+  hasLoaded: false,
 };
 
 export const themesReducer = createReducer<ThemesState, ThemesActions>(initialThemesState, {
@@ -18,6 +20,7 @@ export const themesReducer = createReducer<ThemesState, ThemesActions>(initialTh
     return {
       activeThemes: action.payload.filter((t) => t.active),
       inactiveThemes: action.payload.filter((t) => !t.active),
+      hasLoaded: true,
     };
   },
 });

--- a/apps/client/src/services/Themes/themes.selectors.ts
+++ b/apps/client/src/services/Themes/themes.selectors.ts
@@ -3,6 +3,7 @@ import { createSelector } from "reselect";
 import type { RootState } from "../rootReducer";
 
 export const themesSelector = (state: RootState): GetThemeResponse[] => state.themes.activeThemes;
+export const hasThemesLoadedSelector = (state: RootState): boolean => state.themes.hasLoaded;
 
 const selectActiveThemes = (state: RootState): GetThemeResponse[] => state.themes.activeThemes;
 const selectInactiveThemes = (state: RootState): GetThemeResponse[] => state.themes.inactiveThemes;


### PR DESCRIPTION
# Description

Fixes an infinite loop issue where `fetchThemes` was called repeatedly when the API returned 0 themes.

## Changes

- Added `hasLoaded` flag to `ThemesState` in Redux.
- Updated `Layout.tsx` to rely on `hasThemesLoaded` selector instead of `themes.length === 0`.
- Updated tests validation for `initialMockStore`.

## Verification

- `pnpm check:types`: PASSED
- `pnpm lint`: PASSED