### PR TITLE
404 and theme regressions

### DIFF
--- a/apps/client/src/components/Pages/dispositif/LinkedThemes/LinkedThemes.tsx
+++ b/apps/client/src/components/Pages/dispositif/LinkedThemes/LinkedThemes.tsx
@@ -10,15 +10,15 @@ import { Event } from "~/lib/tracking";
 import { dispositifNeedsSelector } from "~/services/Needs/needs.selectors";
 import { selectedDispositifSelector } from "~/services/SelectedDispositif/selectedDispositif.selector";
 import {
+  allThemesSelector,
   secondaryThemesSelector,
   themeSelector,
-  themesSelector,
 } from "~/services/Themes/themes.selectors";
 
 const LinkedThemes = ({ className }: { className?: string }) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const themes = useSelector(themesSelector);
+  const themes = useSelector(allThemesSelector);
   const dispositif = useSelector(selectedDispositifSelector);
   const theme = useSelector(themeSelector(dispositif?.theme));
   const secondaryThemes = useSelector(secondaryThemesSelector(dispositif?.secondaryThemes));
@@ -53,10 +53,11 @@ const LinkedThemes = ({ className }: { className?: string }) => {
       {Array.isArray(needs) &&
         needs.map((need, i) => {
           const theme = themes.find((t) => t._id === need.theme._id);
+          if (!theme) return null;
           return (
             <li key={i}>
               <SearchThemeButton
-                theme={theme!}
+                theme={theme}
                 href={getPath("/recherche", "fr", `?${buildUrlQuery({ needs: [need._id] })}`)}
                 value={need[locale]?.text || need.fr.text}
                 onClick={() => Event("DISPO_VIEW", "click need", "Linked themes")}

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/Needs.tsx
@@ -13,7 +13,7 @@ import { activeDispositifsSelector } from "~/services/ActiveDispositifs/activeDi
 import { needsSelector } from "~/services/Needs/needs.selectors";
 import { addToQueryActionCreator } from "~/services/SearchResults/searchResults.actions";
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
-import { themesSelector } from "~/services/Themes/themes.selectors";
+import { allThemesSelector } from "~/services/Themes/themes.selectors";
 import NeedItem from "./NeedItem";
 import styles from "./Needs.module.css";
 import { ThemeMenuContext } from "./ThemeMenuContext";
@@ -26,7 +26,7 @@ const Needs = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
     useContext(ThemeMenuContext);
   const needs = useSelector(needsSelector);
   const allNeeds = useSelector(needsSelector);
-  const themes = useSelector(themesSelector);
+  const themes = useSelector(allThemesSelector);
   const { t } = useTranslation();
   const needsContainerRef = useRef<HTMLDivElement | null>(null);
   const eventName = useSearchEventName();

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeMenu.tsx
@@ -9,7 +9,7 @@ import { sortThemes } from "~/lib/sortThemes";
 import { Event } from "~/lib/tracking";
 import { needsSelector } from "~/services/Needs/needs.selectors";
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
-import { themesSelector } from "~/services/Themes/themes.selectors";
+import { allThemesSelector } from "~/services/Themes/themes.selectors";
 import { useSearchCounts } from "../SearchCountsContext";
 import { getInitialTheme } from "./functions";
 import Needs from "./Needs";
@@ -32,7 +32,7 @@ const ThemeMenu = ({ mobile, isOpen, className }: Props) => {
   const themesContainerRef = useRef<HTMLDivElement | null>(null);
   const needsContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const themes = useSelector(themesSelector);
+  const themes = useSelector(allThemesSelector);
   const sortedThemes = themes.sort(sortThemes);
   const needs = useSelector(needsSelector);
   const query = useSelector(searchQuerySelector);

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/Themes.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/Themes.tsx
@@ -8,14 +8,14 @@ import { useLocale } from "~/hooks";
 import { sortThemes } from "~/lib/sortThemes";
 import { needsSelector } from "~/services/Needs/needs.selectors";
 import { searchQuerySelector } from "~/services/SearchResults/searchResults.selector";
-import { themesSelector } from "~/services/Themes/themes.selectors";
+import { allThemesSelector } from "~/services/Themes/themes.selectors";
 import ThemeItem from "./ThemeItem";
 import { ThemeMenuContext } from "./ThemeMenuContext";
 import styles from "./Themes.module.css";
 
 const Themes = React.forwardRef<HTMLDivElement | null, {}>((props, ref) => {
   const { selectedThemeId } = useContext(ThemeMenuContext);
-  const themes = useSelector(themesSelector);
+  const themes = useSelector(allThemesSelector);
   const sortedThemes = useMemo(() => themes.sort(sortThemes), [themes]);
   const [nbNeedsSelectedByTheme, setNbNeedsSelectedByTheme] = useState<Record<string, number>>({});
   const locale = useLocale();

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -16,7 +16,7 @@ import { getRelativeTimeString } from "~/lib/getRelativeDate";
 import { getTheme } from "~/lib/getTheme";
 import { getPath } from "~/routes";
 import styles from "~/scss/components/contentCard.module.scss";
-import { themesSelector } from "~/services/Themes/themes.selectors";
+import { allThemesSelector } from "~/services/Themes/themes.selectors";
 import { NewThemeBadge } from "../NewThemeBadge";
 
 interface Props {
@@ -30,7 +30,7 @@ interface Props {
 const DispositifCard = (props: Props) => {
   const { t } = useTranslation();
   const locale = useLocale();
-  const themes = useSelector(themesSelector);
+  const themes = useSelector(allThemesSelector);
   const isDispositif = useMemo(
     () => props.dispositif.typeContenu === ContentType.DISPOSITIF,
     [props.dispositif.typeContenu],

--- a/apps/client/src/services/Themes/themes.selectors.ts
+++ b/apps/client/src/services/Themes/themes.selectors.ts
@@ -14,24 +14,17 @@ export const allThemesSelector = createSelector(
 
 export const themeSelector = (themeId: Id | undefined) => (state: RootState) => {
   if (!themeId) return null;
-  const theme =
-    state.themes.activeThemes.find((theme) => theme._id === themeId) ||
-    state.themes.inactiveThemes.find((theme) => theme._id === themeId);
-
-  return theme || null;
+  return allThemesSelector(state).find((theme) => theme._id === themeId) || null;
 };
 
 export const secondaryThemesSelector =
   (themeIds: Id[] | undefined) =>
   (state: RootState): GetThemeResponse[] => {
     if (!themeIds) return [];
+    const allThemes = allThemesSelector(state);
     const themes = themeIds
-      .map(
-        (themeId) =>
-          state.themes.activeThemes.find((theme) => theme._id === themeId) ||
-          state.themes.inactiveThemes.find((theme) => theme._id === themeId),
-      )
-      .filter((t) => t !== undefined) as GetThemeResponse[];
+      .map((themeId) => allThemes.find((theme) => theme._id === themeId))
+      .filter((t): t is GetThemeResponse => t !== undefined);
 
     return themes;
   };

--- a/apps/client/src/services/Themes/themes.selectors.ts
+++ b/apps/client/src/services/Themes/themes.selectors.ts
@@ -14,7 +14,9 @@ export const allThemesSelector = createSelector(
 
 export const themeSelector = (themeId: Id | undefined) => (state: RootState) => {
   if (!themeId) return null;
-  const theme = state.themes.activeThemes.find((theme) => theme._id === themeId);
+  const theme =
+    state.themes.activeThemes.find((theme) => theme._id === themeId) ||
+    state.themes.inactiveThemes.find((theme) => theme._id === themeId);
 
   return theme || null;
 };
@@ -24,7 +26,11 @@ export const secondaryThemesSelector =
   (state: RootState): GetThemeResponse[] => {
     if (!themeIds) return [];
     const themes = themeIds
-      .map((themeId) => state.themes.activeThemes.find((theme) => theme._id === themeId))
+      .map(
+        (themeId) =>
+          state.themes.activeThemes.find((theme) => theme._id === themeId) ||
+          state.themes.inactiveThemes.find((theme) => theme._id === themeId),
+      )
       .filter((t) => t !== undefined) as GetThemeResponse[];
 
     return themes;

--- a/apps/server/src/workflows/dispositif/getContentById/getContentById.ts
+++ b/apps/server/src/workflows/dispositif/getContentById/getContentById.ts
@@ -105,15 +105,6 @@ export const getContentById = async (
     hasDraftVersion: 1,
     administrationLogo: 1,
     origin: 1,
-
-    "translations.fr.content.markdown": 1,
-    "translations.en.content.markdown": 1,
-    "translations.ar.content.markdown": 1,
-    "translations.ps.content.markdown": 1,
-    "translations.uk.content.markdown": 1,
-    "translations.ti.content.markdown": 1,
-    "translations.ru.content.markdown": 1,
-    "translations.fa.content.markdown": 1,
   };
   let draftDispositif = null;
   const originalDispositif = await (await getDispositifById(id, fields))?.populate<{


### PR DESCRIPTION
## Fix Mongoose projection collision causing 500 error
Fixed a "Path collision" error in [getContentById](cci:1://file:///Users/jeremie/refugies.info/karfur/apps/server/src/workflows/dispositif/getContentById/getContentById.ts:76:0-203:2) where `translations.fr.content.markdown` conflicted with `translations: 1`.
Removed the redundant individual field projections since `translations: 1` already covers them. This resolves the 500 error (seen as 404 by the client) on `/demarche/:id`.

## Fix inactive themes display
### Bug
Content associated with inactive themes was displaying "Aucun thème" or generic badges on the Banner, Cards, and Linked Themes list.
### Cause
Frontend selectors ([themeSelector](cci:1://file:///Users/jeremie/refugies.info/karfur/apps/client/src/services/Themes/themes.selectors.ts:14:0-21:2), [DispositifCard](cci:1://file:///Users/jeremie/refugies.info/karfur/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx:29:0-213:2)) were strictly querying the [activeThemes](cci:1://file:///Users/jeremie/refugies.info/karfur/apps/client/src/services/Themes/themes.selectors.ts:8:0-8:99) list. When a theme was deactivated in the backend, it became unresolvable for display purposes.
### Fix
Updated selectors and components to lookup themes in both [activeThemes](cci:1://file:///Users/jeremie/refugies.info/karfur/apps/client/src/services/Themes/themes.selectors.ts:8:0-8:99) and `inactiveThemes` lists ensures valid display for historical content while keeping creation flows restricted to active themes.