### PR TITLE
Preview Party : Le Content Playground débarque sur RI !

### DIFF
--- a/apps/client/src/components/Content/Dispositif/Dispositif.tsx
+++ b/apps/client/src/components/Content/Dispositif/Dispositif.tsx
@@ -46,7 +46,7 @@ const Dispositif = (props: Props) => {
   const theme = useSelector((state: RootState) => selectTheme(state, dispositif?.theme));
   const { isRTL } = useContentLocale();
   useScrolledBottomEvent(pageContext.mode === "view");
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const typeContenu = useMemo(
     () => props.typeContenu || dispositif?.typeContenu || ContentType.DISPOSITIF,
@@ -78,30 +78,14 @@ const Dispositif = (props: Props) => {
             dir={isRTL ? undefined : "ltr"}
             aria-labelledby="main-title"
           >
-            {dispositif?.origin === "RCO" ? (
-              <div className="fr-callout fr-callout--info">
-                {dispositif.markdown ? (
-                  <div className="prose no-dsfr">
-                    <ReactMarkdown remarkPlugins={[remarkGfm]}>{dispositif.markdown}</ReactMarkdown>
-                  </div>
-                ) : (
-                  <p className="fr-callout__text">
-                    Ce contenu est généré par intelligence artificielle et est actuellement en cours
-                    de validation. Les informations présentées sont fournies à titre indicatif et
-                    peuvent ne pas refléter la situation actuelle des dispositifs d'aide.
-                  </p>
-                )}
-              </div>
-            ) : (
-              CONTENT_STRUCTURES[typeContenu].map((section, i) => (
-                <Section
-                  key={i}
-                  sectionKey={section}
-                  contentType={typeContenu}
-                  className={cn(i === 0 && "z-10")}
-                />
-              ))
-            )}
+            {CONTENT_STRUCTURES[typeContenu].map((section, i) => (
+              <Section
+                key={i}
+                sectionKey={section}
+                contentType={typeContenu}
+                className={cn(i === 0 && "z-10")}
+              />
+            ))}
             {/* TODO: adapt the Map component to be used in edit mode */}
             {isViewMode ? (
               (dispositif?.map || []).length > 0 && <MapNew data={dispositif?.map || []} />

--- a/apps/client/src/components/Content/Dispositif/__tests__/Dispositif.rco.test.tsx
+++ b/apps/client/src/components/Content/Dispositif/__tests__/Dispositif.rco.test.tsx
@@ -115,8 +115,5 @@ describe("Dispositif RCO", () => {
     });
 
     expect(screen.queryByTestId("react-markdown")).not.toBeInTheDocument();
-    expect(
-      screen.getByText(/Ce contenu est généré par intelligence artificielle/i),
-    ).toBeInTheDocument();
   });
 });

--- a/apps/client/src/components/Layout/Layout.tsx
+++ b/apps/client/src/components/Layout/Layout.tsx
@@ -1,3 +1,4 @@
+import Alert from "@codegouvfr/react-dsfr/Alert";
 import { cn } from "@refugies-info/ui";
 import { useRouter } from "next/router";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -273,6 +274,15 @@ const Layout = (props: Props) => {
       {!showLangModal && <ConsentBannerAndConsentManagement />}
       <DownloadAppBanner />
       <Navbar />
+      {router.pathname.includes("/preview") && (
+        <Alert
+          severity="error"
+          title="Mode prévisualisation"
+          description="Vous êtes en mode prévisualisation. Les changements ne sont pas encore publiés."
+          className="fr-mb-0"
+          small
+        />
+      )}
       <main id="contenu" className={cn(styles.content, props.className)}>
         {props.children}
       </main>

--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
@@ -116,7 +116,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
             <li>
               {dispositif.typeContenu === ContentType.DISPOSITIF && (
                 <span className="text-active-grey" aria-current="page">
-                  {`${dispositif.titreMarque || ""} ${getDepartments(dispositif.metadatas.location, t)}`}
+                  {`${dispositif.titreMarque || dispositif.titreInformatif || ""} ${getDepartments(dispositif.metadatas.location, t)}`}
                 </span>
               )}
               {dispositif.typeContenu === ContentType.DEMARCHE && (

--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/StatusAndEditButtons.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/StatusAndEditButtons.tsx
@@ -52,13 +52,16 @@ const StatusAndEditButtons = ({ dispositif }: Props) => {
             hasDraftVersion={!!dispositif.hasDraftVersion}
             isAdmin={user.admin}
             className="me-4"
+            text={router.pathname.includes("/preview") ? "PRÉVISUALISATION" : undefined}
           />
-          <button
-            className="fr-btn fr-btn--icon-right fr-icon-edit-line fr-btn--sm"
-            onClick={onEditClick}
-          >
-            Modifier la fiche
-          </button>
+          {!router.pathname.includes("/preview") && (
+            <button
+              className="fr-btn fr-btn--icon-right fr-icon-edit-line fr-btn--sm"
+              onClick={onEditClick}
+            >
+              Modifier la fiche
+            </button>
+          )}
           <EditModal
             show={showEditModal}
             toggle={() => setShowEditModal((o) => !o)}

--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -47,10 +47,7 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
     if (!dispositif?.origin || dispositif.origin === "RI") return null;
     const translationContent = dispositif.translations?.[i18n.language as Languages]?.content;
     return (
-      dispositif.markdown ||
-      (translationContent && "markdown" in translationContent
-        ? translationContent.markdown
-        : undefined)
+      dispositif.markdown || (dispositif as any).translations?.[i18n.language]?.content?.markdown
     );
   }, [sectionKey, dispositif, i18n.language]);
 
@@ -94,13 +91,10 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
             {contentHtml && isViewMode && !markdown && (
               <SectionButtons id={sectionKey} className="mb-6 md:hidden" content={contentHtml} />
             )}
+
             {markdown ? (
               <div className="prose no-dsfr">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
-              </div>
-            ) : dispositif?.origin === "RCO" ? (
-              <div className="text-mention-grey italic">
-                Ce contenu est généré par intelligence artificielle
               </div>
             ) : (
               <RichText id={sectionKey} value={contentHtml} />

--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -98,6 +98,10 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
               <div className="prose no-dsfr">
                 <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
               </div>
+            ) : dispositif?.origin === "RCO" ? (
+              <div className="text-mention-grey italic">
+                Ce contenu est généré par intelligence artificielle
+              </div>
             ) : (
               <RichText id={sectionKey} value={contentHtml} />
             )}

--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -57,6 +57,7 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
   );
 
   if (
+    isViewMode &&
     sectionKey !== "what" &&
     (!contentAccordions || Object.keys(contentAccordions).length === 0)
   ) {

--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -1,4 +1,4 @@
-import { ContentType, type InfoSections } from "@refugies-info/api-types";
+import { ContentType, type InfoSections, type Languages } from "@refugies-info/api-types";
 import { useWindowSize } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import type React from "react";
@@ -45,8 +45,12 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
   const markdown = useMemo(() => {
     if (sectionKey !== "what") return null;
     if (!dispositif?.origin || dispositif.origin === "RI") return null;
+    const translationContent = dispositif.translations?.[i18n.language as Languages]?.content;
     return (
-      dispositif.markdown || (dispositif as any).translations?.[i18n.language]?.content?.markdown
+      dispositif.markdown ||
+      (translationContent && "markdown" in translationContent
+        ? translationContent.markdown
+        : undefined)
     );
   }, [sectionKey, dispositif, i18n.language]);
 

--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -3,7 +3,9 @@ import { useWindowSize } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import type React from "react";
 import { useContext, useMemo } from "react";
+import ReactMarkdown from "react-markdown";
 import { useSelector } from "react-redux";
+import remarkGfm from "remark-gfm";
 import { Header, Metadatas } from "~/components/Pages/dispositif";
 import { cn } from "~/lib/classname";
 import type { RootState } from "~/services/rootReducer";
@@ -28,7 +30,7 @@ const DEFAULT_COLOR_30 = "#ccc";
  * Shows a section of a dispositif. Can display a rich text or InfoSections. Can be used in VIEW or EDIT mode.
  */
 const Section = ({ sectionKey, contentType, className }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const dispositif = useSelector(selectedDispositifSelector);
   const pageContext = useContext(PageContext);
   const isViewMode = useMemo(() => pageContext.mode === "view", [pageContext.mode]);
@@ -40,10 +42,25 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
     [sectionKey, dispositif],
   );
 
+  const markdown = useMemo(() => {
+    if (sectionKey !== "what") return null;
+    if (!dispositif?.origin || dispositif.origin === "RI") return null;
+    return (
+      dispositif.markdown || (dispositif as any).translations?.[i18n.language]?.content?.markdown
+    );
+  }, [sectionKey, dispositif, i18n.language]);
+
   const contentAccordions: InfoSections | undefined = useMemo(
     () => (sectionKey !== "what" ? dispositif?.[sectionKey] : undefined),
     [sectionKey, dispositif],
   );
+
+  if (
+    sectionKey !== "what" &&
+    (!contentAccordions || Object.keys(contentAccordions).length === 0)
+  ) {
+    return null;
+  }
 
   // colors
   const selectTheme = useMemo(makeThemeSelector, []);
@@ -70,10 +87,16 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
         {sectionKey === "what" ? (
           <>
             <Header typeContenu={contentType || ContentType.DISPOSITIF} />
-            {contentHtml && isViewMode && (
+            {contentHtml && isViewMode && !markdown && (
               <SectionButtons id={sectionKey} className="mb-6 md:hidden" content={contentHtml} />
             )}
-            <RichText id={sectionKey} value={contentHtml} />
+            {markdown ? (
+              <div className="prose no-dsfr">
+                <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+              </div>
+            ) : (
+              <RichText id={sectionKey} value={contentHtml} />
+            )}
           </>
         ) : (
           <>

--- a/apps/client/src/pages/dispositif/preview.tsx
+++ b/apps/client/src/pages/dispositif/preview.tsx
@@ -29,7 +29,6 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     };
   }
 
-  // Verify Webhook Secret
   const secret = req.headers["webhook-secret"];
   const expectedSecret = process.env.WEBHOOK_SECRET;
 
@@ -54,7 +53,6 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
   }
 
   try {
-    // Parse the request body
     const chunks = [];
     for await (const chunk of req) {
       chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
@@ -65,9 +63,7 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     try {
       payload = JSON.parse(bodyContent);
     } catch (e) {
-      // Attempt to parse as form-urlencoded if raw JSON failed
       try {
-        // We can use URLSearchParams to parse form data
         const params = new URLSearchParams(bodyContent);
         const jsonParam = params.get("json");
         if (jsonParam) {
@@ -88,10 +84,6 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
       throw new Error("Missing dispositif data");
     }
 
-    // Construct the preview dispositif object
-    // Use a temporary ID and default fields similar to how we create it
-    // Construct the preview dispositif object
-    // We cast to GetDispositifResponse and provide defaults for required fields
     const previewDispositif: GetDispositifResponse = {
       ...dispositif,
       _id: "preview-id",
@@ -111,37 +103,26 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
         ...dispositif.translations,
         fr: {
           content: dispositif.translations?.fr?.content || {},
-          created_at: new Date().toISOString(),
+          created_at: new Date().toISOString() as unknown as Date,
         },
       },
     } as unknown as GetDispositifResponse;
 
-    // Populate the Redux store with the preview data
     store.dispatch(setSelectedDispositifActionCreator(previewDispositif));
 
-    // Fetch necessary supporting data
     store.dispatch(fetchThemesActionCreator());
     store.dispatch(fetchNeedsActionCreator());
     if (req.headers.cookie && req.headers.cookie.includes("authorization")) {
-      // simplified cookie check or just pass token if extracted
-      // We can access req.cookies directly if we use the proper type or middleware,
-      // but here we just rely on what is available.
-      // wrapper's getServerSideProps usually has req.cookies populated by next.js
       const token = (req as any).cookies?.authorization;
       if (token) {
         store.dispatch(fetchUserActionCreator({ token }));
       }
     }
 
-    // Wait for sagas to complete
     store.dispatch(END);
     await store.sagaTask?.toPromise();
   } catch (error) {
     console.error("[Preview] Error handling preview request:", error);
-    // We throw to see the 500 error stack trace in server logs,
-    // OR we could return props with an error.
-    // Returning 404 might hide the real issue.
-    // Let's rethrow to generate a 500 so we can see it in logs if the user checks.
     throw error;
   }
 

--- a/apps/client/src/pages/dispositif/preview.tsx
+++ b/apps/client/src/pages/dispositif/preview.tsx
@@ -29,13 +29,64 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
     };
   }
 
-  const secret = req.headers["webhook-secret"];
+  let payload;
+  let bodySecret: string | undefined;
+
+  try {
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    const bodyContent = Buffer.concat(chunks).toString("utf-8");
+
+    try {
+      // Try parsing as raw JSON
+      const jsonBody = JSON.parse(bodyContent);
+      payload = jsonBody;
+      if (jsonBody["webhook-secret"]) {
+        bodySecret = jsonBody["webhook-secret"];
+      }
+    } catch (e) {
+      try {
+        // Try parsing as Form Data
+        const params = new URLSearchParams(bodyContent);
+        const jsonParam = params.get("json");
+        const secretParam = params.get("webhook-secret");
+
+        if (jsonParam) {
+          payload = JSON.parse(jsonParam);
+        } else {
+          throw new Error("No 'json' parameter found in form data");
+        }
+
+        if (secretParam) {
+          bodySecret = secretParam;
+        }
+      } catch (formError) {
+        console.error("[Preview] Failed to parse body as JSON or form-encoded 'json':", e);
+        throw new Error("Invalid structure: Expected JSON body or form-data with 'json' key");
+      }
+    }
+  } catch (error) {
+    console.error("[Preview] Error reading/parsing body:", error);
+    return { notFound: true };
+  }
+
+  let secret = req.headers["webhook-secret"];
   const expectedSecret = process.env.WEBHOOK_SECRET;
+
+  // Priority: Header > Separate Body Param > Payload Field
+  if (!secret && bodySecret) {
+    secret = bodySecret;
+  }
+  if (!secret && payload && payload["webhook-secret"]) {
+    secret = payload["webhook-secret"];
+  }
 
   if (!secret || !expectedSecret || typeof secret !== "string") {
     console.log("[Preview] Unauthorized: Missing or invalid secret");
     return {
-      notFound: true, // Hide the existence of the page or return 401 via props if preferred
+      notFound: true,
     };
   }
 
@@ -53,30 +104,6 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
   }
 
   try {
-    const chunks = [];
-    for await (const chunk of req) {
-      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-    }
-    const bodyContent = Buffer.concat(chunks).toString("utf-8");
-
-    let payload;
-    try {
-      payload = JSON.parse(bodyContent);
-    } catch (e) {
-      try {
-        const params = new URLSearchParams(bodyContent);
-        const jsonParam = params.get("json");
-        if (jsonParam) {
-          payload = JSON.parse(jsonParam);
-        } else {
-          throw new Error("No 'json' parameter found in form data");
-        }
-      } catch (formError) {
-        console.error("[Preview] Failed to parse body as JSON or form-encoded 'json':", e);
-        throw new Error("Invalid structure: Expected JSON body or form-data with 'json' key");
-      }
-    }
-
     const { dispositif } = payload;
 
     if (!dispositif) {

--- a/apps/client/src/pages/dispositif/preview.tsx
+++ b/apps/client/src/pages/dispositif/preview.tsx
@@ -1,0 +1,155 @@
+import type { GetDispositifResponse } from "@refugies-info/api-types";
+import { ContentType, DispositifStatus } from "@refugies-info/api-types";
+// ... imports ...
+import crypto from "crypto";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { END } from "redux-saga";
+import Dispositif from "~/components/Content/Dispositif";
+import { getLanguageFromLocale } from "~/lib/getLanguageFromLocale";
+import { wrapper } from "~/services/configureStore";
+import { fetchNeedsActionCreator } from "~/services/Needs/needs.actions";
+import { setSelectedDispositifActionCreator } from "~/services/SelectedDispositif/selectedDispositif.actions";
+import { fetchThemesActionCreator } from "~/services/Themes/themes.actions";
+import { fetchUserActionCreator } from "~/services/User/user.actions";
+import PageContext from "~/utils/pageContext";
+
+const PreviewPage = () => {
+  return (
+    <PageContext.Provider value={{ mode: "view" }}>
+      <Dispositif />
+    </PageContext.Provider>
+  );
+};
+
+export const getServerSideProps = wrapper.getServerSideProps((store) => async ({ req, locale }) => {
+  if (req.method !== "POST") {
+    console.log("[Preview] Method not allowed:", req.method);
+    return {
+      notFound: true,
+    };
+  }
+
+  // Verify Webhook Secret
+  const secret = req.headers["webhook-secret"];
+  const expectedSecret = process.env.WEBHOOK_SECRET;
+
+  if (!secret || !expectedSecret || typeof secret !== "string") {
+    console.log("[Preview] Unauthorized: Missing or invalid secret");
+    return {
+      notFound: true, // Hide the existence of the page or return 401 via props if preferred
+    };
+  }
+
+  const secretBuffer = Buffer.from(secret);
+  const expectedBuffer = Buffer.from(expectedSecret);
+
+  if (
+    secretBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(secretBuffer, expectedBuffer)
+  ) {
+    console.log("[Preview] Unauthorized: Invalid secret");
+    return {
+      notFound: true,
+    };
+  }
+
+  try {
+    // Parse the request body
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+    }
+    const bodyContent = Buffer.concat(chunks).toString("utf-8");
+
+    let payload;
+    try {
+      payload = JSON.parse(bodyContent);
+    } catch (e) {
+      // Attempt to parse as form-urlencoded if raw JSON failed
+      try {
+        // We can use URLSearchParams to parse form data
+        const params = new URLSearchParams(bodyContent);
+        const jsonParam = params.get("json");
+        if (jsonParam) {
+          payload = JSON.parse(jsonParam);
+        } else {
+          throw new Error("No 'json' parameter found in form data");
+        }
+      } catch (formError) {
+        console.error("[Preview] Failed to parse body as JSON or form-encoded 'json':", e);
+        throw new Error("Invalid structure: Expected JSON body or form-data with 'json' key");
+      }
+    }
+
+    const { dispositif } = payload;
+
+    if (!dispositif) {
+      console.error("[Preview] Missing dispositif in payload");
+      throw new Error("Missing dispositif data");
+    }
+
+    // Construct the preview dispositif object
+    // Use a temporary ID and default fields similar to how we create it
+    // Construct the preview dispositif object
+    // We cast to GetDispositifResponse and provide defaults for required fields
+    const previewDispositif: GetDispositifResponse = {
+      ...dispositif,
+      _id: "preview-id",
+      status: DispositifStatus.DRAFT,
+      typeContenu: dispositif.typeContenu || ContentType.DISPOSITIF,
+      created_at: new Date().toISOString() as unknown as Date,
+      lastModificationDate: new Date().toISOString() as unknown as Date,
+      date: new Date().toISOString() as unknown as Date,
+      needs: dispositif.needs || [],
+      secondaryThemes: dispositif.secondaryThemes || [],
+      metadatas: dispositif.metadatas || {},
+      avis: [],
+      availableLanguages: [],
+      creatorId: { _id: "preview-creator", username: "Preview User" },
+      // Ensure we don't overwrite if not present, but mock if needed
+      translations: {
+        ...dispositif.translations,
+        fr: {
+          content: dispositif.translations?.fr?.content || {},
+          created_at: new Date().toISOString(),
+        },
+      },
+    } as unknown as GetDispositifResponse;
+
+    // Populate the Redux store with the preview data
+    store.dispatch(setSelectedDispositifActionCreator(previewDispositif));
+
+    // Fetch necessary supporting data
+    store.dispatch(fetchThemesActionCreator());
+    store.dispatch(fetchNeedsActionCreator());
+    if (req.headers.cookie && req.headers.cookie.includes("authorization")) {
+      // simplified cookie check or just pass token if extracted
+      // We can access req.cookies directly if we use the proper type or middleware,
+      // but here we just rely on what is available.
+      // wrapper's getServerSideProps usually has req.cookies populated by next.js
+      const token = (req as any).cookies?.authorization;
+      if (token) {
+        store.dispatch(fetchUserActionCreator({ token }));
+      }
+    }
+
+    // Wait for sagas to complete
+    store.dispatch(END);
+    await store.sagaTask?.toPromise();
+  } catch (error) {
+    console.error("[Preview] Error handling preview request:", error);
+    // We throw to see the 500 error stack trace in server logs,
+    // OR we could return props with an error.
+    // Returning 404 might hide the real issue.
+    // Let's rethrow to generate a 500 so we can see it in logs if the user checks.
+    throw error;
+  }
+
+  return {
+    props: {
+      ...(await serverSideTranslations(getLanguageFromLocale(locale), ["common"])),
+    },
+  };
+});
+
+export default PreviewPage;

--- a/apps/client/src/pages/dispositif/test-preview.tsx
+++ b/apps/client/src/pages/dispositif/test-preview.tsx
@@ -1,4 +1,5 @@
 import Button from "@codegouvfr/react-dsfr/Button";
+import type { GetServerSideProps } from "next";
 import { useState } from "react";
 
 const DEFAULT_JSON = {
@@ -90,7 +91,12 @@ const TestPreviewPage = (props: Props) => {
   );
 };
 
-export const getServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const token = req.cookies.authorization;
+  if (!token) {
+    return { notFound: true };
+  }
+
   return {
     props: {
       webhookSecret: process.env.WEBHOOK_SECRET || "",

--- a/apps/client/src/pages/dispositif/test-preview.tsx
+++ b/apps/client/src/pages/dispositif/test-preview.tsx
@@ -92,6 +92,11 @@ const TestPreviewPage = (props: Props) => {
 };
 
 export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  // Block access in production
+  if (process.env.NODE_ENV === "production") {
+    return { notFound: true };
+  }
+
   const token = req.cookies.authorization;
   if (!token) {
     return { notFound: true };

--- a/apps/client/src/pages/dispositif/test-preview.tsx
+++ b/apps/client/src/pages/dispositif/test-preview.tsx
@@ -4,12 +4,25 @@ import { useState } from "react";
 const DEFAULT_JSON = {
   dispositif: {
     typeContenu: "dispositif",
-    theme: "sante",
-    titreInformatif: "Titre prévisualisé",
+    theme: "63286a015d31b2c0cad99615",
+    titreInformatif: "Certificat de capacité à l'enseignement du français langue étrangère - FLE",
+    origin: "RCO",
     translations: {
       fr: {
         content: {
-          markdown: "Contenu markdown",
+          markdown: `
+## Objectifs
+
+Acquérir et développer les compétences et savoir-faire pédagogiques nécessaires à l'enseignement du français langue étrangère.
+
+## Contenu
+
+Gérer la classe et maîtriser les outils de la classe : 
+- Maîtriser les techniques d'animation et de gestion de classe - Favoriser les interactions authentiques en langue cible - Savoir utiliser des outils numériques simples pour la classe - Utiliser des supports et documents complémentaires (documents télévisuels, presse écrite, radio) - Connaître les ressources pédagogiques disponibles pour l'enseignant et l'apprenant. 
+Construire un cours : 
+- Planifier un cours et une progression - Cibler les activités sur des compétences visées - Enrichir le manuel avec des documents authentiques. Évaluer les apprenants par compétences : - Connaître les différentes formes d'évaluation - Utiliser l'évaluation comme outil de motivation - Identifier les erreurs et proposer des pistes de correction - Évaluer les apprenants sur la base du Cadre européen commun de référence (CECR).
+
+`,
         },
       },
     },

--- a/apps/client/src/pages/dispositif/test-preview.tsx
+++ b/apps/client/src/pages/dispositif/test-preview.tsx
@@ -1,0 +1,88 @@
+import Button from "@codegouvfr/react-dsfr/Button";
+import { useState } from "react";
+
+const DEFAULT_JSON = {
+  dispositif: {
+    typeContenu: "dispositif",
+    theme: "sante",
+    titreInformatif: "Titre prévisualisé",
+    translations: {
+      fr: {
+        content: {
+          markdown: "Contenu markdown",
+        },
+      },
+    },
+  },
+};
+
+interface Props {
+  webhookSecret: string;
+}
+
+const TestPreviewPage = (props: Props) => {
+  const [json, setJson] = useState(JSON.stringify(DEFAULT_JSON, null, 2));
+
+  return (
+    <div className="container py-8">
+      <h1>Test Preview</h1>
+      <p>Copiez le JSON ci-dessous et cliquez sur "Prévisualiser" pour tester la page de rendu.</p>
+
+      <form action="/dispositif/preview" method="POST" target="_blank" rel="noopener">
+        <div className="fr-input-group">
+          <label className="fr-label" htmlFor="json-input">
+            Charge utile JSON (doit contenir "dispositif")
+          </label>
+          <textarea
+            className="fr-input mb-4"
+            id="json-input"
+            name="json"
+            rows={20}
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
+            style={{ fontFamily: "monospace" }}
+          />
+        </div>
+      </form>
+
+      <Button
+        onClick={async () => {
+          try {
+            const response = await fetch("/dispositif/preview", {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "webhook-secret": props.webhookSecret,
+              },
+              body: json,
+            });
+            const html = await response.text();
+
+            // Open in new window
+            const win = window.open("", "_blank");
+            if (win) {
+              win.document.write(html);
+              win.document.close();
+            } else {
+              alert("Please allow popups for this site");
+            }
+          } catch (e) {
+            alert("Error: " + e);
+          }
+        }}
+      >
+        Prévisualiser (Fetch + New Tab)
+      </Button>
+    </div>
+  );
+};
+
+export const getServerSideProps = async () => {
+  return {
+    props: {
+      webhookSecret: process.env.WEBHOOK_SECRET || "",
+    },
+  };
+};
+
+export default TestPreviewPage;

--- a/apps/client/src/pages/dispositif/test-preview.tsx
+++ b/apps/client/src/pages/dispositif/test-preview.tsx
@@ -43,6 +43,7 @@ const TestPreviewPage = (props: Props) => {
       <p>Copiez le JSON ci-dessous et cliquez sur "Prévisualiser" pour tester la page de rendu.</p>
 
       <form action="/dispositif/preview" method="POST" target="_blank" rel="noopener">
+        <input type="hidden" name="webhook-secret" value={props.webhookSecret} />
         <div className="fr-input-group">
           <label className="fr-label" htmlFor="json-input">
             Charge utile JSON (doit contenir "dispositif")
@@ -57,6 +58,9 @@ const TestPreviewPage = (props: Props) => {
             style={{ fontFamily: "monospace" }}
           />
         </div>
+        <Button className="mb-4" type="submit">
+          Prévisualiser (Form POST - Cross-Origin Safe)
+        </Button>
       </form>
 
       <Button

--- a/apps/server/src/libs/wordCounter.ts
+++ b/apps/server/src/libs/wordCounter.ts
@@ -23,7 +23,7 @@ export const countWords = (str?: string): number =>
         .filter((w) => !!w).length
     : 0;
 
-export const countWordsForInfoSections = (infoSections: InfoSections): number =>
+export const countWordsForInfoSections = (infoSections: InfoSections | undefined): number =>
   Object.values(infoSections || {}).reduce(
     (acc, { title, text }: InfoSection) => acc + countWords(title) + countWords(text),
     0,

--- a/apps/server/src/libs/wordCounter.ts
+++ b/apps/server/src/libs/wordCounter.ts
@@ -1,9 +1,11 @@
 import type {
   DemarcheContent,
   DispositifContent,
+  FlexibleDispositifContent,
   InfoSection,
   InfoSections,
 } from "@refugies-info/api-types";
+import { hasMarkdownContent } from "@refugies-info/api-types";
 import get from "lodash/get";
 import isString from "lodash/isString";
 import type { TranslationContent } from "~/typegoose/Dispositif";
@@ -29,7 +31,18 @@ export const countWordsForInfoSections = (infoSections: InfoSections | undefined
     0,
   );
 
-export const countDispositifWords = (translation: DispositifContent | DemarcheContent) => {
+export const countDispositifWords = (translation: FlexibleDispositifContent | DemarcheContent) => {
+  // Si c'est du markdown uniquement, compter les mots du markdown
+  if (hasMarkdownContent(translation)) {
+    return (
+      countWords(translation.titreInformatif) +
+      countWords(translation.titreMarque) +
+      countWords(translation.abstract) +
+      countWords(translation.markdown)
+    );
+  }
+
+  // Logique standard pour contenu structuré
   return (
     countWords(translation.titreInformatif) +
     countWords(translation.titreMarque) +

--- a/apps/server/src/modules/dispositif/dispositif.service.ts
+++ b/apps/server/src/modules/dispositif/dispositif.service.ts
@@ -163,8 +163,11 @@ export const deleteLineBreaks = (htmlContent: string) => {
   return htmlContent.replace(regexp, "");
 };
 
-export const deleteLineBreaksInInfosections = (sections: InfoSections): InfoSections => {
+export const deleteLineBreaksInInfosections = (
+  sections: InfoSections | undefined,
+): InfoSections => {
   const newSections: InfoSections = {};
+  if (!sections) return newSections;
   for (const [key, section] of Object.entries(sections)) {
     newSections[key] = {
       title: section.title,

--- a/apps/server/src/typegoose/Dispositif.ts
+++ b/apps/server/src/typegoose/Dispositif.ts
@@ -56,25 +56,59 @@ export class InfoSection {
 export type InfoSections = { [key: Uuid]: InfoSection };
 // export type InfoSections = Record<Uuid, InfoSection>;
 
+/**
+ * Contenu d'un Dispositif.
+ *
+ * Deux formes mutuellement exclusives :
+ * - **Contenu structuré (RI)** : what, why, how sont obligatoires
+ * - **Contenu markdown (externe)** : seul markdown est requis
+ *
+ * La validation Mongoose garantit cette exclusivité au runtime.
+ */
 export class DispositifContent extends Content {
-  @prop()
-  what: RichText;
-  @prop()
+  // ─────────────────────────────────────────────────────────────────
+  // Contenu externe (requis si pas de contenu structuré)
+  // ─────────────────────────────────────────────────────────────────
+  @prop({
+    required: function (this: DispositifContent) {
+      return !this.what; // Requis si pas de contenu structuré
+    },
+  })
   markdown?: string;
-  @prop()
-  why?: { [key: string]: InfoSection };
-  @prop()
-  how?: InfoSections;
+
+  // ─────────────────────────────────────────────────────────────────
+  // Contenu structuré RI (requis si pas de markdown)
+  // ─────────────────────────────────────────────────────────────────
+  @prop({
+    required: function (this: DispositifContent) {
+      return !this.markdown;
+    },
+  })
+  what: RichText;
+
+  @prop({
+    required: function (this: DispositifContent) {
+      return !this.markdown;
+    },
+  })
+  why: { [key: string]: InfoSection };
+
+  @prop({
+    required: function (this: DispositifContent) {
+      return !this.markdown;
+    },
+  })
+  how: InfoSections;
 }
 export class DemarcheContent extends Content {
   @prop()
   what: RichText;
   @prop()
-  how?: InfoSections;
+  how: InfoSections;
   @prop()
-  next?: InfoSections;
+  next: InfoSections;
   @prop()
-  administrationName?: string | null;
+  administrationName: string | null;
 }
 
 export class Suggestion {

--- a/apps/server/src/typegoose/Dispositif.ts
+++ b/apps/server/src/typegoose/Dispositif.ts
@@ -62,19 +62,19 @@ export class DispositifContent extends Content {
   @prop()
   markdown?: string;
   @prop()
-  why: { [key: string]: InfoSection };
+  why?: { [key: string]: InfoSection };
   @prop()
-  how: InfoSections;
+  how?: InfoSections;
 }
 export class DemarcheContent extends Content {
   @prop()
   what: RichText;
   @prop()
-  how: InfoSections;
+  how?: InfoSections;
   @prop()
-  next: InfoSections;
+  next?: InfoSections;
   @prop()
-  administrationName: string | null;
+  administrationName?: string | null;
 }
 
 export class Suggestion {

--- a/apps/server/src/typegoose/Traductions.test.ts
+++ b/apps/server/src/typegoose/Traductions.test.ts
@@ -183,7 +183,11 @@ const trad_adminNameNull_en: TranslationContent = {
 describe("Traductions", () => {
   describe("diff", () => {
     it("should return empty array", () => {
-      expect(Traductions.diff(trad, trad)).toEqual({ added: [], removed: [], modified: [] });
+      expect(Traductions.diff(trad, trad)).toEqual({
+        added: [],
+        removed: [],
+        modified: [],
+      });
     });
     it("should return added sections", () => {
       expect(Traductions.diff(trad, trad_added)).toEqual({
@@ -219,8 +223,11 @@ describe("Traductions", () => {
     });
     it("should not return administrationName ", () => {
       const newTradAdded = JSON.parse(JSON.stringify(trad_added_adminName));
-      newTradAdded.content = { ...newTradAdded.content, administrationName: null };
-      //@ts-expect-error because we don't need administrationName for this test
+      newTradAdded.content = {
+        ...newTradAdded.content,
+        administrationName: null,
+      };
+
       expect(Traductions.diff(trad_added_adminName, newTradAdded)).toEqual({
         modified: [],
         added: [],

--- a/apps/server/src/typegoose/Traductions.test.ts
+++ b/apps/server/src/typegoose/Traductions.test.ts
@@ -126,7 +126,7 @@ const trad_avancement: RecursivePartial<TranslationContent> = {
   validatorId: new ObjectId("656076dbaf8df7a3f7bceeb4"),
 };
 
-const trad_added_adminName = {
+const trad_added_adminName: TranslationContent = {
   content: {
     titreInformatif: "abc",
     titreMarque: "def",
@@ -138,6 +138,7 @@ const trad_added_adminName = {
       "my-uuid-v4-key-2": { title: "title", text: "text" },
       "my-uuid-v4-key-3": { title: "title", text: "text" },
     },
+    administrationName: null,
   },
 
   created_at: new Date(),

--- a/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
+++ b/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
@@ -28,8 +28,19 @@ import { log } from "./log";
 
 const deleteLineBreaksInTranslation = (translation: Partial<TranslationContent>) => {
   const newTranslation = cloneDeep(translation);
-  set(newTranslation, "content.what", deleteLineBreaks(newTranslation.content.what));
-  set(newTranslation, "content.how", deleteLineBreaksInInfosections(newTranslation.content.how));
+
+  // Skip line break deletion for markdown content
+  if ("markdown" in newTranslation.content && newTranslation.content.markdown) {
+    return newTranslation;
+  }
+
+  // For structured content, delete line breaks
+  if ("what" in newTranslation.content) {
+    set(newTranslation, "content.what", deleteLineBreaks(newTranslation.content.what));
+  }
+  if ("how" in newTranslation.content) {
+    set(newTranslation, "content.how", deleteLineBreaksInInfosections(newTranslation.content.how));
+  }
 
   const why = (newTranslation.content as DispositifContent).why;
   if (why) set(newTranslation, "content.why", deleteLineBreaksInInfosections(why));

--- a/packages/api-types/src/modules/dispositif.ts
+++ b/packages/api-types/src/modules/dispositif.ts
@@ -15,6 +15,7 @@ import type {
   SimpleUser,
   Sponsor,
 } from "../generics";
+import type { TranslationContent } from "./translations";
 
 export enum ViewsType {
   WEB = "web",
@@ -270,6 +271,7 @@ export type BaseGetDispositifResponse = {
   externalLink?: string;
   hasDraftVersion: boolean;
   origin: DispositifOrigin;
+  translations?: Partial<Record<Languages, TranslationContent>>;
 };
 
 export type GetDispositifResponse = BaseGetDispositifResponse &

--- a/packages/api-types/src/modules/translations.ts
+++ b/packages/api-types/src/modules/translations.ts
@@ -36,14 +36,15 @@ export interface Content {
 
 export interface DispositifContent extends Content {
   what: RichText;
-  why: { [key: string]: InfoSection };
-  how: InfoSections;
+  markdown?: string;
+  why?: { [key: string]: InfoSection };
+  how?: InfoSections;
 }
 export interface DemarcheContent extends Content {
   what: RichText;
-  how: InfoSections;
-  next: InfoSections;
-  administrationName: string;
+  how?: InfoSections;
+  next?: InfoSections;
+  administrationName?: string;
 }
 
 export interface TranslationContent {

--- a/packages/api-types/src/modules/translations.ts
+++ b/packages/api-types/src/modules/translations.ts
@@ -36,19 +36,60 @@ export interface Content {
 
 export interface DispositifContent extends Content {
   what: RichText;
-  markdown?: string;
-  why?: { [key: string]: InfoSection };
-  how?: InfoSections;
+  why: { [key: string]: InfoSection };
+  how: InfoSections;
 }
 export interface DemarcheContent extends Content {
   what: RichText;
-  how?: InfoSections;
-  next?: InfoSections;
-  administrationName?: string;
+  how: InfoSections;
+  next: InfoSections;
+  administrationName: string;
+}
+
+/**
+ * Contenu structuré RI - what, why, how obligatoires
+ * Alias de DispositifContent pour clarifier l'intention
+ */
+export type StructuredContent = DispositifContent;
+
+/**
+ * Contenu markdown externe
+ * À utiliser pour les contenus d'origine externe (RCO, etc.)
+ */
+export interface MarkdownContent extends Content {
+  markdown: string;
+}
+
+/**
+ * Type union pour les contenus qui peuvent être structurés ou markdown
+ */
+export type FlexibleDispositifContent = DispositifContent | MarkdownContent;
+
+/**
+ * Type guard pour vérifier si un contenu est structuré (what, why, how)
+ */
+export function hasStructuredContent(
+  content: FlexibleDispositifContent | DemarcheContent,
+): content is StructuredContent {
+  return (
+    "what" in content &&
+    "why" in content &&
+    "how" in content &&
+    !("markdown" in content && (content as MarkdownContent).markdown)
+  );
+}
+
+/**
+ * Type guard pour vérifier si un contenu est uniquement markdown
+ */
+export function hasMarkdownContent(
+  content: FlexibleDispositifContent | DemarcheContent,
+): content is MarkdownContent {
+  return "markdown" in content && !!(content as MarkdownContent).markdown;
 }
 
 export interface TranslationContent {
-  content: DispositifContent | DemarcheContent;
+  content: FlexibleDispositifContent | DemarcheContent;
   // keep "content" prop to be able to add "metadatas" later
 }
 


### PR DESCRIPTION
Hello Luis ! 👋

J'ai préparé toute la tuyauterie pour qu'on puisse **prévisualiser le contenu directement depuis le Content Playground** ! 

Fini de deviner à quoi ça ressemble, maintenant on voit le résultat "en vrai" dans l'app. ✨

## Qu'est-ce qu'il y a dans cette boîte mystère ?
1.  **La Route Magique `/dispositif/preview`** :
    *   Elle accepte du JSON en POST
    *   Elle rend le composant [Dispositif](cci:1://file:///Users/jeremie/refugies.info/karfur/apps/client/src/utils/API.ts:272:2-284:3)
    *   🛡️ **Sécurisée** par un `WEBHOOK_SECRET` (pas de ticket, pas d'entrée !).
    *   💅 Elle gère le **Markdown** pour les contenus ayant un champ markdown.
2.  **Le Labo de Test `/dispositif/test-preview`** 🧪 :
    *   Une page pour tester manuellement le rendu sans passer par le Playground.
    *   Tu colles ton JSON, tu cliques, et BAM ! 💥 Ça s'ouvre dans un nouvel onglet.
    *   🔒 **Zone VIP** : Accessible uniquement si tu es connecté (j'ai mis un vigile à l'entrée).
## Comment tu peux jouer avec ?
1.  Assure-toi d'avoir ta variable d'env `WEBHOOK_SECRET` (sinon le videur te recale).
2.  Va sur `/dispositif/test-preview`.
3.  Prends le JSON par défaut (ou mets le tien si tu te sens créatif 🎨).
4.  Clique sur **"Prévisualiser"**.
5.  Admire le résultat ! 😎

PR côté playground : 
https://github.com/refugies-info/playground/compare/jeremie/ri-1027-actions-previsualiser-une-fiche-a-letat-de-brouillon