### PR TITLE
fix(client): update installer l'application and help center links in sitemap

### DIFF
--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -112,7 +112,7 @@ const PlanDuSite = () => {
         {
           id: "installApp",
           label: t("sitemap.links.installApp", "Installer l'application"),
-          href: "https://refugies.info/#application",
+          href: "/#application",
           isExternal: true,
         },
         {

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -112,7 +112,7 @@ const PlanDuSite = () => {
         {
           id: "installApp",
           label: t("sitemap.links.installApp", "Installer l'application"),
-          href: "#application",
+          href: "https://refugies.info/#application",
           isExternal: true,
         },
         {

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -118,8 +118,8 @@ const PlanDuSite = () => {
         {
           id: "helpCenter",
           label: t("sitemap.links.helpCenter", "Centre d'aide"),
-          href: "/faq",
-          isExternal: false,
+          href: "https://help.refugies.info/fr/",
+          isExternal: true,
         },
       ],
     },


### PR DESCRIPTION
Ce PR met à jour deux liens dans le plan du site :
1. Le lien "Installer l'application" pointe désormais vers l'ancre `#application` de la page d'accueil (https://refugies.info/#application).
2. Le lien "Centre d'aide" pointe désormais vers le centre d'aide externe (https://help.refugies.info/fr/) au lieu de la FAQ interne.