### PR TITLE
🐛 Correction Erreur 500 sur `/sms/content-link`

### DIFF
--- a/apps/server/src/connectors/brevo/sendSMS.ts
+++ b/apps/server/src/connectors/brevo/sendSMS.ts
@@ -33,6 +33,9 @@ export const sendSMS = async (text: string, phone: string): Promise<SendSMSResul
     const { response } = await apiInstance.sendTransacSms(sms);
     return { status: response.statusCode, sent: response.statusCode === 201 };
   } catch (error) {
-    return { status: error instanceof HttpError ? error.response.statusCode : 500, sent: false };
+    return {
+      status: error instanceof HttpError ? error.response.statusCode : 500,
+      sent: false,
+    };
   }
 };

--- a/apps/server/src/workflows/sms/contentLink/contentLink.test.ts
+++ b/apps/server/src/workflows/sms/contentLink/contentLink.test.ts
@@ -1,0 +1,101 @@
+import type { ContentLinkRequest } from "@refugies-info/api-types";
+import { InternalError, NotFoundError } from "~/errors";
+import { getDispositifByIdWithAllFields } from "~/modules/dispositif/dispositif.repository";
+import { sendSMS } from "~/services";
+import { contentLink } from "./contentLink";
+
+// Mocks
+jest.mock("~/modules/dispositif/dispositif.repository");
+jest.mock("~/services");
+jest.mock("~/logger");
+
+const mockGetDispositif = getDispositifByIdWithAllFields as jest.Mock;
+const mockSendSMS = sendSMS as jest.Mock;
+
+const validDispositif = {
+  _id: "valid_id",
+  translations: {
+    fr: {
+      content: {
+        titreInformatif: "Titre Français",
+      },
+    },
+  },
+};
+
+const incompleteDispositif = {
+  _id: "incomplete_id",
+  translations: {
+    // No 'fr' and no requested locale
+  },
+};
+
+const emptyTitleDispositif = {
+  _id: "empty_title_id",
+  translations: {
+    fr: {
+      content: {
+        titreInformatif: "", // Empty
+      },
+    },
+  },
+};
+
+describe("contentLink", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should send SMS successfully when data is valid", async () => {
+    mockGetDispositif.mockResolvedValue(validDispositif);
+    mockSendSMS.mockResolvedValue({ status: 201, sent: true });
+
+    const body: ContentLinkRequest = {
+      id: "valid_id",
+      phone: "+33600000000",
+      url: "https://example.com",
+      locale: "fr",
+    };
+
+    const res = await contentLink(body);
+    expect(res).toEqual({ text: "success" });
+    expect(mockSendSMS).toHaveBeenCalled();
+  });
+
+  it("should throw NotFoundError if translations are missing", async () => {
+    mockGetDispositif.mockResolvedValue(incompleteDispositif);
+    const body: ContentLinkRequest = {
+      id: "incomplete_id",
+      phone: "+33600000000",
+      url: "https://example.com",
+      locale: "fr",
+    };
+    await expect(contentLink(body)).rejects.toThrow(NotFoundError);
+  });
+
+  it("should throw NotFoundError if title is empty", async () => {
+    mockGetDispositif.mockResolvedValue(emptyTitleDispositif);
+    const body: ContentLinkRequest = {
+      id: "empty_title_id",
+      phone: "+33600000000",
+      url: "https://example.com",
+      locale: "fr",
+    };
+    await expect(contentLink(body)).rejects.toThrow(NotFoundError);
+  });
+
+  it("should throw InternalError if SMS sending fails with non-400 status", async () => {
+    mockGetDispositif.mockResolvedValue(validDispositif);
+    mockSendSMS.mockResolvedValue({ status: 401, sent: false });
+
+    const body: ContentLinkRequest = {
+      id: "valid_id",
+      phone: "+33600000000",
+      url: "https://example.com",
+      locale: "fr",
+    };
+
+    await expect(contentLink(body)).rejects.toThrow(InternalError);
+    await expect(contentLink(body)).rejects.toThrow("[contentLink] SMS not sent. Status: 401");
+  });
+});

--- a/apps/server/src/workflows/sms/contentLink/contentLink.ts
+++ b/apps/server/src/workflows/sms/contentLink/contentLink.ts
@@ -11,14 +11,25 @@ export const contentLink = async (body: ContentLinkRequest): Response => {
 
   const dispositif = await getDispositifByIdWithAllFields(body.id);
   if (!dispositif) throw new NotFoundError("[contentLink] Dispositif not found");
-  const title: string =
-    dispositif.translations[body.locale as Languages]?.content?.titreInformatif ||
-    dispositif.translations.fr.content.titreInformatif;
+  if (!dispositif.translations)
+    throw new NotFoundError("[contentLink] Dispositif has no translations");
+
+  const translation =
+    dispositif.translations[body.locale as Languages] || dispositif.translations.fr;
+
+  if (!translation || !translation.content) {
+    throw new NotFoundError(
+      `[contentLink] Content not found for locale ${body.locale} and fallback fr`,
+    );
+  }
+
+  const title: string = translation.content.titreInformatif;
   const text = t(body.locale, "contentLink", { title: title, link: body.url });
   const smsSentOk = await sendSMS(text, body.phone);
   if (!smsSentOk.sent) {
+    logger.error("[contentLink] SMS not sent", smsSentOk);
     if (smsSentOk.status === 400) throw new InvalidRequestError("[contentLink] Invalid request");
-    throw new Error("[contentLink] SMS not sent.");
+    throw new Error(`[contentLink] SMS not sent. Status: ${smsSentOk.status}`);
   }
 
   return { text: "success" };

--- a/apps/server/src/workflows/sms/contentLink/contentLink.ts
+++ b/apps/server/src/workflows/sms/contentLink/contentLink.ts
@@ -1,5 +1,5 @@
 import type { ContentLinkRequest, Languages } from "@refugies-info/api-types";
-import { InvalidRequestError, NotFoundError } from "~/errors";
+import { InternalError, InvalidRequestError, NotFoundError } from "~/errors";
 import { getLocaleString as t } from "~/libs/getLocaleString";
 import logger from "~/logger";
 import { getDispositifByIdWithAllFields } from "~/modules/dispositif/dispositif.repository";
@@ -17,9 +17,9 @@ export const contentLink = async (body: ContentLinkRequest): Response => {
   const translation =
     dispositif.translations[body.locale as Languages] || dispositif.translations.fr;
 
-  if (!translation || !translation.content) {
+  if (!translation || !translation.content || !translation.content.titreInformatif) {
     throw new NotFoundError(
-      `[contentLink] Content not found for locale ${body.locale} and fallback fr`,
+      `[contentLink] Content or title not found for locale ${body.locale} and fallback fr`,
     );
   }
 
@@ -29,7 +29,7 @@ export const contentLink = async (body: ContentLinkRequest): Response => {
   if (!smsSentOk.sent) {
     logger.error("[contentLink] SMS not sent", smsSentOk);
     if (smsSentOk.status === 400) throw new InvalidRequestError("[contentLink] Invalid request");
-    throw new Error(`[contentLink] SMS not sent. Status: ${smsSentOk.status}`);
+    throw new InternalError(`[contentLink] SMS not sent. Status: ${smsSentOk.status}`);
   }
 
   return { text: "success" };


### PR DESCRIPTION

## 📝 Description du problème
L'endpoint `POST /sms/content-link` renvoyait une erreur **500 Internal Server Error** lorsqu'il était appelé pour un Dispositif ayant des traductions incomplètes (spécifiquement si la traduction de fallback 'fr' était manquante).
Le serveur plantait avec une `TypeError` en tentant d'accéder aux propriétés d'un objet `undefined` :
\`\`\`typescript
// contentLink.ts
dispositif.translations.fr.content.titreInformatif // -> Crash si translations.fr n'existe pas
\`\`\`
## 🔍 Cause Racine
Cette régression a été introduite (probablement en août 2024) lorsque la logique de fallback vers le français a été ajoutée sans vérifier au préalable si la traduction française existait bien en base.
## 🛠️ Solution
- **Accès sécurisé** : Ajout de vérifications pour s'assurer que `dispositif.translations` et `dispositif.translations.fr` existent avant d'y accéder.
- **Erreur gérée** : Si les traductions sont manquantes, l'endpoint renvoie désormais une `NotFoundError` (404) propre au lieu de crasher avec une 500.
- **Meilleur débogage** : Amélioration des logs lorsqu'une erreur survient côté fournisseur SMS (ex: erreur Brevo 401 ou 402). Le message d'erreur inclut désormais le code de statut pour faciliter le diagnostic.
## ✅ Vérification
- **Test automatisé** : Ajout d'un cas de test de non-régression dans [contentLink.test.ts](cci:7://file:///Users/jeremie/refugies.info/karfur/apps/server/src/workflows/sms/contentLink/contentLink.test.ts:0:0-0:0) qui reproduit le crash et valide le correctif.
- **Vérification manuelle** : Confirmation que le serveur ne plante plus et renvoie un message d'erreur explicite dans ce cas de figure.