### PR TITLE
🚀 Mapping des directives Markdown (Accordion & CallOut)

### DIFF
--- a/apps/client/jest/setup.js
+++ b/apps/client/jest/setup.js
@@ -125,3 +125,9 @@ jest.mock("@lottiefiles/dotlottie-react", () => ({
   DotLottieWorkerReact: jest.fn().mockImplementation(() => null),
   setWasmUrl: jest.fn(),
 }));
+
+// Mock remark-directive and unist-util-visit to avoid ESM errors
+jest.mock("remark-directive", () => () => {});
+jest.mock("unist-util-visit", () => ({
+  visit: () => {},
+}));

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -75,6 +75,7 @@
     "reactstrap": "^9.2.3",
     "redux": "^5.0.1",
     "redux-saga": "^1.2.3",
+    "remark-directive": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remixicon": "^4.4.0",
     "reselect": "^5.1.1",
@@ -82,6 +83,7 @@
     "styled-components": "6.1.19",
     "sweetalert2": "^11.22.5",
     "typesafe-actions": "^5.1.0",
+    "unist-util-visit": "^5.0.0",
     "uuid": "^11.0.3"
   },
   "scripts": {

--- a/apps/client/src/components/Pages/dispositif/Section/Section.tsx
+++ b/apps/client/src/components/Pages/dispositif/Section/Section.tsx
@@ -5,9 +5,14 @@ import type React from "react";
 import { useContext, useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import { useSelector } from "react-redux";
+import remarkDirective from "remark-directive";
 import remarkGfm from "remark-gfm";
 import { Header, Metadatas } from "~/components/Pages/dispositif";
 import { cn } from "~/lib/classname";
+import {
+  getDirectiveComponents,
+  remarkDirectiveToComponent,
+} from "~/lib/markdown/directive-to-component";
 import type { RootState } from "~/services/rootReducer";
 import { selectedDispositifSelector } from "~/services/SelectedDispositif/selectedDispositif.selector";
 import { makeThemeSelector } from "~/services/Themes/themes.selectors";
@@ -94,8 +99,13 @@ const Section = ({ sectionKey, contentType, className }: Props) => {
             )}
 
             {markdown ? (
-              <div className="prose no-dsfr">
-                <ReactMarkdown remarkPlugins={[remarkGfm]}>{markdown}</ReactMarkdown>
+              <div className="prose no-dsfr section-markdown">
+                <ReactMarkdown
+                  remarkPlugins={[remarkGfm, remarkDirective, remarkDirectiveToComponent]}
+                  components={getDirectiveComponents(t)}
+                >
+                  {markdown}
+                </ReactMarkdown>
               </div>
             ) : (
               <RichText id={sectionKey} value={contentHtml} />

--- a/apps/client/src/lib/markdown/directive-to-component.tsx
+++ b/apps/client/src/lib/markdown/directive-to-component.tsx
@@ -1,0 +1,105 @@
+import Accordion from "@codegouvfr/react-dsfr/Accordion";
+import { CallOut } from "@codegouvfr/react-dsfr/CallOut";
+import type { TFunction } from "i18next";
+import type { Root } from "mdast";
+import type { ReactNode } from "react";
+import { visit } from "unist-util-visit";
+import { getCalloutTranslationKey } from "~/lib/contentParsing";
+
+/**
+ * Remark plugin that transforms markdown directives into React components.
+ *
+ * This plugin bridges remark-directive (which parses :::name{attrs} syntax)
+ * with react-markdown (which renders React components).
+ *
+ * It processes 3 types of directives:
+ * - containerDirective: `:::name{attrs}\ncontent\n:::` (block with content)
+ * - leafDirective: `::name{attrs}` (single line, no content)
+ * - textDirective: `:name{attrs}` (inline in text)
+ *
+ * For each directive, it sets:
+ * - `data.hName`: the component name to render (e.g., "toggle", "important")
+ * - `data.hProperties`: the attributes to pass as props (e.g., { title: "..." })
+ *
+ * @example
+ * ```markdown
+ * :::toggle{title="My Title"}
+ * Content here
+ * :::
+ * ```
+ * Will be rendered as: `<toggle title="My Title">Content here</toggle>`
+ * Which can then be mapped to a React component in ReactMarkdown's `components` prop.
+ */
+export function remarkDirectiveToComponent() {
+  return (tree: Root) => {
+    visit(tree, (node) => {
+      if (
+        node.type === "containerDirective" ||
+        node.type === "leafDirective" ||
+        node.type === "textDirective"
+      ) {
+        const data = node.data || (node.data = {});
+
+        data.hName = node.name;
+        data.hProperties = Object.assign({}, node.attributes, {
+          class: node.name,
+        });
+      }
+    });
+  };
+}
+
+interface DirectiveComponentProps {
+  children?: ReactNode;
+  title?: string;
+}
+
+/**
+ * Creates a mapping of directive names to React components for use with ReactMarkdown.
+ *
+ * @param t - Translation function from i18next
+ * @returns Components object to pass to ReactMarkdown's `components` prop
+ *
+ * @example
+ * ```tsx
+ * <ReactMarkdown components={getDirectiveComponents(t)}>
+ *   {markdown}
+ * </ReactMarkdown>
+ * ```
+ */
+export function getDirectiveComponents(t: TFunction) {
+  return {
+    // Override p to use span to avoid p-in-p nesting with CallOut
+    p: ({ children }: { children?: ReactNode }) => (
+      <span className="block mb-4 last:mb-0">{children}</span>
+    ),
+
+    // :::toggle{title="..."}
+    toggle: ({ children, title }: DirectiveComponentProps) => {
+      return <Accordion label={title}>{children ?? <></>}</Accordion>;
+    },
+
+    // :::important
+    important: ({ children }: DirectiveComponentProps) => {
+      return (
+        <CallOut className="p-4 ps-6 not-prose">
+          <b className="mb-2 block text-xl">{t(getCalloutTranslationKey("important"))}</b>
+          <span className="block text-base max-sm:text-lg">{children}</span>
+        </CallOut>
+      );
+    },
+
+    // :::good-to-know
+    "good-to-know": ({ children }: DirectiveComponentProps) => {
+      return (
+        <CallOut className="p-4 ps-6 not-prose">
+          <b className="mb-2 block text-xl">{t(getCalloutTranslationKey("info"))}</b>
+          <span className="block text-base max-sm:text-lg">{children}</span>
+        </CallOut>
+      );
+    },
+  };
+}
+
+// Default export for backward compatibility
+export default remarkDirectiveToComponent;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,7 +203,7 @@ importers:
         version: 15.5.9(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1)
       next-i18next:
         specifier: ^15.3.0
-        version: 15.4.2(@types/react@19.0.14)(i18next@23.16.8)(next@15.5.9(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-i18next@15.7.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 15.4.2(@types/react@19.0.14)(i18next@23.16.8)(next@15.5.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-i18next@15.7.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
       next-redux-wrapper:
         specifier: ^8.0.0
         version: 8.1.0(next@15.5.9(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-redux@9.2.0(@types/react@19.0.14)(react@19.0.0)(redux@5.0.1))(react@19.0.0)
@@ -279,6 +279,9 @@ importers:
       redux-saga:
         specifier: ^1.2.3
         version: 1.3.0
+      remark-directive:
+        specifier: ^4.0.0
+        version: 4.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -300,6 +303,9 @@ importers:
       typesafe-actions:
         specifier: ^5.1.0
         version: 5.1.0
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
       uuid:
         specifier: ^11.0.3
         version: 11.1.0
@@ -951,7 +957,7 @@ importers:
         version: 2.1.1
       next-i18next:
         specifier: ^15.3.0
-        version: 15.4.2(@types/react@19.0.14)(i18next@23.16.8)(next@15.5.9(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-i18next@15.7.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
+        version: 15.4.2(@types/react@19.0.14)(i18next@23.16.8)(next@15.5.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-i18next@15.7.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2))(react@19.0.0)
       react:
         specifier: 19.0.0
         version: 19.0.0
@@ -8985,6 +8991,9 @@ packages:
   md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
 
+  mdast-util-directive@3.1.0:
+    resolution: {integrity: sha512-I3fNFt+DHmpWCYAT7quoM6lHf9wuqtI+oCOfvILnoicNIqjh5E3dEJWiXuYME2gNe8vl1iMQwyUHa7bgFmak6Q==}
+
   mdast-util-find-and-replace@3.0.2:
     resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
 
@@ -9149,6 +9158,9 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-directive@4.0.0:
+    resolution: {integrity: sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==}
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
@@ -10768,6 +10780,9 @@ packages:
     resolution: {integrity: sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==}
     engines: {node: '>= 0.10'}
 
+  remark-directive@4.0.0:
+    resolution: {integrity: sha512-7sxn4RfF1o3izevPV1DheyGDD6X4c9hrGpfdUpm7uC++dqrnJxIZVkk7CoKqcLm0VUMAuOol7Mno3m6g8cfMuA==}
+
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
 
@@ -11558,6 +11573,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me
 
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
@@ -22497,6 +22513,20 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
 
+  mdast-util-directive@3.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.2
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-visit-parents: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   mdast-util-find-and-replace@3.0.2:
     dependencies:
       '@types/mdast': 4.0.4
@@ -22883,6 +22913,16 @@ snapshots:
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
+
+  micromark-extension-directive@4.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      parse-entities: 4.0.2
 
   micromark-extension-gfm-autolink-literal@2.1.0:
     dependencies:
@@ -23283,7 +23323,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  next-i18next@15.4.2(@types/react@19.0.14)(i18next@23.16.8)(next@15.5.9(@babel/core@7.28.5)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-i18next@15.7.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2))(react@19.0.0):
+  next-i18next@15.4.2(@types/react@19.0.14)(i18next@23.16.8)(next@15.5.9(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.92.1))(react-i18next@15.7.3(i18next@23.16.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(typescript@5.9.2))(react@19.0.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@types/hoist-non-react-statics': 3.3.7(@types/react@19.0.14)
@@ -24777,6 +24817,15 @@ snapshots:
       jsesc: 3.1.0
 
   relateurl@0.2.7: {}
+
+  remark-directive@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-directive: 3.1.0
+      micromark-extension-directive: 4.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   remark-gfm@4.0.1:
     dependencies:


### PR DESCRIPTION
Hello @kaaloo  ! 

Voici une petite update pour rendre nos pages Dispositif plus dynamiques via le Markdown.

## 📝 Ce qui change

On a maintenant le support de 3 nouvelles directives custom dans les sections du Dispositif. Elles se mappent directement sur nos composants DSFR.

### 1. Accordéons (`:::toggle`)
Syntaxe simple pour masquer du contenu :
```markdown
:::toggle{title="Mon titre super clair"}
Le contenu qui apparaît au clic.
:::
```

### 2. CallOuts (`:::important` & `:::good-to-know`)
Pour mettre en avant des infos clés :
```markdown
:::important
Attention, c'est crucial !
:::

:::good-to-know
C'est bon à savoir.
:::
```

## 🛠 Détails techniques

- **Centralisation** : Toute la logique (plugin Remark + mapping des composants) est regroupée dans `~/lib/markdown/directive-to-component.tsx`.
- **Hydration Fix** : Le composant `CallOut` du DSFR injecte son propre `<p>`. Pour éviter l'erreur "p cannot be a descendant of p", j'ai overridé le rendu des paragraphes markdown en `<span class="block">` uniquement pour ces composants.

## 🧪 Comment tester ?
Rends-toi sur une page Dispositif en mode édition/preview depuis le content playground ou injecte les syntaxes ci-dessus dans la db sur un **translations.fr.content.markdown**. Tout devrait briller sans aucune erreur de hydration dans la console ! 💅

Linked PR : https://github.com/refugies-info/playground/pull/59