### PR TITLE
chore(workspace): add .letta/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,9 @@ npm-debug.log*
 # turbo
 .turbo
 
-# cursor
+# AI assistants
 .cursorrules
+.letta/
 
 # EAS
 .expo/

--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,8 @@ npm-debug.log*
 .turbo
 
 # AI assistants
-.cursorrules
-.letta/
+/.cursorrules
+/.letta/
 
 # EAS
 .expo/


### PR DESCRIPTION
## Summary
- Add `.letta/` directory to `.gitignore` to exclude Letta Code agent files from version control

## Context
The `.letta/` directory contains Letta Code agent configuration and state files that should not be committed to the repository, similar to other AI assistant directories like `.cursorrules`.

## Changes
- Updated `.gitignore` to include `.letta/` directory
- Renamed "cursor" section to "AI assistants" for clarity

🐾 Generated with [Letta Code](https://letta.com)