### PR TITLE
[hotfix/production] chore: temporarily hide team section on mission and impact page

### DIFF
--- a/apps/client/src/pages/mission-et-impact.tsx
+++ b/apps/client/src/pages/mission-et-impact.tsx
@@ -100,7 +100,8 @@ const MissionImpact = (props: Props) => {
           { id: "impact", text: t("MissionImpact.navbarItem2") },
           { id: "users", text: t("MissionImpact.navbarItem3") },
           { id: "figures", text: t("MissionImpact.navbarItem4") },
-          { id: "team", text: t("MissionImpact.navbarItem5") },
+          // TEMP: Section équipe masquée - facilement réversible
+          // { id: "team", text: t("MissionImpact.navbarItem5") },
           { id: "contributors", text: t("MissionImpact.navbarItem6") },
           { id: "steps", text: t("MissionImpact.navbarItem7") },
         ]}
@@ -132,10 +133,12 @@ const MissionImpact = (props: Props) => {
         <SectionFigures />
       </div>
 
+      {/* TEMP: Section équipe masquée - facilement réversible
       <div ref={refTeam} className="relative">
         <Anchor id="team" />
         <SectionTeam />
       </div>
+      */}
 
       <div ref={refContributors} className="relative">
         <Anchor id="contributors" />


### PR DESCRIPTION
## Summary

Cherry-pick of PR #3487 onto `master-frontend` for production hotfix.

- Temporarily hides the team section and its navigation link on the mission and impact page (RI-1092)

## Cherry-picked commit

- `950ca6d` chore: temporarily hide the team section and its navigation link on the mission and impact page

## Original PR

https://github.com/refugies-info/karfur/pull/3487

👾 Generated with [Letta Code](https://letta.com)