### PR TITLE
[workspace] unify staging release into single staging branch

### DIFF
--- a/.github/workflows/build_mobile_staging.yaml
+++ b/.github/workflows/build_mobile_staging.yaml
@@ -9,7 +9,7 @@ on:
   # mobile app or the API types.
   push:
     branches:
-      - staging-mobile
+      - staging
     paths:
       - pnpm-lock.yaml
       - package.json

--- a/.github/workflows/migrate_staging.yaml
+++ b/.github/workflows/migrate_staging.yaml
@@ -7,12 +7,12 @@ on:
   pull_request:
     types: [closed]
     branches:
-      - staging-backend
+      - staging
   workflow_dispatch:
 
 jobs:
   migrate-staging:
-    if: github.event.pull_request.merged == true && github.base_ref == 'staging-backend'
+    if: github.event.pull_request.merged == true && github.base_ref == 'staging'
     runs-on: ubuntu-latest
     environment: staging-migrate
     concurrency:

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "lint:style": "stylelint \"**/*.css\" \"**/*.scss\"",
     "client:i18n:export": "pnpm --filter @refugies-info/client i18n:export",
     "client:i18n:import": "pnpm --filter @refugies-info/client i18n:import",
+    "pr:stg": "gh pr create -B staging -H dev -l release -t '[STG] Release' -b ''",
     "pr:prod:client": "gh pr create -B master-frontend -H staging-frontend -l release -t '[PROD-FRONT] Release' -b ''",
     "pr:stg:client": "gh pr create -B staging-frontend -H dev -l release -t '[STG-FRONT] Release' -b ''",
     "pr:prod:mobile": "gh pr create -B master-mobile -H staging-mobile -l release -t '[PROD-MOBILE] Release' -b ''",


### PR DESCRIPTION
## Summary
- Creates a unified `staging` branch replacing `staging-backend`, `staging-frontend`, `staging-mobile`
- Updates GitHub Actions workflows to target the new `staging` branch
- Adds `pnpm pr:stg` convenience script for single-command staging releases

## What's changed
- `build_mobile_staging.yaml`: targets `staging` (was `staging-mobile`)
- `migrate_staging.yaml`: targets `staging` (was `staging-backend`)
- `package.json`: adds `pr:stg` script; old `pr:stg:*` scripts kept during transition

## Manual steps required after merge
1. **GCP Console** — update Cloud Build triggers:
   - `backend-stag`: change branch to `staging`, add path filter `apps/server/**`
   - `frontend-stag`: change branch to `staging`, add path filter `apps/client/**`
2. **GitHub Settings → Environments → `staging-migrate`**: update deployment branches to `staging`
3. **GitHub Settings**: add branch protection rules for `staging`

## Transition
Old staging branches (`staging-backend`, `staging-frontend`, `staging-mobile`) will be kept for ~2 weeks as fallback before deletion.

👾 Generated with [Letta Code](https://letta.com)