### PR TITLE
[ci] add release pipeline to sequence backend → frontend deployments

### DIFF
--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -1,0 +1,150 @@
+name: Release Pipeline
+
+# Orchestrates backend → frontend deployments in sequence so that the
+# frontend build (which prerenders via SSR) always runs against an
+# already-deployed backend.
+#
+# Mobile builds are NOT included here — the EAS build does not call the
+# backend at build time, so build_mobile_staging.yaml / build_mobile_prod.yaml
+# can continue to run independently.
+#
+# IMPORTANT: disable the GCP Cloud Build branch-push triggers for
+# backend-stag, frontend-stag, backend-prod, frontend-prod after merging
+# this PR, otherwise builds will fire twice.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - staging
+      - production
+  workflow_dispatch:
+
+jobs:
+  # ─── Detect which components changed ───────────────────────────────────────
+  detect-changes:
+    name: Detect changed components
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'apps/server/**'
+              - 'packages/api-types/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+            frontend:
+              - 'apps/client/**'
+              - 'packages/ui/**'
+              - 'packages/api-types/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+
+  # ─── Backend — always before frontend ──────────────────────────────────────
+  deploy-backend:
+    name: Deploy Backend
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Trigger and await backend Cloud Build
+        run: |
+          if [[ "${{ github.ref_name }}" == "staging" ]]; then
+            TRIGGER_ID="9725eef6-b227-4cdb-af3f-4ff263eb9d35"
+          else
+            TRIGGER_ID="5afe00f9-f11c-41d8-a4cc-5936cb6b90ec"
+          fi
+
+          echo "Triggering backend Cloud Build ($TRIGGER_ID) on ${{ github.ref_name }}..."
+          BUILD_ID=$(gcloud builds triggers run "$TRIGGER_ID" \
+            --branch="${{ github.ref_name }}" \
+            --project=refugies-info \
+            --format='value(metadata.build.id)')
+
+          echo "Build ID: $BUILD_ID"
+          echo "🔗 https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=refugies-info"
+
+          until [[ "$STATUS" == "SUCCESS" || "$STATUS" == "FAILURE" || "$STATUS" == "CANCELLED" || "$STATUS" == "TIMEOUT" || "$STATUS" == "EXPIRED" ]]; do
+            sleep 30
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project=refugies-info \
+              --format='value(status)')
+            echo "Status: $STATUS"
+          done
+
+          if [[ "$STATUS" != "SUCCESS" ]]; then
+            echo "❌ Backend build failed: $STATUS"
+            exit 1
+          fi
+          echo "✅ Backend deployed successfully"
+
+  # ─── Frontend — runs after backend (or immediately if no backend changes) ──
+  deploy-frontend:
+    name: Deploy Frontend
+    needs: [detect-changes, deploy-backend]
+    # Run if frontend changed AND (backend succeeded OR backend was skipped)
+    if: |
+      always() &&
+      needs.detect-changes.outputs.frontend == 'true' &&
+      (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Trigger and await frontend Cloud Build
+        run: |
+          if [[ "${{ github.ref_name }}" == "staging" ]]; then
+            TRIGGER_ID="13256662-bcdc-4526-88fe-475660d66fac"
+          else
+            TRIGGER_ID="bc32ef8b-ee21-489a-be3e-ac2b0721d310"
+          fi
+
+          echo "Triggering frontend Cloud Build ($TRIGGER_ID) on ${{ github.ref_name }}..."
+          BUILD_ID=$(gcloud builds triggers run "$TRIGGER_ID" \
+            --branch="${{ github.ref_name }}" \
+            --project=refugies-info \
+            --format='value(metadata.build.id)')
+
+          echo "Build ID: $BUILD_ID"
+          echo "🔗 https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=refugies-info"
+
+          until [[ "$STATUS" == "SUCCESS" || "$STATUS" == "FAILURE" || "$STATUS" == "CANCELLED" || "$STATUS" == "TIMEOUT" || "$STATUS" == "EXPIRED" ]]; do
+            sleep 30
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project=refugies-info \
+              --format='value(status)')
+            echo "Status: $STATUS"
+          done
+
+          if [[ "$STATUS" != "SUCCESS" ]]; then
+            echo "❌ Frontend build failed: $STATUS"
+            exit 1
+          fi
+          echo "✅ Frontend deployed successfully"


### PR DESCRIPTION
## Summary
- Adds `release_pipeline.yaml` — a GitHub Actions workflow that orchestrates backend → frontend Cloud Build deploys in sequence
- Prevents the frontend SSR build from hitting a stale/unavailable API
- Uses path filtering so a backend-only change won't trigger a frontend rebuild and vice versa

## How it works

```
push to staging or production
        │
        ▼
  detect-changes (dorny/paths-filter)
    ├── backend changed?
    └── frontend changed?
        │
        ▼
  deploy-backend (if backend changed)
    └── triggers GCP Cloud Build, polls until SUCCESS/FAILURE
        │
        ▼
  deploy-frontend (if frontend changed AND backend succeeded or was skipped)
    └── triggers GCP Cloud Build, polls until SUCCESS/FAILURE
```

Mobile builds continue to run independently via `build_mobile_staging.yaml` / `build_mobile_prod.yaml` (EAS build does not call the backend at build time).

## ⚠️ Manual step required after merge
Disable the **branch-push** event on these GCP Cloud Build triggers to avoid duplicate builds (they'll now be invoked by this workflow instead):
- `backend-stag` (`9725eef6`)
- `frontend-stag` (`13256662`)
- `backend-prod` (`5afe00f9`)
- `frontend-prod` (`bc32ef8b`)

GCP Console → Cloud Build → Triggers → Edit each → change event from "Push to branch" to "Manual invocation".

## New GitHub secret required
`GCP_SA_KEY` — already added ✅

👾 Generated with [Letta Code](https://letta.com)