### PR TITLE
feat(client): add webhook endpoints for themes and needs reference data

### DIFF
--- a/apps/client/src/__tests__/api/webhook/dispositif/webhook.test.ts
+++ b/apps/client/src/__tests__/api/webhook/dispositif/webhook.test.ts
@@ -4,6 +4,8 @@ import archiveHandler from "../../../../pages/api/webhook/dispositif/archive";
 import createHandler from "../../../../pages/api/webhook/dispositif/create";
 import translationHandler from "../../../../pages/api/webhook/dispositif/translation";
 import updateHandler from "../../../../pages/api/webhook/dispositif/update";
+import needsHandler from "../../../../pages/api/webhook/needs";
+import themesHandler from "../../../../pages/api/webhook/themes";
 
 jest.mock("../../../../lib/webhookUtils");
 
@@ -45,9 +47,23 @@ describe("Webhook API Endpoints", () => {
       Theme: {
         find: jest.fn().mockReturnValue({
           collation: jest.fn().mockReturnThis(),
+          sort: jest.fn().mockReturnThis(),
           select: jest.fn().mockResolvedValue([
             { _id: "theme1", name: { fr: "Apprendre le français" } },
             { _id: "theme2", name: { fr: "Santé" } },
+          ]),
+        }),
+      },
+      Need: {
+        find: jest.fn().mockReturnValue({
+          sort: jest.fn().mockReturnThis(),
+          select: jest.fn().mockResolvedValue([
+            {
+              _id: "need1",
+              fr: { text: "Je veux apprendre le français" },
+              theme: { _id: "theme1" },
+            },
+            { _id: "need2", fr: { text: "Je cherche un emploi" }, theme: { _id: "theme2" } },
           ]),
         }),
       },
@@ -302,6 +318,64 @@ describe("Webhook API Endpoints", () => {
           }),
         }),
       );
+    });
+  });
+
+  describe("GET /api/webhook/themes", () => {
+    it("should return 405 if method is not GET", async () => {
+      const req = mockRequest({ method: "POST" });
+      const res = mockResponse();
+      await themesHandler(req, res);
+      expect(res._getStatusCode()).toBe(405);
+    });
+
+    it("should return 401 if secret is invalid", async () => {
+      (webhookUtils.validateWebhookSecret as jest.Mock).mockReturnValue(false);
+      const req = mockRequest({ method: "GET" });
+      const res = mockResponse();
+      await themesHandler(req, res);
+      expect(res._getStatusCode()).toBe(401);
+    });
+
+    it("should return 200 with the list of themes in id/name format", async () => {
+      const req = mockRequest({ method: "GET" });
+      const res = mockResponse();
+      await themesHandler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = JSON.parse(res._getData());
+      expect(data).toEqual([
+        { id: "theme1", name: "Apprendre le français" },
+        { id: "theme2", name: "Santé" },
+      ]);
+    });
+  });
+
+  describe("GET /api/webhook/needs", () => {
+    it("should return 405 if method is not GET", async () => {
+      const req = mockRequest({ method: "POST" });
+      const res = mockResponse();
+      await needsHandler(req, res);
+      expect(res._getStatusCode()).toBe(405);
+    });
+
+    it("should return 401 if secret is invalid", async () => {
+      (webhookUtils.validateWebhookSecret as jest.Mock).mockReturnValue(false);
+      const req = mockRequest({ method: "GET" });
+      const res = mockResponse();
+      await needsHandler(req, res);
+      expect(res._getStatusCode()).toBe(401);
+    });
+
+    it("should return 200 with the list of needs in id/name/themeId format", async () => {
+      const req = mockRequest({ method: "GET" });
+      const res = mockResponse();
+      await needsHandler(req, res);
+      expect(res._getStatusCode()).toBe(200);
+      const data = JSON.parse(res._getData());
+      expect(data).toEqual([
+        { id: "need1", name: "Je veux apprendre le français", themeId: "theme1" },
+        { id: "need2", name: "Je cherche un emploi", themeId: "theme2" },
+      ]);
     });
   });
 });

--- a/apps/client/src/lib/webhookUtils.ts
+++ b/apps/client/src/lib/webhookUtils.ts
@@ -79,11 +79,14 @@ export const getWebhookModels = async () => {
   const Theme =
     mongoose.models.Theme ||
     mongoose.model("Theme", new mongoose.Schema({}, { strict: false, collection: "themes" }));
+  const Need =
+    mongoose.models.Need ||
+    mongoose.model("Need", new mongoose.Schema({}, { strict: false, collection: "needs" }));
   const Log =
     mongoose.models.Log ||
     mongoose.model("Log", new mongoose.Schema({}, { strict: false, collection: "logs" }));
 
-  return { User, Role, Dispositif, Theme, Log };
+  return { User, Role, Dispositif, Theme, Need, Log };
 };
 
 export const checkWebhookPermissions = (

--- a/apps/client/src/pages/api/webhook/needs.ts
+++ b/apps/client/src/pages/api/webhook/needs.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  getWebhookModels,
+  standardErrorResponse,
+  validateSourceIP,
+  validateWebhookSecret,
+} from "~/lib/webhookUtils";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "GET") {
+    return res.status(405).json({ message: "Method Not Allowed" });
+  }
+
+  if (!validateWebhookSecret(req)) {
+    return res.status(401).json({ message: "Accès refusé : Secret invalide ou manquant" });
+  }
+
+  if (!validateSourceIP(req)) {
+    return res.status(403).json({ message: "Accès refusé : IP non autorisée" });
+  }
+
+  try {
+    const { Need } = await getWebhookModels();
+    const needs = await Need.find({}).sort({ position: 1 }).select("_id fr.text theme");
+
+    return res.status(200).json(
+      needs.map((n: any) => ({
+        id: n._id,
+        name: n.fr?.text,
+        themeId: n.theme?._id ?? n.theme,
+      })),
+    );
+  } catch (error: unknown) {
+    return standardErrorResponse(res, error);
+  }
+};
+
+export default handler;

--- a/apps/client/src/pages/api/webhook/needs.ts
+++ b/apps/client/src/pages/api/webhook/needs.ts
@@ -6,6 +6,18 @@ import {
   validateWebhookSecret,
 } from "~/lib/webhookUtils";
 
+interface NeedDocument {
+  _id: string;
+  fr?: { text: string };
+  theme?: { _id: string } | string;
+}
+
+const getThemeId = (theme: NeedDocument["theme"]): string | undefined => {
+  if (!theme) return undefined;
+  if (typeof theme === "string") return theme;
+  return theme._id;
+};
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "GET") {
     return res.status(405).json({ message: "Method Not Allowed" });
@@ -24,10 +36,10 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const needs = await Need.find({}).sort({ position: 1 }).select("_id fr.text theme");
 
     return res.status(200).json(
-      needs.map((n: any) => ({
+      needs.map((n: NeedDocument) => ({
         id: n._id,
         name: n.fr?.text,
-        themeId: n.theme?._id ?? n.theme,
+        themeId: getThemeId(n.theme),
       })),
     );
   } catch (error: unknown) {

--- a/apps/client/src/pages/api/webhook/themes.ts
+++ b/apps/client/src/pages/api/webhook/themes.ts
@@ -6,6 +6,11 @@ import {
   validateWebhookSecret,
 } from "~/lib/webhookUtils";
 
+interface ThemeDocument {
+  _id: string;
+  name?: { fr: string };
+}
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   if (req.method !== "GET") {
     return res.status(405).json({ message: "Method Not Allowed" });
@@ -24,7 +29,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
     const themes = await Theme.find({}).sort({ position: 1 }).select("_id name.fr");
 
     return res.status(200).json(
-      themes.map((t: any) => ({
+      themes.map((t: ThemeDocument) => ({
         id: t._id,
         name: t.name?.fr,
       })),

--- a/apps/client/src/pages/api/webhook/themes.ts
+++ b/apps/client/src/pages/api/webhook/themes.ts
@@ -1,0 +1,37 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  getWebhookModels,
+  standardErrorResponse,
+  validateSourceIP,
+  validateWebhookSecret,
+} from "~/lib/webhookUtils";
+
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== "GET") {
+    return res.status(405).json({ message: "Method Not Allowed" });
+  }
+
+  if (!validateWebhookSecret(req)) {
+    return res.status(401).json({ message: "Accès refusé : Secret invalide ou manquant" });
+  }
+
+  if (!validateSourceIP(req)) {
+    return res.status(403).json({ message: "Accès refusé : IP non autorisée" });
+  }
+
+  try {
+    const { Theme } = await getWebhookModels();
+    const themes = await Theme.find({}).sort({ position: 1 }).select("_id name.fr");
+
+    return res.status(200).json(
+      themes.map((t: any) => ({
+        id: t._id,
+        name: t.name?.fr,
+      })),
+    );
+  } catch (error: unknown) {
+    return standardErrorResponse(res, error);
+  }
+};
+
+export default handler;

--- a/documentation/client/webhooks.md
+++ b/documentation/client/webhooks.md
@@ -124,6 +124,42 @@ Archives an existing dispositif by setting its status to `Archivé`.
   }
   ```
 
+### 5. List Themes
+
+Returns the list of available themes in id/value format. Useful to populate selectors in external tools and to build valid webhook payloads (theme names must match exactly).
+
+- **URL**: `/api/webhook/themes`
+- **Method**: `GET`
+- **Response** (`200 OK`):
+  ```json
+  [
+    { "id": "507f1f77bcf86cd799439011", "name": "Apprendre le français" },
+    { "id": "507f1f77bcf86cd799439012", "name": "Emploi" }
+  ]
+  ```
+
+> [!NOTE]
+> Results are sorted by display position. The `name` field corresponds to `name.fr` and is the value expected in the `themes` array of the create/update endpoints.
+
+---
+
+### 6. List Needs
+
+Returns the list of available needs in id/value format, grouped by their associated theme.
+
+- **URL**: `/api/webhook/needs`
+- **Method**: `GET`
+- **Response** (`200 OK`):
+  ```json
+  [
+    { "id": "507f1f77bcf86cd799439021", "name": "Je veux apprendre le français", "themeId": "507f1f77bcf86cd799439011" },
+    { "id": "507f1f77bcf86cd799439022", "name": "Je cherche un emploi", "themeId": "507f1f77bcf86cd799439012" }
+  ]
+  ```
+
+> [!NOTE]
+> Results are sorted by display position. The `themeId` field allows grouping needs by theme on the client side.
+
 ---
 
 ## Error Handling


### PR DESCRIPTION
Ajout de deux endpoints webhook pour exposer les données de référence (themes et needs) au Content Playground.

## Nouveaux endpoints

**`GET /api/webhook/themes`**
Retourne la liste des thèmes disponibles au format id/valeur, triés par position d'affichage.
```json
[
  { "id": "63286a015d31b2c0cad9960a", "name": "Apprendre le français" },
  ...
]
```

**`GET /api/webhook/needs`**
Retourne la liste des besoins au format id/valeur avec leur thème parent, triés par position.
```json
[
  { "id": "...", "name": "Je veux apprendre le français", "themeId": "63286a015d31b2c0cad9960a" },
  ...
]
```

## Authentification
Les deux endpoints utilisent le même mécanisme d'authentification que les autres webhooks :
- Header `webhook-secret` requis
- Validation IP via `ALLOWED_WEBHOOK_IPS`

## Implémentation
- Ajout du modèle `Need` dans `getWebhookModels()` pour isolation du contexte webhook
- Pattern cohérent avec les endpoints existants (create, update, archive, translation)
- 6 nouveaux tests ajoutés (405, 401, 200 pour chaque endpoint)
- Documentation mise à jour (sections 5 et 6)

## Test plan
- [x] Tests automatisés passent (23/23)
- [x] TypeScript compilation OK
- [x] Test manuel réalisé en local avec curl

## Files changed
- `apps/client/src/lib/webhookUtils.ts` — ajout modèle Need
- `apps/client/src/pages/api/webhook/themes.ts` — nouveau endpoint
- `apps/client/src/pages/api/webhook/needs.ts` — nouveau endpoint
- `apps/client/src/__tests__/api/webhook/dispositif/webhook.test.ts` — tests
- `documentation/client/webhooks.md` — documentation

Contributes to : RI-1038

Linked to : https://github.com/refugies-info/playground/pull/126