### PR TITLE
[server] disable publishedFiche emails for réseau Mens (hotfix staging)

### DIFF
--- a/apps/server/src/modules/mail/__tests__/helpers.test.ts
+++ b/apps/server/src/modules/mail/__tests__/helpers.test.ts
@@ -13,8 +13,12 @@ describe("consentsToEmail - réseau MENS restrictions", () => {
     expect(consentsToEmail(MENS_ID, "resetPassword")).toBe(true);
   });
 
-  it("should allow publishedFicheToStructureMembers", () => {
-    expect(consentsToEmail(MENS_ID, "publishedFicheToStructureMembers")).toBe(true);
+  it("should block publishedFicheToStructureMembers", () => {
+    expect(consentsToEmail(MENS_ID, "publishedFicheToStructureMembers")).toBe(false);
+  });
+
+  it("should block publishedFicheToCreator", () => {
+    expect(consentsToEmail(MENS_ID, "publishedFicheToCreator")).toBe(false);
   });
 
   it("should block newMember", () => {

--- a/apps/server/src/modules/mail/data.ts
+++ b/apps/server/src/modules/mail/data.ts
@@ -30,5 +30,9 @@ export const PREFS: Record<string, Record<TemplateName, boolean>> = {
   // "programme agir"
   "65f8245fd9babd17f5825aac": DEFAULT_MAIL_PREFS,
   // "réseau Mens"
-  "63985164fd1bf4e22792ef6e": DEFAULT_MAIL_PREFS,
+  "63985164fd1bf4e22792ef6e": {
+    ...DEFAULT_MAIL_PREFS,
+    publishedFicheToCreator: false,
+    publishedFicheToStructureMembers: false,
+  },
 };


### PR DESCRIPTION
## Summary

Hotfix for staging — cherry-pick of #3511.

- Sets `publishedFicheToStructureMembers: false` and `publishedFicheToCreator: false` in the réseau Mens mail prefs override
- Updates test suite accordingly

## Test plan

- [x] `pnpm test:server` — all mail tests pass (8/8) on this branch

Refs RI-1114

👾 Generated with [Letta Code](https://letta.com)