### PR TITLE
[ci] fix migrate workflows: use push trigger to satisfy env protection rules

### DIFF
--- a/.github/workflows/migrate_production.yaml
+++ b/.github/workflows/migrate_production.yaml
@@ -4,15 +4,14 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - production
   workflow_dispatch:
 
 jobs:
   migrate-production:
-    if: github.event.pull_request.merged == true && github.base_ref == 'production'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: master-migrate
     concurrency:

--- a/.github/workflows/migrate_staging.yaml
+++ b/.github/workflows/migrate_staging.yaml
@@ -4,15 +4,14 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - staging
   workflow_dispatch:
 
 jobs:
   migrate-staging:
-    if: github.event.pull_request.merged == true && github.base_ref == 'staging'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: staging-migrate
     concurrency:


### PR DESCRIPTION
## Summary
- Replace `pull_request [closed]` trigger with `push` on `staging`/`production` branches in both migrate workflows
- The old trigger ran in the `refs/pull/N/merge` context which was rejected by `staging-migrate` and `master-migrate` environment protection rules
- `push` trigger fires on the real branch ref after a PR merges, satisfying the protection rules

## Test plan
- [ ] Merge a PR into `staging` and verify the `migrate-staging` workflow runs successfully
- [ ] Verify `workflow_dispatch` still works for manual runs on both workflows

👾 Generated with [Letta Code](https://letta.com)