### PR TITLE
[STG] Release

### DIFF
--- a/.github/workflows/migrate_production.yaml
+++ b/.github/workflows/migrate_production.yaml
@@ -4,15 +4,14 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - production
   workflow_dispatch:
 
 jobs:
   migrate-production:
-    if: github.event.pull_request.merged == true && github.base_ref == 'production'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: master-migrate
     concurrency:

--- a/.github/workflows/migrate_staging.yaml
+++ b/.github/workflows/migrate_staging.yaml
@@ -4,15 +4,14 @@ permissions:
   contents: read
 
 on:
-  pull_request:
-    types: [closed]
+  push:
     branches:
       - staging
   workflow_dispatch:
 
 jobs:
   migrate-staging:
-    if: github.event.pull_request.merged == true && github.base_ref == 'staging'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: staging-migrate
     concurrency:


### PR DESCRIPTION
Replace pull_request trigger with push on staging/production branches.
The PR merge ref (refs/pull/N/merge) was being rejected by the
staging-migrate and master-migrate environment protection rules which
only allow deployments from real branch refs.

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta <noreply@letta.com>
