### PR TITLE
[server] hotfix: disable publishedFiche emails for réseau Mens

### DIFF
--- a/apps/server/src/modules/mail/__tests__/helpers.test.ts
+++ b/apps/server/src/modules/mail/__tests__/helpers.test.ts
@@ -13,8 +13,12 @@ describe("consentsToEmail - réseau MENS restrictions", () => {
     expect(consentsToEmail(MENS_ID, "resetPassword")).toBe(true);
   });
 
-  it("should allow publishedFicheToStructureMembers", () => {
-    expect(consentsToEmail(MENS_ID, "publishedFicheToStructureMembers")).toBe(true);
+  it("should block publishedFicheToStructureMembers", () => {
+    expect(consentsToEmail(MENS_ID, "publishedFicheToStructureMembers")).toBe(false);
+  });
+
+  it("should block publishedFicheToCreator", () => {
+    expect(consentsToEmail(MENS_ID, "publishedFicheToCreator")).toBe(false);
   });
 
   it("should block newMember", () => {

--- a/apps/server/src/modules/mail/data.ts
+++ b/apps/server/src/modules/mail/data.ts
@@ -30,5 +30,9 @@ export const PREFS: Record<string, Record<TemplateName, boolean>> = {
   // "programme agir"
   "65f8245fd9babd17f5825aac": DEFAULT_MAIL_PREFS,
   // "réseau Mens"
-  "63985164fd1bf4e22792ef6e": DEFAULT_MAIL_PREFS,
+  "63985164fd1bf4e22792ef6e": {
+    ...DEFAULT_MAIL_PREFS,
+    publishedFicheToCreator: false,
+    publishedFicheToStructureMembers: false,
+  },
 };


### PR DESCRIPTION
## Summary

Hotfix for production — cherry-pick of #3511.

- Sets `publishedFicheToStructureMembers: false` and `publishedFicheToCreator: false` in the réseau Mens mail prefs override (was using `DEFAULT_MAIL_PREFS` which had both as `true`)
- Updates test suite accordingly (8/8 mail tests pass)

Closes RI-1114

## Test plan
- [x] Cherry-picked cleanly from `dev` (commit `cce61d02`)
- [x] `pnpm test:server` — all mail tests pass (8/8)

👾 Generated with [Letta Code](https://letta.com)