### PR TITLE
[STG] Release

### DIFF
--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -1,0 +1,150 @@
+name: Release Pipeline
+
+# Orchestrates backend → frontend deployments in sequence so that the
+# frontend build (which prerenders via SSR) always runs against an
+# already-deployed backend.
+#
+# Mobile builds are NOT included here — the EAS build does not call the
+# backend at build time, so build_mobile_staging.yaml / build_mobile_prod.yaml
+# can continue to run independently.
+#
+# IMPORTANT: disable the GCP Cloud Build branch-push triggers for
+# backend-stag, frontend-stag, backend-prod, frontend-prod after merging
+# this PR, otherwise builds will fire twice.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - staging
+      - production
+  workflow_dispatch:
+
+jobs:
+  # ─── Detect which components changed ───────────────────────────────────────
+  detect-changes:
+    name: Detect changed components
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            backend:
+              - 'apps/server/**'
+              - 'packages/api-types/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+            frontend:
+              - 'apps/client/**'
+              - 'packages/ui/**'
+              - 'packages/api-types/**'
+              - 'pnpm-lock.yaml'
+              - 'package.json'
+
+  # ─── Backend — always before frontend ──────────────────────────────────────
+  deploy-backend:
+    name: Deploy Backend
+    needs: detect-changes
+    if: needs.detect-changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Trigger and await backend Cloud Build
+        run: |
+          if [[ "${{ github.ref_name }}" == "staging" ]]; then
+            TRIGGER_ID="9725eef6-b227-4cdb-af3f-4ff263eb9d35"
+          else
+            TRIGGER_ID="5afe00f9-f11c-41d8-a4cc-5936cb6b90ec"
+          fi
+
+          echo "Triggering backend Cloud Build ($TRIGGER_ID) on ${{ github.ref_name }}..."
+          BUILD_ID=$(gcloud builds triggers run "$TRIGGER_ID" \
+            --branch="${{ github.ref_name }}" \
+            --project=refugies-info \
+            --format='value(metadata.build.id)')
+
+          echo "Build ID: $BUILD_ID"
+          echo "🔗 https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=refugies-info"
+
+          until [[ "$STATUS" == "SUCCESS" || "$STATUS" == "FAILURE" || "$STATUS" == "CANCELLED" || "$STATUS" == "TIMEOUT" || "$STATUS" == "EXPIRED" ]]; do
+            sleep 30
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project=refugies-info \
+              --format='value(status)')
+            echo "Status: $STATUS"
+          done
+
+          if [[ "$STATUS" != "SUCCESS" ]]; then
+            echo "❌ Backend build failed: $STATUS"
+            exit 1
+          fi
+          echo "✅ Backend deployed successfully"
+
+  # ─── Frontend — runs after backend (or immediately if no backend changes) ──
+  deploy-frontend:
+    name: Deploy Frontend
+    needs: [detect-changes, deploy-backend]
+    # Run if frontend changed AND (backend succeeded OR backend was skipped)
+    if: |
+      always() &&
+      needs.detect-changes.outputs.frontend == 'true' &&
+      (needs.deploy-backend.result == 'success' || needs.deploy-backend.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Trigger and await frontend Cloud Build
+        run: |
+          if [[ "${{ github.ref_name }}" == "staging" ]]; then
+            TRIGGER_ID="13256662-bcdc-4526-88fe-475660d66fac"
+          else
+            TRIGGER_ID="bc32ef8b-ee21-489a-be3e-ac2b0721d310"
+          fi
+
+          echo "Triggering frontend Cloud Build ($TRIGGER_ID) on ${{ github.ref_name }}..."
+          BUILD_ID=$(gcloud builds triggers run "$TRIGGER_ID" \
+            --branch="${{ github.ref_name }}" \
+            --project=refugies-info \
+            --format='value(metadata.build.id)')
+
+          echo "Build ID: $BUILD_ID"
+          echo "🔗 https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=refugies-info"
+
+          until [[ "$STATUS" == "SUCCESS" || "$STATUS" == "FAILURE" || "$STATUS" == "CANCELLED" || "$STATUS" == "TIMEOUT" || "$STATUS" == "EXPIRED" ]]; do
+            sleep 30
+            STATUS=$(gcloud builds describe "$BUILD_ID" \
+              --project=refugies-info \
+              --format='value(status)')
+            echo "Status: $STATUS"
+          done
+
+          if [[ "$STATUS" != "SUCCESS" ]]; then
+            echo "❌ Frontend build failed: $STATUS"
+            exit 1
+          fi
+          echo "✅ Frontend deployed successfully"


### PR DESCRIPTION
Introduces a GitHub Actions orchestration workflow that ensures the backend
is always deployed and healthy before the frontend build starts. This
prevents frontend SSR prerendering from hitting a stale or unavailable API.

- detect-changes job uses dorny/paths-filter to determine which components
  changed, avoiding unnecessary builds
- deploy-backend triggers GCP Cloud Build and polls until completion
- deploy-frontend only starts after backend succeeds (or was skipped when
  no backend changes detected)
- Supports both staging and production branches via trigger ID mapping
- Mobile builds remain in their own workflows (EAS build does not call
  the backend at build time)

⚠️  After merging: disable branch-push triggers for backend-stag,
frontend-stag, backend-prod, frontend-prod in GCP Cloud Build Console
to avoid duplicate builds.

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta <noreply@letta.com>
