### PR TITLE
[workspace] remove .envrc from repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-layout node
-dotenv

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage
 # misc
 .DS_Store
 .env
+.envrc
 .env.local*
 .env.development.local
 .env.test.local


### PR DESCRIPTION
## Summary
- Remove tracked `.envrc` file (direnv config) from the repository
- Add `.envrc` to `.gitignore` so it stays local to each developer's machine

## Test plan
- [ ] Verify `.envrc` is no longer in the repo after merge
- [ ] Verify local `.envrc` files are ignored by git going forward

🤖 Generated with [Letta Code](https://letta.com)