### PR TITLE
[STG] Release

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,5 @@
+[post-create]
+deps = "pnpm install"
+
+[post-start]
+copy = "wt step copy-ignored"

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-layout node
-dotenv

--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Detect backend changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: backend
         if: github.event_name == 'push'
         with:
@@ -48,7 +48,7 @@ jobs:
             package.json
 
       - name: Detect frontend changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: frontend
         if: github.event_name == 'push'
         with:
@@ -60,7 +60,7 @@ jobs:
             package.json
 
       - name: Detect mobile changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@v47
         id: mobile
         if: github.event_name == 'push'
         with:

--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -84,7 +84,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Trigger and await backend Cloud Build
         run: |
@@ -135,7 +135,7 @@ jobs:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Trigger and await frontend Cloud Build
         run: |

--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -79,7 +79,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -130,7 +130,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ coverage
 # misc
 .DS_Store
 .env
+.envrc
 .env.local*
 .env.development.local
 .env.test.local

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -5,9 +5,6 @@
 .env
 .envrc
 
-# Dependencies (pnpm store is shared, but node_modules links need to exist)
-node_modules/
-
 # Build caches
 .next/
 .turbo/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,16 @@
+# Files to copy from primary worktree via `wt step copy-ignored`
+# Must also be gitignored to be copied.
+
+# Environment files
+.env
+.envrc
+
+# Dependencies (pnpm store is shared, but node_modules links need to exist)
+node_modules/
+
+# Build caches
+.next/
+.turbo/
+
+# Agent config
+.letta/

--- a/apps/client/src/__tests__/api/webhook/dispositif/webhook.test.ts
+++ b/apps/client/src/__tests__/api/webhook/dispositif/webhook.test.ts
@@ -75,8 +75,11 @@ describe("Webhook API Endpoints", () => {
       ...mockUser,
       roles: [{ nom: "Admin" }],
     });
-    (webhookUtils.getThemeIdsByNames as jest.Mock).mockResolvedValue(["theme1", "theme2"]);
+    // Theme IDs are now passed directly by Luna, no resolution needed
     (webhookUtils.validateSourceIP as jest.Mock).mockReturnValue(true);
+    (webhookUtils.convertMetadatasDates as jest.Mock).mockImplementation(
+      (metadatas: any) => metadatas,
+    );
     // Restoration of the real checkWebhookPermissions function to test it
     const originalUtils = jest.requireActual("../../../../lib/webhookUtils");
     (webhookUtils.checkWebhookPermissions as jest.Mock).mockImplementation(
@@ -85,7 +88,7 @@ describe("Webhook API Endpoints", () => {
   });
 
   describe("POST /api/webhook/dispositif/create", () => {
-    it("should create a new dispositif successfully with origin and resolved themes", async () => {
+    it("should create a new dispositif successfully with origin and theme IDs", async () => {
       const req = mockRequest({
         method: "POST",
         headers: { "webhook-secret": mockSecret },
@@ -93,7 +96,8 @@ describe("Webhook API Endpoints", () => {
           email: mockEmail,
           dispositif: {
             origin: DispositifOrigin.RI,
-            themes: ["Apprendre le français", "Santé"],
+            theme: "507f1f77bcf86cd799439011",
+            secondaryThemes: ["507f1f77bcf86cd799439012"],
             translations: {
               fr: {
                 content: {
@@ -114,13 +118,13 @@ describe("Webhook API Endpoints", () => {
       expect(data.message).toBe("Dispositif created successfully");
       expect(data.id).toBe("newId");
 
-      // Verify origin and resolved themes were passed to create
+      // Verify origin and theme IDs were passed to create
       const { Dispositif } = await webhookUtils.getWebhookModels();
       expect(Dispositif.create).toHaveBeenCalledWith(
         expect.objectContaining({
           origin: DispositifOrigin.RI,
-          theme: "theme1",
-          secondaryThemes: ["theme2"],
+          theme: "507f1f77bcf86cd799439011",
+          secondaryThemes: ["507f1f77bcf86cd799439012"],
           status: DispositifStatus.ACTIVE,
         }),
       );
@@ -177,7 +181,8 @@ describe("Webhook API Endpoints", () => {
           email: mockEmail,
           dispositif: {
             origin: DispositifOrigin.RI,
-            themes: ["Apprendre le français", "Santé"],
+            theme: "507f1f77bcf86cd799439011",
+            secondaryThemes: ["507f1f77bcf86cd799439012"],
             translations: {
               fr: {
                 content: {
@@ -211,14 +216,15 @@ describe("Webhook API Endpoints", () => {
   });
 
   describe("POST /api/webhook/dispositif/update", () => {
-    it("should update a dispositif successfully with resolved themes", async () => {
+    it("should update a dispositif successfully with theme IDs", async () => {
       const req = mockRequest({
         method: "POST",
         body: {
           email: mockEmail,
           dispositif: {
             _id: "507f1f77bcf86cd799439011",
-            themes: ["Santé"],
+            theme: "507f1f77bcf86cd799439011",
+            secondaryThemes: ["507f1f77bcf86cd799439012"],
             translations: {
               fr: {
                 content: { titreInformatif: "Updated" },
@@ -239,7 +245,8 @@ describe("Webhook API Endpoints", () => {
         "507f1f77bcf86cd799439011",
         expect.objectContaining({
           $set: expect.objectContaining({
-            theme: "theme1", // Based on getThemeIdsByNames mock in beforeEach
+            theme: "507f1f77bcf86cd799439011",
+            secondaryThemes: ["507f1f77bcf86cd799439012"],
           }),
         }),
       );

--- a/apps/client/src/lib/webhookSchemas.ts
+++ b/apps/client/src/lib/webhookSchemas.ts
@@ -66,7 +66,9 @@ const AgeSchema = z
 const PriceSchema = z.object(
   {
     values: z.array(
-      z.number().min(0, { message: "Les valeurs de prix doivent être positives ou nulles" }),
+      z.number().min(0, {
+        message: "Les valeurs de prix doivent être positives ou nulles",
+      }),
       {
         message:
           "Le champ 'values' doit être un tableau de nombres (0 = gratuit, vide = montant libre)",
@@ -159,16 +161,12 @@ const FrequencySchema = z.object(
 const SessionSchema = z
   .object(
     {
-      startDate: z
-        .string()
-        .datetime({
-          message: "startDate doit être une date ISO 8601 valide (ex: 2025-11-24T00:00:00.000Z)",
-        }),
-      endDate: z
-        .string()
-        .datetime({
-          message: "endDate doit être une date ISO 8601 valide (ex: 2026-01-16T00:00:00.000Z)",
-        }),
+      startDate: z.string().datetime({
+        message: "startDate doit être une date ISO 8601 valide (ex: 2025-11-24T00:00:00.000Z)",
+      }),
+      endDate: z.string().datetime({
+        message: "endDate doit être une date ISO 8601 valide (ex: 2026-01-16T00:00:00.000Z)",
+      }),
       registrationStartDate: z
         .string()
         .datetime({
@@ -189,7 +187,9 @@ const SessionSchema = z
         .optional(),
       url: z
         .string()
-        .url({ message: "url doit être une URL valide (ex: https://example.com/session/123)" })
+        .url({
+          message: "url doit être une URL valide (ex: https://example.com/session/123)",
+        })
         .optional(),
     },
     {
@@ -235,6 +235,8 @@ const SessionSchema = z
       path: ["registrationEndDate"],
     },
   );
+
+export type WebhookSession = z.infer<typeof SessionSchema>;
 
 // Main Metadatas schema with detailed error messages
 export const MetadatasSchema = z.object(
@@ -329,13 +331,16 @@ export const MetadatasSchema = z.object(
       .optional(),
 
     sessions: z
-      .array(SessionSchema, { message: "sessions doit être un tableau de sessions" })
+      .array(SessionSchema, {
+        message: "sessions doit être un tableau de sessions",
+      })
       .optional(),
   },
   {
     message: "Structure des métadonnées invalide",
   },
 );
+export type WebhookMetadatas = z.infer<typeof MetadatasSchema>;
 
 import { activatedLanguages } from "../data/activatedLanguages";
 

--- a/apps/client/src/lib/webhookSchemas.ts
+++ b/apps/client/src/lib/webhookSchemas.ts
@@ -22,6 +22,321 @@ const DispositifContentSchema = z
   })
   .passthrough(); // Allow some flexibility but still strict at the top level
 
+// ============================================
+// SPONSOR SCHEMA
+// ============================================
+
+const SponsorSchema = z.object({
+  name: z.string().min(1, { message: "Le nom du sponsor est requis" }),
+  logo: z.string().url({ message: "Le logo doit être une URL valide" }).optional(),
+  link: z.string().url({ message: "Le lien doit être une URL valide" }).optional(),
+});
+
+// ============================================
+// METADATAS SCHEMAS - with detailed error messages
+// ============================================
+
+// Age schema with detailed validation
+const AgeSchema = z
+  .object(
+    {
+      type: z.enum(["lessThan", "moreThan", "between"], {
+        message: "Type d'âge invalide. Valeurs autorisées: 'lessThan', 'moreThan', 'between'",
+      }),
+      ages: z.array(z.number().int({ message: "Les âges doivent être des nombres entiers" }), {
+        message: "Le champ 'ages' doit être un tableau de nombres",
+      }),
+    },
+    {
+      message: "Structure d'âge invalide",
+    },
+  )
+  .refine(
+    (data) => {
+      if (data.type === "between") return data.ages.length === 2;
+      return data.ages.length >= 1;
+    },
+    {
+      message:
+        "Pour 'between', exactement 2 âges sont requis. Pour les autres types, au moins 1 âge.",
+    },
+  );
+
+// Price schema with detailed validation
+const PriceSchema = z.object(
+  {
+    values: z.array(
+      z.number().min(0, { message: "Les valeurs de prix doivent être positives ou nulles" }),
+      {
+        message:
+          "Le champ 'values' doit être un tableau de nombres (0 = gratuit, vide = montant libre)",
+      },
+    ),
+    details: z
+      .enum(["once", "eachTime", "hour", "day", "week", "month", "trimester", "semester", "year"], {
+        message:
+          "Détails de prix invalide. Valeurs autorisées: 'once', 'eachTime', 'hour', 'day', 'week', 'month', 'trimester', 'semester', 'year'",
+      })
+      .optional(),
+  },
+  {
+    message: "Structure de prix invalide",
+  },
+);
+
+// Commitment schema with detailed validation
+const CommitmentSchema = z.object(
+  {
+    amountDetails: z.enum(["minimum", "maximum", "approximately", "exactly", "between"], {
+      message:
+        "Type de détails d'engagement invalide. Valeurs autorisées: 'minimum', 'maximum', 'approximately', 'exactly', 'between'",
+    }),
+    hours: z.array(
+      z.number().positive({ message: "Les heures doivent être des nombres positifs" }),
+      {
+        message: "Le champ 'hours' doit être un tableau de nombres positifs",
+      },
+    ),
+    timeUnit: z.enum(
+      [
+        "sessions",
+        "hours",
+        "half-days",
+        "days",
+        "weeks",
+        "months",
+        "trimesters",
+        "semesters",
+        "years",
+      ],
+      {
+        message:
+          "Unité de temps invalide. Valeurs autorisées: 'sessions', 'hours', 'half-days', 'days', 'weeks', 'months', 'trimesters', 'semesters', 'years'",
+      },
+    ),
+  },
+  {
+    message: "Structure d'engagement invalide",
+  },
+);
+
+// Frequency schema with detailed validation
+const FrequencySchema = z.object(
+  {
+    amountDetails: z.enum(["minimum", "maximum", "approximately", "exactly"], {
+      message:
+        "Type de détails de fréquence invalide. Valeurs autorisées: 'minimum', 'maximum', 'approximately', 'exactly'",
+    }),
+    hours: z.number().positive({ message: "Le nombre d'heures doit être un nombre positif" }),
+    timeUnit: z.enum(
+      [
+        "sessions",
+        "hours",
+        "half-days",
+        "days",
+        "weeks",
+        "months",
+        "trimesters",
+        "semesters",
+        "years",
+      ],
+      {
+        message:
+          "Unité de temps invalide. Valeurs autorisées: 'sessions', 'hours', 'half-days', 'days', 'weeks', 'months', 'trimesters', 'semesters', 'years'",
+      },
+    ),
+    frequencyUnit: z.enum(["session", "day", "week", "month", "trimester", "semester", "year"], {
+      message:
+        "Unité de fréquence invalide. Valeurs autorisées: 'session', 'day', 'week', 'month', 'trimester', 'semester', 'year'",
+    }),
+  },
+  {
+    message: "Structure de fréquence invalide",
+  },
+);
+
+// Session schema with detailed validation for dates
+const SessionSchema = z
+  .object(
+    {
+      startDate: z
+        .string()
+        .datetime({
+          message: "startDate doit être une date ISO 8601 valide (ex: 2025-11-24T00:00:00.000Z)",
+        }),
+      endDate: z
+        .string()
+        .datetime({
+          message: "endDate doit être une date ISO 8601 valide (ex: 2026-01-16T00:00:00.000Z)",
+        }),
+      registrationStartDate: z
+        .string()
+        .datetime({
+          message:
+            "registrationStartDate doit être une date ISO 8601 valide (ex: 2025-10-01T00:00:00.000Z)",
+        })
+        .optional(),
+      registrationEndDate: z
+        .string()
+        .datetime({
+          message:
+            "registrationEndDate doit être une date ISO 8601 valide (ex: 2025-11-20T23:59:59.000Z)",
+        })
+        .optional(),
+      externalRef: z
+        .string()
+        .min(1, { message: "externalRef ne peut pas être une chaîne vide" })
+        .optional(),
+      url: z
+        .string()
+        .url({ message: "url doit être une URL valide (ex: https://example.com/session/123)" })
+        .optional(),
+    },
+    {
+      message: "Structure de session invalide",
+    },
+  )
+  .refine(
+    (data) => {
+      const start = new Date(data.startDate);
+      const end = new Date(data.endDate);
+      return start <= end;
+    },
+    {
+      message: "startDate doit être antérieure ou égale à endDate",
+      path: ["startDate"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (data.registrationStartDate && data.registrationEndDate) {
+        const regStart = new Date(data.registrationStartDate);
+        const regEnd = new Date(data.registrationEndDate);
+        return regStart <= regEnd;
+      }
+      return true;
+    },
+    {
+      message: "registrationStartDate doit être antérieure ou égale à registrationEndDate",
+      path: ["registrationStartDate"],
+    },
+  )
+  .refine(
+    (data) => {
+      if (data.registrationEndDate && data.startDate) {
+        const regEnd = new Date(data.registrationEndDate);
+        const start = new Date(data.startDate);
+        return regEnd <= start;
+      }
+      return true;
+    },
+    {
+      message: "registrationEndDate doit être antérieure ou égale à startDate de la session",
+      path: ["registrationEndDate"],
+    },
+  );
+
+// Main Metadatas schema with detailed error messages
+export const MetadatasSchema = z.object(
+  {
+    location: z
+      .union([
+        z.enum(["france", "online"], {
+          message: "Location générale invalide. Valeurs autorisées: 'france', 'online'",
+        }),
+        z.array(z.string().min(1, { message: "Les départements ne peuvent pas être vides" }), {
+          message: "La location par département doit être un tableau de strings non vides",
+        }),
+      ])
+      .optional(),
+
+    frenchLevel: z
+      .array(
+        z.enum(["alpha", "A1", "A2", "B1", "B2", "C1", "C2"], {
+          message:
+            "Niveau de français invalide. Valeurs autorisées: 'alpha', 'A1', 'A2', 'B1', 'B2', 'C1', 'C2'",
+        }),
+        {
+          message: "frenchLevel doit être un tableau de niveaux de français",
+        },
+      )
+      .optional(),
+
+    age: AgeSchema.optional(),
+
+    price: PriceSchema.optional(),
+
+    publicStatus: z
+      .array(
+        z.enum(["asile", "refugie", "subsidiaire", "temporaire", "apatride", "french"], {
+          message:
+            "Statut public invalide. Valeurs autorisées: 'asile', 'refugie', 'subsidiaire', 'temporaire', 'apatride', 'french'",
+        }),
+        {
+          message: "publicStatus doit être un tableau de statuts",
+        },
+      )
+      .optional(),
+
+    public: z
+      .array(
+        z.enum(["family", "women", "youths", "senior", "gender"], {
+          message:
+            "Type de public invalide. Valeurs autorisées: 'family', 'women', 'youths', 'senior', 'gender'",
+        }),
+        {
+          message: "public doit être un tableau de types de public",
+        },
+      )
+      .optional(),
+
+    conditions: z
+      .array(
+        z.enum(
+          [
+            "acte naissance",
+            "titre sejour",
+            "cir",
+            "bank account",
+            "pole emploi",
+            "driver license",
+            "school",
+          ],
+          {
+            message:
+              "Condition invalide. Valeurs autorisées: 'acte naissance', 'titre sejour', 'cir', 'bank account', 'pole emploi', 'driver license', 'school'",
+          },
+        ),
+        {
+          message: "conditions doit être un tableau de conditions",
+        },
+      )
+      .optional(),
+
+    commitment: CommitmentSchema.optional(),
+
+    frequency: FrequencySchema.optional(),
+
+    timeSlots: z
+      .array(
+        z.enum(["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"], {
+          message: "Jour de la semaine invalide. Valeurs autorisées: 'monday' à 'sunday'",
+        }),
+        {
+          message: "timeSlots doit être un tableau de jours",
+        },
+      )
+      .optional(),
+
+    sessions: z
+      .array(SessionSchema, { message: "sessions doit être un tableau de sessions" })
+      .optional(),
+  },
+  {
+    message: "Structure des métadonnées invalide",
+  },
+);
+
 import { activatedLanguages } from "../data/activatedLanguages";
 
 const AllowedLanguages = activatedLanguages.map((l) => l.i18nCode);
@@ -51,8 +366,11 @@ export const DispositifCreateSchema = BaseWebhookSchema.extend({
     titreInformatif: z.string().optional(),
     titreMarque: z.string().optional(),
     abstract: z.string().optional(),
-    themes: z.array(z.string()).optional(),
+    theme: ObjectIdSchema.optional(),
+    secondaryThemes: z.array(ObjectIdSchema).optional(),
+    sponsors: z.array(SponsorSchema).optional(),
     translations: TranslationSchema,
+    metadatas: MetadatasSchema.optional(),
     origin: z
       .nativeEnum(DispositifOrigin)
       .refine((val) => val === DispositifOrigin.RI || val === DispositifOrigin.RCO, {
@@ -68,8 +386,11 @@ export const DispositifUpdateSchema = BaseWebhookSchema.extend({
     titreInformatif: z.string().optional(),
     titreMarque: z.string().optional(),
     abstract: z.string().optional(),
-    themes: z.array(z.string()).optional(),
+    theme: ObjectIdSchema.optional(),
+    secondaryThemes: z.array(ObjectIdSchema).optional(),
+    sponsors: z.array(SponsorSchema).optional(),
     translations: TranslationSchema,
+    metadatas: MetadatasSchema.optional(),
   }),
 });
 

--- a/apps/client/src/lib/webhookUtils.ts
+++ b/apps/client/src/lib/webhookUtils.ts
@@ -170,3 +170,38 @@ export const standardErrorResponse = (res: NextApiResponse, error: unknown) => {
   const errorMessage = error instanceof Error ? error.message : "An unknown error occurred";
   return res.status(500).json({ message: "Internal Server Error", error: errorMessage });
 };
+
+/**
+ * Convertit les dates ISO en objets Date MongoDB pour les métadonnées
+ * Gère spécialement les sessions avec leurs dates multiples
+ */
+export const convertMetadatasDates = (metadatas: any): any => {
+  if (!metadatas) return undefined;
+
+  const converted = { ...metadatas };
+
+  // Conversion des sessions
+  if (converted.sessions && Array.isArray(converted.sessions)) {
+    converted.sessions = converted.sessions.map((session: any, index: number) => {
+      try {
+        return {
+          ...session,
+          startDate: new Date(session.startDate),
+          endDate: new Date(session.endDate),
+          registrationStartDate: session.registrationStartDate
+            ? new Date(session.registrationStartDate)
+            : undefined,
+          registrationEndDate: session.registrationEndDate
+            ? new Date(session.registrationEndDate)
+            : undefined,
+        };
+      } catch (err) {
+        throw new Error(
+          `Erreur de conversion des dates pour la session #${index + 1}: ${(err as Error).message}`,
+        );
+      }
+    });
+  }
+
+  return converted;
+};

--- a/apps/client/src/lib/webhookUtils.ts
+++ b/apps/client/src/lib/webhookUtils.ts
@@ -3,6 +3,7 @@ import crypto from "crypto";
 import mongoose from "mongoose";
 import type { NextApiRequest, NextApiResponse } from "next";
 import dbConnect from "./db";
+import type { WebhookMetadatas, WebhookSession } from "./webhookSchemas";
 
 export const validateWebhookSecret = (req: NextApiRequest) => {
   const secret = req.headers["webhook-secret"];
@@ -175,14 +176,28 @@ export const standardErrorResponse = (res: NextApiResponse, error: unknown) => {
  * Convertit les dates ISO en objets Date MongoDB pour les métadonnées
  * Gère spécialement les sessions avec leurs dates multiples
  */
-export const convertMetadatasDates = (metadatas: any): any => {
+export const convertMetadatasDates = (
+  metadatas: WebhookMetadatas,
+):
+  | (WebhookMetadatas & {
+      sessions?: (Omit<
+        WebhookSession,
+        "startDate" | "endDate" | "registrationStartDate" | "registrationEndDate"
+      > & {
+        startDate: Date;
+        endDate: Date;
+        registrationStartDate?: Date;
+        registrationEndDate?: Date;
+      })[];
+    })
+  | undefined => {
   if (!metadatas) return undefined;
 
   const converted = { ...metadatas };
 
   // Conversion des sessions
   if (converted.sessions && Array.isArray(converted.sessions)) {
-    converted.sessions = converted.sessions.map((session: any, index: number) => {
+    converted.sessions = converted.sessions.map((session: WebhookSession, index: number) => {
       try {
         return {
           ...session,
@@ -200,8 +215,8 @@ export const convertMetadatasDates = (metadatas: any): any => {
           `Erreur de conversion des dates pour la session #${index + 1}: ${(err as Error).message}`,
         );
       }
-    });
+    }) as any; // sessions contiennent maintenant des Date, pas des strings
   }
 
-  return converted;
+  return converted as any;
 };

--- a/apps/client/src/lib/webhookUtils.ts
+++ b/apps/client/src/lib/webhookUtils.ts
@@ -177,7 +177,7 @@ export const standardErrorResponse = (res: NextApiResponse, error: unknown) => {
  * Gère spécialement les sessions avec leurs dates multiples
  */
 export const convertMetadatasDates = (
-  metadatas: WebhookMetadatas,
+  metadatas: WebhookMetadatas | undefined,
 ):
   | (WebhookMetadatas & {
       sessions?: (Omit<

--- a/apps/client/src/pages/api/webhook/dispositif/create.ts
+++ b/apps/client/src/pages/api/webhook/dispositif/create.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { DispositifCreateSchema } from "~/lib/webhookSchemas";
 import {
   checkWebhookPermissions,
-  getThemeIdsByNames,
+  convertMetadatasDates,
   getWebhookModels,
   getWebhookUser,
   standardErrorResponse,
@@ -38,7 +38,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { email, dispositif } = result.data;
 
   try {
-    const { User, Dispositif, Theme } = await getWebhookModels();
+    const { User, Dispositif } = await getWebhookModels();
     const user = await getWebhookUser(User, email);
 
     if (!user) {
@@ -49,18 +49,23 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.status(403).json({ message: "Accès refusé. Rôle requis : Admin ou Contrib" });
     }
 
-    // Resolve themes from names if provided
-    let themeId: any;
-    let secondaryThemeIds: any[] = [];
-    if (dispositif.themes && Array.isArray(dispositif.themes)) {
-      const themeIds = await getThemeIdsByNames(Theme, dispositif.themes);
-      if (themeIds.length > 0) {
-        themeId = themeIds[0];
-        secondaryThemeIds = themeIds.slice(1);
-      }
+    // Use theme IDs directly (sent by Luna)
+    const themeId = dispositif.theme;
+    const secondaryThemeIds = dispositif.secondaryThemes || [];
+
+    const { theme, secondaryThemes, ...dispositifData } = dispositif;
+
+    // Convertir les dates ISO en objets Date MongoDB
+    let metadatas;
+    try {
+      metadatas = convertMetadatasDates(dispositif.metadatas);
+    } catch (dateError) {
+      return res.status(400).json({
+        message: "Erreur de format de date dans les métadonnées",
+        error: (dateError as Error).message,
+      });
     }
 
-    const { themes, ...dispositifData } = dispositif;
     const newDispositif: any = {
       ...dispositifData,
       creatorId: user._id,
@@ -72,6 +77,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       lastModificationDate: new Date(),
       lastModificationAuthor: user._id,
       origin: dispositif.origin || DispositifOrigin.RCO, // Respect payload but default to RCO
+      metadatas,
       translations: {
         ...dispositif.translations,
         fr: {

--- a/apps/client/src/pages/api/webhook/dispositif/update.ts
+++ b/apps/client/src/pages/api/webhook/dispositif/update.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { DispositifUpdateSchema } from "~/lib/webhookSchemas";
 import {
   checkWebhookPermissions,
-  getThemeIdsByNames,
+  convertMetadatasDates,
   getWebhookModels,
   getWebhookUser,
   standardErrorResponse,
@@ -36,7 +36,7 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   const { email, dispositif } = result.data;
 
   try {
-    const { User, Dispositif, Theme } = await getWebhookModels();
+    const { User, Dispositif } = await getWebhookModels();
     const user = await getWebhookUser(User, email);
 
     if (!user) {
@@ -49,23 +49,29 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
 
     const { _id } = dispositif;
 
-    // Resolve themes from names if provided
-    let themeId: any;
-    let secondaryThemeIds: any[] = [];
-    if (dispositif.themes && Array.isArray(dispositif.themes)) {
-      const themeIds = await getThemeIdsByNames(Theme, dispositif.themes);
-      if (themeIds.length > 0) {
-        themeId = themeIds[0];
-        secondaryThemeIds = themeIds.slice(1);
-      }
-    }
+    // Use theme IDs directly (sent by Luna)
+    const themeId = dispositif.theme;
+    const secondaryThemeIds = dispositif.secondaryThemes || [];
 
     // Prepare update payload, preserving original creator and creation date
-    const { themes, ...dispositifData } = dispositif;
+    const { theme, secondaryThemes, ...dispositifData } = dispositif;
+
+    // Convertir les dates ISO en objets Date MongoDB
+    let metadatas;
+    try {
+      metadatas = convertMetadatasDates(dispositif.metadatas);
+    } catch (dateError) {
+      return res.status(400).json({
+        message: "Erreur de format de date dans les métadonnées",
+        error: (dateError as Error).message,
+      });
+    }
+
     const updatePayload: any = {
       ...dispositifData,
       lastModificationDate: new Date(),
       lastModificationAuthor: user._id,
+      metadatas,
       translations: {
         ...(dispositif.translations || {}),
         fr: {

--- a/apps/client/src/pages/dispositif/preview.tsx
+++ b/apps/client/src/pages/dispositif/preview.tsx
@@ -140,14 +140,10 @@ export const getServerSideProps = wrapper.getServerSideProps((store) => async ({
       avis: [],
       availableLanguages,
       creatorId: { _id: "preview-creator", username: "Preview User" },
-      // Titres: utiliser traduction si disponible, sinon fallback
-      titreInformatif:
-        translationContent?.titreInformatif ||
-        frenchContent?.titreInformatif ||
-        dispositif.titreInformatif,
-      titreMarque:
-        translationContent?.titreMarque || frenchContent?.titreMarque || dispositif.titreMarque,
-      abstract: translationContent?.abstract || frenchContent?.abstract || dispositif.abstract,
+      // Titres: utiliser traduction si disponible, sinon fallback FR (toujours présent)
+      titreInformatif: translationContent?.titreInformatif || frenchContent?.titreInformatif,
+      titreMarque: translationContent?.titreMarque || frenchContent?.titreMarque,
+      abstract: translationContent?.abstract || frenchContent?.abstract,
       // Pour RCO: stocker le markdown traduit
       markdown:
         hasTranslation && translationContent?.markdown

--- a/documentation/client/webhooks.md
+++ b/documentation/client/webhooks.md
@@ -99,6 +99,13 @@ Updates the main editorial content (French) and metadata of an existing disposit
       "_id": "60f7b1b5b5b5b5b5b5b5b5b5", // Must be a valid MongoDB ObjectId (24 hex characters)
       "theme": "63286a015d31b2c0cad99615", // Optional - Main theme ObjectId
       "secondaryThemes": ["63286a025d31b2c0cad99616"], // Optional - Secondary theme ObjectIds
+      "sponsors": [ // Optional - Sponsors/partners
+        {
+          "name": "Alliance Française",
+          "logo": "https://example.com/logo.png",
+          "link": "https://example.com"
+        }
+      ],
       "translations": {
         "fr": {
           "content": {
@@ -108,6 +115,18 @@ Updates the main editorial content (French) and metadata of an existing disposit
             "markdown": "Updated markdown content..."
           }
         }
+      },
+      "metadatas": { // Optional - All metadata fields
+        "location": ["75 - Paris"],
+        "frenchLevel": ["B1"],
+        "age": { "type": "between", "ages": [18, 65] },
+        "price": { "values": [0] },
+        "sessions": [
+          {
+            "startDate": "2025-11-24T00:00:00.000Z",
+            "endDate": "2026-01-16T00:00:00.000Z"
+          }
+        ]
       }
     }
   }
@@ -170,7 +189,7 @@ Returns the list of available themes in id/value format. Useful to populate sele
   ```
 
 > [!NOTE]
-> Results are sorted by display position. The `name` field corresponds to `name.fr` and is the value expected in the `themes` array of the create/update endpoints.
+> Results are sorted by display position. The `name` field corresponds to `name.fr`.
 
 ---
 
@@ -190,6 +209,47 @@ Returns the list of available needs in id/value format, grouped by their associa
 
 > [!NOTE]
 > Results are sorted by display position. The `themeId` field allows grouping needs by theme on the client side.
+
+---
+
+## Field Values Reference
+
+### Location
+- `"france"` - France entière
+- `"online"` - En ligne
+- `["75 - Paris", "77 - Seine-et-Marne", ...]` - Départements spécifiques
+
+### French Level
+`"alpha"`, `"A1"`, `"A2"`, `"B1"`, `"B2"`, `"C1"`, `"C2"`
+
+### Age Type
+- `"lessThan"` - Moins de X ans (1 valeur dans `ages`)
+- `"moreThan"` - Plus de X ans (1 valeur dans `ages`)
+- `"between"` - Entre X et Y ans (2 valeurs dans `ages`)
+
+### Price Details
+`"once"`, `"eachTime"`, `"hour"`, `"day"`, `"week"`, `"month"`, `"trimester"`, `"semester"`, `"year"`
+
+### Public Status
+`"asile"`, `"refugie"`, `"subsidiaire"`, `"temporaire"`, `"apatride"`, `"french"`
+
+### Public Type
+`"family"`, `"women"`, `"youths"`, `"senior"`, `"gender"`
+
+### Conditions
+`"acte naissance"`, `"titre sejour"`, `"cir"`, `"bank account"`, `"pole emploi"`, `"driver license"`, `"school"`
+
+### Commitment/Frequency Amount Details
+`"minimum"`, `"maximum"`, `"approximately"`, `"exactly"`, `"between"`
+
+### Time Unit
+`"sessions"`, `"hours"`, `"half-days"`, `"days"`, `"weeks"`, `"months"`, `"trimesters"`, `"semesters"`, `"years"`
+
+### Frequency Unit
+`"session"`, `"day"`, `"week"`, `"month"`, `"trimester"`, `"semester"`, `"year"`
+
+### Time Slots
+`"monday"`, `"tuesday"`, `"wednesday"`, `"thursday"`, `"friday"`, `"saturday"`, `"sunday"`
 
 ---
 
@@ -238,12 +298,19 @@ POST /{locale}/dispositif/preview
     "theme": "63286a015d31b2c0cad99615",
     "secondaryThemes": [],
     "needs": [],
+    "sponsors": [
+      {
+        "name": "Alliance Française",
+        "logo": "https://example.com/logo.png",
+        "link": "https://example.com"
+      }
+    ],
     "metadatas": {
-      "location": "à distance",
+      "location": ["75 - Paris"],
       "frenchLevel": ["A1", "A2"],
       "age": { "type": "between", "ages": [18, 65] },
       "public": ["tout public"],
-      "price": { "values": [0], "details": "Gratuit" },
+      "price": { "values": [0] },
       "sessions": [
         {
           "startDate": "2025-11-24T00:00:00.000Z",
@@ -281,7 +348,7 @@ POST /{locale}/dispositif/preview
 curl -X POST http://localhost:3000/fr/dispositif/preview \
   -H "Content-Type: application/json" \
   -H "webhook-secret: xxx" \
-  -d '{"dispositif": {"titreInformatif": "Cours FLE", "origin": "RCO", "translations": {"fr": {"content": {"titreInformatif": "Cours FLE", "abstract": "...", "markdown": "# Content"}}}}}'
+  -d '{"dispositif": {"origin": "RCO", "theme": "63286a015d31b2c0cad99615", "translations": {"fr": {"content": {"titreInformatif": "Cours FLE", "abstract": "...", "markdown": "# Content"}}}}}'
 ```
 
 **Arabic preview:**
@@ -289,7 +356,7 @@ curl -X POST http://localhost:3000/fr/dispositif/preview \
 curl -X POST http://localhost:3000/ar/dispositif/preview \
   -H "Content-Type: application/json" \
   -H "webhook-secret: xxx" \
-  -d '{"dispositif": {"titreInformatif": "Cours FLE", "origin": "RCO", "translations": {"fr": {"content": {...}}, "ar": {"content": {"titreInformatif": "...", "abstract": "...", "markdown": "..."}}}}}'
+  -d '{"dispositif": {"origin": "RCO", "theme": "63286a015d31b2c0cad99615", "translations": {"fr": {"content": {...}}, "ar": {"content": {"titreInformatif": "...", "abstract": "...", "markdown": "..."}}}}}'
 ```
 
 ### Behavior

--- a/documentation/client/webhooks.md
+++ b/documentation/client/webhooks.md
@@ -36,7 +36,15 @@ Creates a new dispositif record with initial translations.
     "email": "exemple@email.com",
     "dispositif": {
       "origin": "RI", // Mandatory ("RI" or "RCO")
-      "themes": ["Apprendre le français", "Santé"],
+      "theme": "63286a015d31b2c0cad99615", // Optional - Main theme ObjectId
+      "secondaryThemes": ["63286a025d31b2c0cad99616"], // Optional - Secondary theme ObjectIds
+      "sponsors": [ // Optional - Sponsors/partners
+        {
+          "name": "Alliance Française",
+          "logo": "https://example.com/logo.png",
+          "link": "https://example.com"
+        }
+      ],
       "translations": {
         "fr": {
           "content": {
@@ -46,6 +54,28 @@ Creates a new dispositif record with initial translations.
             "markdown": "### Objectif de la formation\n\n..."
           }
         }
+      },
+      "metadatas": {
+        "location": "france",
+        "frenchLevel": ["A1", "A2"],
+        "age": { "type": "between", "ages": [18, 65] },
+        "price": { "values": [0], "details": "month" },
+        "publicStatus": ["refugie", "asile"],
+        "public": ["family"],
+        "conditions": ["titre sejour"],
+        "commitment": { "amountDetails": "approximately", "hours": [10], "timeUnit": "weeks" },
+        "frequency": { "amountDetails": "exactly", "hours": 5, "timeUnit": "hours", "frequencyUnit": "week" },
+        "timeSlots": ["monday", "wednesday"],
+        "sessions": [
+          {
+            "startDate": "2025-11-24T00:00:00.000Z",
+            "endDate": "2026-01-16T00:00:00.000Z",
+            "registrationStartDate": "2025-10-01T00:00:00.000Z",
+            "registrationEndDate": "2025-11-20T23:59:59.000Z",
+            "externalRef": "585188",
+            "url": "https://example.com/session/585188"
+          }
+        ]
       }
     }
   }
@@ -67,7 +97,8 @@ Updates the main editorial content (French) and metadata of an existing disposit
     "email": "exemple@email.com",
     "dispositif": {
       "_id": "60f7b1b5b5b5b5b5b5b5b5b5", // Must be a valid MongoDB ObjectId (24 hex characters)
-      "themes": ["Santé"],
+      "theme": "63286a015d31b2c0cad99615", // Optional - Main theme ObjectId
+      "secondaryThemes": ["63286a025d31b2c0cad99616"], // Optional - Secondary theme ObjectIds
       "translations": {
         "fr": {
           "content": {
@@ -203,9 +234,6 @@ POST /{locale}/dispositif/preview
 ```json
 {
   "dispositif": {
-    "titreInformatif": "Titre en français (fallback)",
-    "titreMarque": "Marque française",
-    "abstract": "Résumé français",
     "origin": "RCO",
     "theme": "63286a015d31b2c0cad99615",
     "secondaryThemes": [],


### PR DESCRIPTION
- **chore(deps): bump google-github-actions/setup-gcloud from 2 to 3**
- **chore(deps): bump google-github-actions/auth from 2 to 3**
- **chore(deps): bump tj-actions/changed-files from 46 to 47**
- **chore: remove .envrc from repo and add to .gitignore**
- **chore(workspace): add worktrunk config for worktree lifecycle hooks**
- **fix(workspace): remove node_modules from .worktreeinclude**
- **feat: Implement direct theme ID and metadata handling for webhook payloads, and update preview title fallbacks.**
- **feat: enhance webhook documentation with `sponsors`, detailed `metadatas`, and a new field values reference section.**
- **refactor: enhance type safety for webhook metadata date conversion and improve code formatting.**
- **refactor: improve code readability with formatting adjustments and update webhook metadata type to allow undefined.**
