### PR TITLE
[server] set ficheArchived to false for réseau Mens

### DIFF
--- a/apps/server/src/modules/mail/data.ts
+++ b/apps/server/src/modules/mail/data.ts
@@ -34,5 +34,6 @@ export const PREFS: Record<string, Record<TemplateName, boolean>> = {
     ...DEFAULT_MAIL_PREFS,
     publishedFicheToCreator: false,
     publishedFicheToStructureMembers: false,
+    ficheArchived: false,
   },
 };


### PR DESCRIPTION
## Summary
- Adds `ficheArchived: false` override to the réseau Mens mail preferences
- Prevents the MENS network from receiving email notifications when a fiche is archived
- Aligns with other restricted mail prefs already set for this structure (`publishedFicheToCreator: false`, `publishedFicheToStructureMembers: false`)

## Test plan
- [ ] Verify réseau Mens structure does not receive `ficheArchived` email when a fiche is archived
- [ ] Verify other structures still receive `ficheArchived` email as expected (default is `true`)

Fixes: RI-1122

👾 Generated with [Letta Code](https://letta.com)