### PR TITLE
[client] allow admins to change structure logos from details modal

### DIFF
--- a/apps/client/src/components/Backend/screens/Admin/AdminStructures/StructureDetailsModal/StructureDetailsModal.module.scss
+++ b/apps/client/src/components/Backend/screens/Admin/AdminStructures/StructureDetailsModal/StructureDetailsModal.module.scss
@@ -40,7 +40,7 @@ $containerHeight: 435px;
 }
 
 // Logo edit area in modal header
-.logo_edit {
+%logo-button {
   position: absolute;
   display: flex;
   align-items: center;
@@ -53,26 +53,20 @@ $containerHeight: 435px;
   opacity: 0;
   transition: opacity 0.15s ease;
   padding: 0;
-  bottom: -4px;
   right: -4px;
+}
+
+.logo_edit {
+  @extend %logo-button;
+
+  bottom: -4px;
   background: var(--background-action-high-blue-france);
 }
 
 .logo_delete {
-  position: absolute;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: none;
-  border-radius: 50%;
-  width: 24px;
-  height: 24px;
-  cursor: pointer;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  padding: 0;
+  @extend %logo-button;
+
   top: -4px;
-  right: -4px;
   background: var(--background-action-high-error);
 }
 

--- a/apps/client/src/components/Backend/screens/Admin/AdminStructures/StructureDetailsModal/StructureDetailsModal.module.scss
+++ b/apps/client/src/components/Backend/screens/Admin/AdminStructures/StructureDetailsModal/StructureDetailsModal.module.scss
@@ -38,3 +38,68 @@ $containerHeight: 435px;
   flex-direction: column;
   height: $containerHeight;
 }
+
+// Logo edit area in modal header
+.logo_edit {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  padding: 0;
+  bottom: -4px;
+  right: -4px;
+  background: var(--background-action-high-blue-france);
+}
+
+.logo_delete {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s ease;
+  padding: 0;
+  top: -4px;
+  right: -4px;
+  background: var(--background-action-high-error);
+}
+
+.logo_wrapper {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &:hover .logo_edit,
+  &:hover .logo_delete {
+    opacity: 1;
+  }
+}
+
+.logo_uploading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(0 0 0 / 40%);
+  border-radius: $radius;
+  z-index: 2;
+}
+
+.logo_file_input {
+  display: none;
+}

--- a/apps/client/src/components/Backend/screens/Admin/AdminStructures/StructureDetailsModal/StructureDetailsModal.tsx
+++ b/apps/client/src/components/Backend/screens/Admin/AdminStructures/StructureDetailsModal/StructureDetailsModal.tsx
@@ -1,17 +1,20 @@
-import type { GetLogResponse, Id, PatchStructureRequest } from "@refugies-info/api-types";
+import type { GetLogResponse, Id, PatchStructureRequest, Picture } from "@refugies-info/api-types";
 import moment from "moment";
 import "moment/locale/fr";
 import { useRouter } from "next/router";
 import type React from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Link, type RouteComponentProps, withRouter } from "react-router-dom";
 import { useToggle } from "react-use";
+import { Spinner } from "reactstrap";
 import Swal from "sweetalert2";
 import noStructure from "~/assets/noStructure.png";
+import EVAIcon from "~/components/UI/EVAIcon/EVAIcon";
 import FButton from "~/components/UI/FButton/FButton";
 import Image from "~/components/UI/Image";
 import useRouterLocale from "~/hooks/useRouterLocale";
+import { handleApiDefaultError } from "~/lib/handleApiErrors";
 import { fetchActiveStructuresActionCreator } from "~/services/ActiveStructures/activeStructures.actions";
 import { allDispositifsSelector } from "~/services/AllDispositifs/allDispositifs.selector";
 import { setAllStructuresActionCreator } from "~/services/AllStructures/allStructures.actions";
@@ -89,6 +92,8 @@ const StructureDetailsModalComponent: React.FC<Props> = (props) => {
   const [adminCommentsSaved, setAdminCommentsSaved] = useState(false);
   const [currentId, setCurrentId] = useState<Id | null>(null);
   const [logs, setLogs] = useState<GetLogResponse[]>([]);
+  const [logoUploading, setLogoUploading] = useState(false);
+  const logoFileInputRef = useRef<HTMLInputElement>(null);
 
   const allStructures = useSelector(allStructuresSelector);
   const allDispositifs = useSelector(allDispositifsSelector);
@@ -118,8 +123,9 @@ const StructureDetailsModalComponent: React.FC<Props> = (props) => {
       | "status"
       | "adminProgressionStatus"
       | "adminPercentageProgressionStatus"
-      | "nom",
-    value: string,
+      | "nom"
+      | "picture",
+    value: string | Picture | undefined,
   ) => {
     const structures = [...allStructures];
     const newStructure = structures.find((s) => s._id === structureId);
@@ -127,6 +133,49 @@ const StructureDetailsModalComponent: React.FC<Props> = (props) => {
     if (newStructure) newStructure[property] = value;
     dispatch(setAllStructuresActionCreator(structures));
     updateLogs();
+  };
+
+  const handleLogoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!structure || !e.target.files?.[0]) return;
+    setLogoUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("0", e.target.files[0]);
+      const imgData = await API.postImage(formData);
+      const picture: Picture = {
+        secure_url: imgData.secure_url,
+        public_id: imgData.public_id,
+        imgId: imgData.imgId,
+      };
+      await API.updateStructure(structure._id, { picture });
+      updateStructuresStore(structure._id, "picture", picture);
+    } catch (err) {
+      handleApiDefaultError(err);
+    } finally {
+      setLogoUploading(false);
+      if (logoFileInputRef.current) logoFileInputRef.current.value = "";
+    }
+  };
+
+  const handleLogoDelete = async () => {
+    if (!structure) return;
+    const res = await Swal.fire({
+      title: "Supprimer le logo ?",
+      text: "Le logo de cette structure sera supprimé",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: colors.rouge,
+      cancelButtonColor: colors.vert,
+      confirmButtonText: "Oui, supprimer",
+      cancelButtonText: "Annuler",
+    });
+    if (!res.value) return;
+    try {
+      await API.updateStructure(structure._id, { picture: null });
+      updateStructuresStore(structure._id, "picture", undefined);
+    } catch (err) {
+      handleApiDefaultError(err);
+    }
   };
 
   const changeNom = (nom: string) =>
@@ -201,13 +250,46 @@ const StructureDetailsModalComponent: React.FC<Props> = (props) => {
         isLoading={isLoading}
         leftHead={
           <>
-            <Image
-              src={secureUrl || noStructure}
-              alt=""
-              width={140}
-              height={60}
-              style={{ objectFit: "contain" }}
-            />
+            <div className={styles.logo_wrapper}>
+              <Image
+                src={secureUrl || noStructure}
+                alt=""
+                width={140}
+                height={60}
+                style={{ objectFit: "contain" }}
+              />
+              {logoUploading && (
+                <div className={styles.logo_uploading}>
+                  <Spinner color="white" size="sm" />
+                </div>
+              )}
+              <button
+                type="button"
+                className={styles.logo_edit}
+                onClick={() => logoFileInputRef.current?.click()}
+                title="Changer le logo"
+              >
+                <EVAIcon name="edit-2-outline" size={16} fill="white" />
+              </button>
+              {secureUrl && (
+                <button
+                  type="button"
+                  className={styles.logo_delete}
+                  onClick={handleLogoDelete}
+                  title="Supprimer le logo"
+                >
+                  <EVAIcon name="close-outline" size={16} fill="white" />
+                </button>
+              )}
+              <input
+                ref={logoFileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleLogoUpload}
+                className={styles.logo_file_input}
+                aria-label="Changer le logo de la structure"
+              />
+            </div>
             <EditableH2
               onValidate={changeNom}
               title={`${structure.acronyme ? structure.acronyme + " - " : ""}${structure.nom}`}


### PR DESCRIPTION
## Summary
- Since the annuaire page was removed, admins could no longer update structure logos
- Adds upload/replace/delete logo controls to the `StructureDetailsModal` header (hover-to-reveal edit & delete buttons)
- Uses existing `POST /images` (Cloudinary) and `PATCH /structures/{id}` endpoints — no backend changes needed

## Test plan
- [x] Open admin panel → Structures tab → click a structure to open the details modal
- [x] Hover over the logo area — edit (pencil) button should appear bottom-right
- [x] Click edit button → file picker opens → select an image → spinner shows → logo updates in modal and table
- [x] Hover again — delete (X) button should appear top-right (only when a logo exists)
- [x] Click delete → confirmation dialog → confirm → logo reverts to placeholder
- [x] Verify structure without a logo shows placeholder + edit button (no delete button)

Closes RI-1129

🐾 Generated with [Letta Code](https://letta.com)