### PR TITLE
[server] use error code for Brevo duplicate contact check

### DIFF
--- a/apps/server/src/connectors/brevo/addToNewsletter.ts
+++ b/apps/server/src/connectors/brevo/addToNewsletter.ts
@@ -41,8 +41,8 @@ export const addToNewsletter = async (email: string) => {
       error.statusCode === 400 &&
       typeof error.body === "object" &&
       error.body !== null &&
-      "message" in error.body &&
-      (error.body as { message: string }).message === "Contact already exist"
+      "code" in error.body &&
+      (error.body as { code: string }).code === "duplicate_parameter"
     )
       throw new InvalidRequestError("This email is already in the list.", "CONTACT_ALREADY_EXIST");
     throw new Error("Error while creating contact");


### PR DESCRIPTION
## Context

The Brevo v5 migration was landed in `bc05590b9`. This PR adds a follow-up fix from the code review.

## Summary

- In `addToNewsletter.ts`, switch the duplicate-contact guard from matching the error message string to checking `error.body.code === "duplicate_parameter"`

The `code` field is more stable than `message`, which may be localised or changed in future SDK versions.

## Test plan

- [x] Existing `isInContact` and `deleteContact` test suites pass
- [ ] Verify newsletter subscribe / unsubscribe on staging with the new error check

👾 Generated with [Letta Code](https://letta.com)