### PR TITLE
[mongo,server,client] Add speedgoose write-through MongoDB cache

### DIFF
--- a/apps/client/src/lib/db.ts
+++ b/apps/client/src/lib/db.ts
@@ -23,10 +23,11 @@ if (!cached) {
  * Only imports once — subsequent calls are no-ops because mongoose.model() checks
  * if the model is already registered.
  */
-async function registerSharedModels() {
+async function registerSharedModelsAndCache() {
   // Dynamic import to avoid loading at module parse time (server-only code).
   // The import triggers @zodyac/zod-mongoose extendZod() and registers all models.
-  await import("@refugies-info/mongo");
+  const { initCache } = await import("@refugies-info/mongo");
+  await initCache(process.env.REDIS_URI);
 }
 
 async function dbConnect() {
@@ -44,7 +45,7 @@ async function dbConnect() {
     }
 
     cached.promise = mongoose.connect(MONGODB_URI!, opts).then(async (mongoose) => {
-      await registerSharedModels();
+      await registerSharedModelsAndCache();
       return mongoose;
     });
   }

--- a/apps/server/src/controllers/traduction/lib.ts
+++ b/apps/server/src/controllers/traduction/lib.ts
@@ -19,4 +19,5 @@ export const computeGlobalIndicator = async (userId: string): Promise<Progressio
         timeSpent: { $sum: "$timeSpent" },
       },
     },
+    // Explicit type required: speedgoose's Aggregate<R, ResultType> augmentation breaks .then() callback inference
   ]).then((results: ProgressionIndicator[]) => results.shift());

--- a/apps/server/src/controllers/traduction/lib.ts
+++ b/apps/server/src/controllers/traduction/lib.ts
@@ -19,4 +19,4 @@ export const computeGlobalIndicator = async (userId: string): Promise<Progressio
         timeSpent: { $sum: "$timeSpent" },
       },
     },
-  ]).then((results) => results.shift());
+  ]).then((results: ProgressionIndicator[]) => results.shift());

--- a/apps/server/src/modules/adminOptions/adminOptions.repository.ts
+++ b/apps/server/src/modules/adminOptions/adminOptions.repository.ts
@@ -1,6 +1,7 @@
 import { type AdminOptions, AdminOptionsModel } from "@refugies-info/mongo";
 
-export const getAdminOption = async (key: string) => AdminOptionsModel.findOne({ key: key });
+export const getAdminOption = async (key: string) =>
+  AdminOptionsModel.findOne({ key: key }).cacheQuery();
 
 export const createAdminOption = async (adminOption: AdminOptions) =>
   AdminOptionsModel.create(adminOption);

--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -46,6 +46,16 @@ export const getDispositifsFromDB = async () =>
 type DispositifKeys = keyof Dispositif;
 type DispositifFieldsRequest = Partial<Record<DispositifKeys, number>>;
 
+/**
+ * Result type for getDispositifsWithCreatorId — a subset of Dispositif fields
+ * (determined at runtime by neededFields) with a projected mainSponsor.
+ * mainSponsor is omitted from Partial<Dispositif> (ObjectId ref) and replaced
+ * with the populated shape emitted by the $lookup + $unwind pipeline stages.
+ */
+type DispositifContributionAggResult = Omit<Partial<Dispositif>, "mainSponsor"> & {
+  mainSponsor?: { _id: Id; nom: string };
+};
+
 export const getDispositifsForExport = async () => {
   return DispositifModel.find({ status: "Actif" })
     .populate<{
@@ -537,7 +547,8 @@ export const getDispositifsWithCreatorId = async (
     },
   );
 
-  return await DispositifModel.aggregate<any>(pipeline);
+  // Cast required: speedgoose's Aggregate<R, ResultType> augmentation breaks awaited type inference
+  return (await DispositifModel.aggregate(pipeline)) as DispositifContributionAggResult[];
 };
 
 export const getDispositifByIdWithMainSponsor = async (

--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -537,7 +537,7 @@ export const getDispositifsWithCreatorId = async (
     },
   );
 
-  return await DispositifModel.aggregate(pipeline);
+  return await DispositifModel.aggregate<any>(pipeline);
 };
 
 export const getDispositifByIdWithMainSponsor = async (

--- a/apps/server/src/modules/langues/langues.repository.ts
+++ b/apps/server/src/modules/langues/langues.repository.ts
@@ -13,9 +13,9 @@ export const getActiveLanguagesFromDB = () =>
       avancement: 1,
       avancementTrad: 1,
     },
-  ).sort({
-    avancement: -1,
-  });
+  )
+    .sort({ avancement: -1 })
+    .cacheQuery();
 
 export const updateLanguageAvancementInDB = (langueId: Types.ObjectId, avancementTrad: number) =>
   LangueModel.findByIdAndUpdate({ _id: langueId }, { avancementTrad });

--- a/apps/server/src/modules/needs/needs.repository.ts
+++ b/apps/server/src/modules/needs/needs.repository.ts
@@ -5,7 +5,7 @@ import type { DeleteResult } from "~/types/interface";
 export const createNeedInDB = async (need: Partial<Need>) => await new NeedModel(need).save();
 
 export const getNeedsFromDB = async () =>
-  NeedModel.find().populate<{ theme: SimpleTheme }>("theme");
+  NeedModel.find().populate<{ theme: SimpleTheme }>("theme").cacheQuery();
 
 export const getNeedFromDB = async (id: NeedId) => NeedModel.findOne({ _id: id });
 

--- a/apps/server/src/modules/role/role.repository.ts
+++ b/apps/server/src/modules/role/role.repository.ts
@@ -3,4 +3,4 @@ import { RoleModel } from "@refugies-info/mongo";
 
 export const getRoleByName = async (name: RoleName) => await RoleModel.findOne({ nom: name });
 
-export const getRoles = async () => RoleModel.find();
+export const getRoles = async () => RoleModel.find().cacheQuery();

--- a/apps/server/src/modules/themes/themes.repository.ts
+++ b/apps/server/src/modules/themes/themes.repository.ts
@@ -3,7 +3,7 @@ import type { DeleteResult } from "~/types/interface";
 
 export const getTheme = (id: ThemeId) => ThemeModel.findOne({ _id: id });
 
-export const getAllThemes = () => ThemeModel.find();
+export const getAllThemes = () => ThemeModel.find().cacheQuery();
 
 export const createTheme = (theme: ThemeType) => ThemeModel.create(theme);
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -2,6 +2,7 @@ import { config } from "dotenv";
 
 config();
 
+import { initCache } from "@refugies-info/mongo";
 import cloudinary from "cloudinary";
 import compression from "compression";
 import cors from "cors";
@@ -32,7 +33,11 @@ const db_path = MONGODB_URI;
 const connectWithRetry = async () => {
   return mongoose
     .connect(db_path)
-    .then(() => logger.info("[mongoose] Connected to mongoDB"))
+    .then(async () => {
+      logger.info("[mongoose] Connected to mongoDB");
+      await initCache(process.env.REDIS_URI);
+      logger.info("[cache] Speedgoose cache layer initialized");
+    })
     .catch((e) => {
       logger.error("[mongoose] Error while DB connecting. Retrying in 5 seconds...", {
         message: e.message,

--- a/apps/server/src/workflows/dispositif/getUserContributions/getUserContributions.ts
+++ b/apps/server/src/workflows/dispositif/getUserContributions/getUserContributions.ts
@@ -22,7 +22,7 @@ export const getUserContributions = async (
     hasDraftVersion: 1,
     origin: 1,
   };
-  const dispositifs = await getDispositifsWithCreatorId(userId, neededFields);
+  const dispositifs: any[] = await getDispositifsWithCreatorId(userId, neededFields);
 
   const res: GetUserContributionsResponse[] = dispositifs.map((d) => ({
     ...pick(d, ["_id", "typeContenu", "status", "mainSponsor", "nbVues", "origin"]),

--- a/apps/server/src/workflows/dispositif/getUserContributions/getUserContributions.ts
+++ b/apps/server/src/workflows/dispositif/getUserContributions/getUserContributions.ts
@@ -22,14 +22,17 @@ export const getUserContributions = async (
     hasDraftVersion: 1,
     origin: 1,
   };
-  const dispositifs: any[] = await getDispositifsWithCreatorId(userId, neededFields);
+  const dispositifs = await getDispositifsWithCreatorId(userId, neededFields);
 
-  const res: GetUserContributionsResponse[] = dispositifs.map((d) => ({
+  // Double-cast required: the $project pipeline always selects these fields but
+  // DispositifContributionAggResult exposes them as Partial (optional), while
+  // GetUserContributionsResponse requires them. The pipeline guarantees presence at runtime.
+  const res = dispositifs.map((d) => ({
     ...pick(d, ["_id", "typeContenu", "status", "mainSponsor", "nbVues", "origin"]),
     ...pick(d.translations?.fr?.content ?? {}, ["titreInformatif", "titreMarque"]),
     nbMercis: (d.merci ?? []).length,
     hasDraftVersion: !!d.hasDraftVersion,
-  }));
+  })) as unknown as GetUserContributionsResponse[];
 
   return { text: "success", data: res };
 };

--- a/apps/server/src/workflows/translation/getProgression/getProgression.ts
+++ b/apps/server/src/workflows/translation/getProgression/getProgression.ts
@@ -22,6 +22,7 @@ export const computeIndicator = async (
         timeSpent: { $sum: "$timeSpent" },
       },
     },
+    // Explicit type required: speedgoose's Aggregate<R, ResultType> augmentation breaks .then() callback inference
   ]).then((results: ProgressionIndicator[]) => results.shift());
 
 export const computeAllIndicators = async (

--- a/apps/server/src/workflows/translation/getProgression/getProgression.ts
+++ b/apps/server/src/workflows/translation/getProgression/getProgression.ts
@@ -22,7 +22,7 @@ export const computeIndicator = async (
         timeSpent: { $sum: "$timeSpent" },
       },
     },
-  ]).then((results) => results.shift());
+  ]).then((results: ProgressionIndicator[]) => results.shift());
 
 export const computeAllIndicators = async (
   userId: string,

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -14,6 +14,7 @@
     "jwt-simple": "^0.5.6",
     "mongoose": "^8.23.0",
     "password-hash": "^1.2.2",
+    "speedgoose": "~2.2.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/packages/mongo/src/cache.ts
+++ b/packages/mongo/src/cache.ts
@@ -1,0 +1,38 @@
+import mongoose from "mongoose";
+import type { SpeedGooseConfig } from "speedgoose";
+import { applySpeedGooseCacheLayer, SharedCacheStrategies } from "speedgoose";
+
+let cacheInitialized = false;
+
+/**
+ * Initializes the speedgoose write-through cache layer on the global Mongoose connection.
+ *
+ * - When `redisUri` is provided, uses Redis as the shared cache backend (production/staging).
+ * - When `redisUri` is omitted, uses in-memory caching (local dev, CI).
+ * - When called multiple times, subsequent calls are no-ops.
+ *
+ * Must be called AFTER `mongoose.connect()` and BEFORE any cached queries.
+ */
+export const initCache = async (redisUri?: string): Promise<void> => {
+  if (cacheInitialized) return;
+
+  const config: SpeedGooseConfig = {
+    defaultTtl: 300, // 5 minutes
+  };
+
+  if (redisUri) {
+    config.redisUri = redisUri;
+  } else {
+    // In-memory fallback for local dev and CI (no Redis dependency required)
+    config.sharedCacheStrategy = SharedCacheStrategies.IN_MEMORY;
+  }
+
+  await applySpeedGooseCacheLayer(mongoose, config);
+  cacheInitialized = true;
+};
+
+/**
+ * Returns whether the cache layer has been initialized.
+ * Useful for health checks.
+ */
+export const isCacheInitialized = (): boolean => cacheInitialized;

--- a/packages/mongo/src/index.ts
+++ b/packages/mongo/src/index.ts
@@ -4,6 +4,8 @@ import { z } from "zod";
 extendZod(z);
 
 export { DispositifStatus } from "@refugies-info/api-types";
+// Cache layer
+export { initCache, isCacheInitialized } from "./cache";
 export * from "./schemas/AdminOptions";
 export * from "./schemas/AppUser";
 export * from "./schemas/Dispositif";

--- a/packages/mongo/src/schemas/AdminOptions.ts
+++ b/packages/mongo/src/schemas/AdminOptions.ts
@@ -1,5 +1,6 @@
 import { zodSchema } from "@zodyac/zod-mongoose";
 import { type Document, model, type Types } from "mongoose";
+import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { z } from "zod";
 
 // AdminOptions Schema
@@ -16,5 +17,7 @@ export const AdminOptionsMongooseSchema = zodSchema(AdminOptionsSchema);
 AdminOptionsMongooseSchema.path("key").unique(true);
 AdminOptionsMongooseSchema.set("collection", "adminoptions");
 AdminOptionsMongooseSchema.set("timestamps", { createdAt: "created_at", updatedAt: "updatedAt" });
+
+AdminOptionsMongooseSchema.plugin(SpeedGooseCacheAutoCleaner);
 
 export const AdminOptionsModel = model("AdminOptions", AdminOptionsMongooseSchema);

--- a/packages/mongo/src/schemas/Dispositif.ts
+++ b/packages/mongo/src/schemas/Dispositif.ts
@@ -1,6 +1,7 @@
 import { ContentType, DispositifOrigin, DispositifStatus } from "@refugies-info/api-types";
 import { zId, zodSchema } from "@zodyac/zod-mongoose";
 import { type Document, model, type Types } from "mongoose";
+import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { z } from "zod";
 import { type ImageType, ImageZodSchema } from "./generics";
 import { I18nCodeZodSchema } from "./Langue";
@@ -306,6 +307,8 @@ if (adminLogoPath && adminLogoPath.schema) adminLogoPath.schema.set("_id", false
 
 // Note: suggestions, merci, avis, map (Poi) usually HAVE _ids in Mongoose default.
 // The original schema didn't set _id: false for them, so we keep defaults (TRUE).
+
+DispositifMongooseSchema.plugin(SpeedGooseCacheAutoCleaner);
 
 export const DispositifModel = model("Dispositif", DispositifMongooseSchema);
 export const DispositifDraftModel = model(

--- a/packages/mongo/src/schemas/Langue.ts
+++ b/packages/mongo/src/schemas/Langue.ts
@@ -1,5 +1,6 @@
 import { zodSchema } from "@zodyac/zod-mongoose";
 import { type Document, model, type Types } from "mongoose";
+import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { z } from "zod";
 
 // Reusable i18n code schema for language codes
@@ -36,5 +37,7 @@ LangueSchema.path("langueFr").unique(true);
 LangueSchema.path("i18nCode").unique(true);
 LangueSchema.set("collection", "langues");
 LangueSchema.set("timestamps", { createdAt: "created_at" });
+
+LangueSchema.plugin(SpeedGooseCacheAutoCleaner);
 
 export const LangueModel = model("Langue", LangueSchema);

--- a/packages/mongo/src/schemas/Need.ts
+++ b/packages/mongo/src/schemas/Need.ts
@@ -1,5 +1,6 @@
 import { zId, zodSchema } from "@zodyac/zod-mongoose";
 import { type Document, model, type Types } from "mongoose";
+import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { z } from "zod";
 import { ImageZodSchema } from "./generics";
 
@@ -54,5 +55,7 @@ for (const path of subdocPaths) {
     p.schema.set("_id", false);
   }
 }
+
+NeedMongooseSchema.plugin(SpeedGooseCacheAutoCleaner);
 
 export const NeedModel = model("Need", NeedMongooseSchema);

--- a/packages/mongo/src/schemas/Role.ts
+++ b/packages/mongo/src/schemas/Role.ts
@@ -1,6 +1,7 @@
 import { RoleName } from "@refugies-info/api-types";
 import { zodSchema } from "@zodyac/zod-mongoose";
 import { type Document, model, type Types } from "mongoose";
+import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { z } from "zod";
 
 export const RoleZodSchema = z.object({
@@ -28,5 +29,7 @@ export const RoleMongooseSchema = zodSchema(RoleZodSchema);
 RoleMongooseSchema.path("nom").unique(true);
 RoleMongooseSchema.set("collection", "roles");
 RoleMongooseSchema.set("timestamps", { createdAt: "created_at" });
+
+RoleMongooseSchema.plugin(SpeedGooseCacheAutoCleaner);
 
 export const RoleModel = model("Role", RoleMongooseSchema);

--- a/packages/mongo/src/schemas/Theme.ts
+++ b/packages/mongo/src/schemas/Theme.ts
@@ -1,5 +1,6 @@
 import { zodSchema } from "@zodyac/zod-mongoose";
 import { type Document, model, type Schema, type Types } from "mongoose";
+import { SpeedGooseCacheAutoCleaner } from "speedgoose";
 import { z } from "zod";
 import { ImageZodSchema } from "./generics";
 import type { Langue } from "./Langue";
@@ -118,5 +119,7 @@ ThemeMongooseSchema.methods.isActive = function (this: Theme, activeLanguages: L
   }
   return true;
 };
+
+ThemeMongooseSchema.plugin(SpeedGooseCacheAutoCleaner);
 
 export const ThemeModel = model<Theme>("Theme", ThemeMongooseSchema as unknown as Schema<Theme>);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,6 +968,9 @@ importers:
       password-hash:
         specifier: ^1.2.2
         version: 1.2.2
+      speedgoose:
+        specifier: ~2.2.0
+        version: 2.2.0(@aws-sdk/credential-providers@3.883.0)(socks@2.8.7)
       zod:
         specifier: ^3.22.4
         version: 3.25.76
@@ -3149,6 +3152,9 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@ioredis/commands@1.5.0':
+    resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -6195,6 +6201,10 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
@@ -6581,6 +6591,10 @@ packages:
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -7181,6 +7195,9 @@ packages:
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
   faye-websocket@0.11.4:
     resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
     engines: {node: '>=0.8.0'}
@@ -7726,6 +7743,10 @@ packages:
 
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
+
+  ioredis@5.9.2:
+    resolution: {integrity: sha512-tAAg/72/VxOUW7RQSX1pIxJVucYKcjFjfvj60L57jrZpYCHC3XN0WCQ3sNYL4Gmvv+7GPvTAjc+KSdeNuE8oWQ==}
+    engines: {node: '>=12.22.0'}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -8288,6 +8309,9 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-parse-better-errors@1.0.2:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==}
 
@@ -8328,6 +8352,9 @@ packages:
   kareem@2.6.3:
     resolution: {integrity: sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==}
     engines: {node: '>=12.0.0'}
+
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -8569,8 +8596,14 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
   lodash.isboolean@3.0.3:
     resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
@@ -10376,6 +10409,14 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
   redux-mock-store@1.5.5:
     resolution: {integrity: sha512-YxX+ofKUTQkZE4HbhYG4kKGr7oCTJfB0GLy7bSeqx86GLpGirrbUWstMnqXkqHNaQpcnbMGbof2dYs5KsPE6Zg==}
     peerDependencies:
@@ -10811,6 +10852,9 @@ packages:
   sparse-bitfield@3.0.3:
     resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
 
+  speedgoose@2.2.0:
+    resolution: {integrity: sha512-7N8zwSrHg4oNUrl4Cc/o2nD7GCMmUdoNX065U6/7uu9g1ztA8iMgE0ro/7IcRql1o3PzTvGqZRD398YMjXCEIw==}
+
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
@@ -10844,6 +10888,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
@@ -11426,6 +11473,9 @@ packages:
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typedi@0.10.0:
+    resolution: {integrity: sha512-v3UJF8xm68BBj6AF4oQML3ikrfK2c9EmZUyLOfShpJuItAqVBHWP/KtpGinkSsIiP6EZyyb6Z3NXyW9dgS9X1w==}
 
   typesafe-actions@5.1.0:
     resolution: {integrity: sha512-bna6Yi1pRznoo6Bz1cE6btB/Yy8Xywytyfrzu/wc+NFW3ZF0I+2iCGImhBsoYYCOWuICtRO4yHcnDlzgo1AdNg==}
@@ -14865,6 +14915,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.3':
     optional: true
+
+  '@ioredis/commands@1.5.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -18518,6 +18570,8 @@ snapshots:
 
   clsx@2.1.1: {}
 
+  cluster-key-slot@1.1.2: {}
+
   co@4.6.0: {}
 
   collect-v8-coverage@1.0.2: {}
@@ -18949,6 +19003,8 @@ snapshots:
       object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
+
+  denque@2.1.0: {}
 
   depd@1.1.2: {}
 
@@ -19632,6 +19688,10 @@ snapshots:
   fastest-stable-stringify@2.0.2: {}
 
   fastq@1.19.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
@@ -20337,6 +20397,20 @@ snapshots:
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
+
+  ioredis@5.9.2:
+    dependencies:
+      '@ioredis/commands': 1.5.0
+      cluster-key-slot: 1.1.2
+      debug: 4.4.1(supports-color@5.5.0)
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
 
   ip-address@10.1.0:
     optional: true
@@ -21496,6 +21570,8 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-buffer@3.0.1: {}
+
   json-parse-better-errors@1.0.2: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -21548,6 +21624,10 @@ snapshots:
   jwt-simple@0.5.6: {}
 
   kareem@2.6.3: {}
+
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
 
   keyv@5.6.0:
     dependencies:
@@ -21756,7 +21836,11 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
+  lodash.defaults@4.2.0: {}
+
   lodash.includes@4.3.0: {}
+
+  lodash.isarguments@3.1.0: {}
 
   lodash.isboolean@3.0.3: {}
 
@@ -23993,6 +24077,12 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
   redux-mock-store@1.5.5(redux@5.0.1):
     dependencies:
       lodash.isplainobject: 4.0.6
@@ -24545,6 +24635,25 @@ snapshots:
     dependencies:
       memory-pager: 1.5.0
 
+  speedgoose@2.2.0(@aws-sdk/credential-providers@3.883.0)(socks@2.8.7):
+    dependencies:
+      debug: 4.4.1(supports-color@5.5.0)
+      fastq: 1.20.1
+      ioredis: 5.9.2
+      keyv: 4.5.4
+      mongoose: 8.23.0(@aws-sdk/credential-providers@3.883.0)(socks@2.8.7)
+      mpath: 0.9.0
+      typedi: 0.10.0
+    transitivePeerDependencies:
+      - '@aws-sdk/credential-providers'
+      - '@mongodb-js/zstd'
+      - gcp-metadata
+      - kerberos
+      - mongodb-client-encryption
+      - snappy
+      - socks
+      - supports-color
+
   split-on-first@1.1.0: {}
 
   split-on-first@3.0.0: {}
@@ -24577,6 +24686,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  standard-as-callback@2.1.0: {}
 
   statuses@1.5.0: {}
 
@@ -25243,6 +25354,8 @@ snapshots:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.1
+
+  typedi@0.10.0: {}
 
   typesafe-actions@5.1.0: {}
 


### PR DESCRIPTION
## Summary

- **Installs `speedgoose@~2.2.0`** in `packages/mongo` — last version supporting mongoose 8
- **Creates `initCache()`** in `packages/mongo/src/cache.ts` — uses Redis when `REDIS_URI` is set, falls back to in-memory for local dev / CI (no Redis required to run)
- **Wires cache into both connections**: server (`server.ts`) and client (`db.ts`) after `mongoose.connect()`
- **Adds `SpeedGooseCacheAutoCleaner` plugin** to 6 schemas (Dispositif, Theme, Need, Role, Langue, AdminOptions) — writes to these collections auto-invalidate cached queries
- **Adds `.cacheQuery()`** to 5 static reference data read paths: `getAllThemes`, `getNeedsFromDB`, `getRoles`, `getActiveLanguagesFromDB`, `getAdminOption`
- **Fixes 3 type inference issues** caused by speedgoose's `Aggregate<R, ResultType>` augmentation

## Architecture

```
REDIS_URI set?
    ├── YES → Redis (shared cache across all instances, production/staging)
    └── NO  → In-memory (per-process, local dev / CI — no Redis required)

Write to Dispositif/Theme/Need/Role/Langue/AdminOptions
    └── SpeedGooseCacheAutoCleaner fires
        └── All cached queries for that collection are invalidated
```

## What's cached (Phase 2 — static reference data)

| Function | Model | TTL |
|---|---|---|
| `getAllThemes` | Theme | 5 min |
| `getNeedsFromDB` | Need | 5 min |
| `getRoles` | Role | 5 min |
| `getActiveLanguagesFromDB` | Langue | 5 min |
| `getAdminOption` | AdminOptions | 5 min |

High-traffic queries (search counts, search results, dispositif arrays) are targeted in Phase 3.

## Environment variable

```bash
REDIS_URI=redis://127.0.0.1:6379   # local dev
# For staging/production: set via GCP Secret Manager
```

No `REDIS_URI` → cache works with in-memory fallback (safe for CI/dev).

## Test plan

- [x] `pnpm check:types` — 0 errors (all packages)
- [x] `pnpm test:client` — 52/52 suites pass
- [x] `pnpm test:server` — 30/30 suites pass
- [x] `pnpm lint` — 0 warnings/errors
- [ ] Manual: start server with Redis locally, confirm cache hits in logs
- [ ] Manual: update a theme, confirm cache is invalidated and next request hits DB

👾 Generated with [Letta Code](https://letta.com)