### PR TITLE
[client] prevent recherche build crash from eager mongo imports

### DIFF
--- a/apps/client/src/lib/db.ts
+++ b/apps/client/src/lib/db.ts
@@ -1,4 +1,5 @@
 import mongoose from "mongoose";
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
 
 // Note: Do NOT validate MONGODB_URI at module load time.
 // In tests and some CI contexts (e.g., PRs from forks), this env var may be absent
@@ -28,7 +29,7 @@ async function registerSharedModelsAndCache() {
   // constrained environment where loading mongo schemas can fail. Skip shared
   // model/cache initialization at build time; runtime requests still initialize
   // cache normally in Cloud Run / local dev.
-  if (process.env.NEXT_PHASE === "phase-production-build") {
+  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
     return;
   }
 

--- a/apps/client/src/lib/db.ts
+++ b/apps/client/src/lib/db.ts
@@ -24,6 +24,14 @@ if (!cached) {
  * if the model is already registered.
  */
 async function registerSharedModelsAndCache() {
+  // During `next build`, page-data collection imports server code paths in a
+  // constrained environment where loading mongo schemas can fail. Skip shared
+  // model/cache initialization at build time; runtime requests still initialize
+  // cache normally in Cloud Run / local dev.
+  if (process.env.NEXT_PHASE === "phase-production-build") {
+    return;
+  }
+
   // Dynamic import to avoid loading at module parse time (server-only code).
   // The import triggers @zodyac/zod-mongoose extendZod() and registers all models.
   const { initCache } = await import("@refugies-info/mongo");

--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -1,6 +1,5 @@
 import { type SearchClient, searchClient } from "@algolia/client-search";
 import type { SimpleDispositif } from "@refugies-info/api-types";
-import { NeedModel } from "@refugies-info/mongo";
 import type { AgeOptions, FrenchOptions, PublicOptions, StatusOptions } from "data/searchFilters";
 import mongoose, { type FilterQuery, type Model, type PipelineStage } from "mongoose";
 import type { ParsedUrlQuery } from "querystring";
@@ -451,7 +450,7 @@ const buildSuggestionsQuery = async (
     const needIds = toObjectIds(needs);
     if (needIds.length === 0) return [];
     // Find needs' parent themes, then get items from those themes without the selected needs
-    const Need = Dispositif.db.models.Need || NeedModel;
+    const Need = Dispositif.db.models.Need || (await import("@refugies-info/mongo")).NeedModel;
     const selectedNeeds = await Need.find({ _id: { $in: needIds } }, { theme: 1 }).lean();
     const parentThemeIds = [
       ...new Set(selectedNeeds.map((n) => (n as unknown as { theme: unknown }).theme)),


### PR DESCRIPTION
## Summary
- skip shared mongo model/cache initialization from `apps/client/src/lib/db.ts` during `next build` page-data collection phase
- remove eager top-level `NeedModel` import in `search-helpers` and lazy-load it only when suggestions need the model at runtime
- keep runtime behavior unchanged for Cloud Run/API usage while unblocking Next.js build for `/recherche`

## Test plan
- [x] Run `pnpm -C apps/client build` locally (build now completes)
- [x] Run `pnpm lint:client`
- [ ] Trigger `frontend-stag` Cloud Build and confirm build no longer fails on `/recherche`

👾 Generated with [Letta Code](https://letta.com)