### PR TITLE
[client] add runtime fallback for search API routes when shared models unavailable

### DIFF
--- a/apps/client/src/lib/db.ts
+++ b/apps/client/src/lib/db.ts
@@ -25,18 +25,23 @@ if (!cached) {
  * if the model is already registered.
  */
 async function registerSharedModelsAndCache() {
-  // During `next build`, page-data collection imports server code paths in a
-  // constrained environment where loading mongo schemas can fail. Skip shared
-  // model/cache initialization at build time; runtime requests still initialize
-  // cache normally in Cloud Run / local dev.
+  // During next build, page-data collection can import server-side modules in a
+  // constrained context where schema registration is not required.
   if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
     return;
   }
 
-  // Dynamic import to avoid loading at module parse time (server-only code).
-  // The import triggers @zodyac/zod-mongoose extendZod() and registers all models.
-  const { initCache } = await import("@refugies-info/mongo");
-  await initCache(process.env.REDIS_URI);
+  try {
+    // Dynamic import to avoid loading at module parse time (server-only code).
+    // The import triggers @zodyac/zod-mongoose extendZod() and registers all models.
+    const { initCache } = await import("@refugies-info/mongo");
+    await initCache(process.env.REDIS_URI);
+  } catch (error) {
+    // Keep the app available even if shared model bootstrap fails in a given
+    // runtime (e.g. bundling edge-cases). Search API routes include degraded
+    // fallbacks that operate with lightweight models and uncached queries.
+    console.warn("[db] Shared model/cache bootstrap skipped", error);
+  }
 }
 
 async function dbConnect() {

--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -24,19 +24,27 @@ const toObjectIds = (values: string[]): mongoose.Types.ObjectId[] => {
     .map((value) => new mongoose.Types.ObjectId(value));
 };
 
-const executeCachedPipeline = async <T = any>(aggregateQuery: any): Promise<T[]> => {
-  return typeof aggregateQuery.cachePipeline === "function"
-    ? aggregateQuery.cachePipeline()
-    : aggregateQuery.exec();
+/** Safely execute an aggregate with speedgoose cache, falling back to plain exec(). */
+export const executeCachedPipeline = async <T = any>(
+  aggregateQuery: mongoose.Aggregate<T[]>,
+): Promise<T[]> => {
+  const q = aggregateQuery as mongoose.Aggregate<T[]> & { cachePipeline?: () => Promise<T[]> };
+  return typeof q.cachePipeline === "function" ? q.cachePipeline() : q.exec();
 };
 
-const executeCachedQuery = async <T = any>(query: any): Promise<T> => {
-  return typeof query.cacheQuery === "function" ? query.cacheQuery() : query.exec();
+/** Safely execute a query with speedgoose cache, falling back to plain exec(). */
+export const executeCachedQuery = async <T = any>(query: mongoose.Query<T, any>): Promise<T> => {
+  const q = query as mongoose.Query<T, any> & { cacheQuery?: () => Promise<T> };
+  return typeof q.cacheQuery === "function" ? q.cacheQuery() : q.exec();
 };
 
-const getDispositifModel = (conn: {
+/**
+ * Resolve the Dispositif model from the connection. Prefers the canonical shared
+ * model; falls back to a lightweight strict:false model for degraded operation.
+ */
+export const getDispositifModel = (conn: {
   models: Record<string, Model<any>>;
-  model?: (name: string, schema?: any, collection?: string) => Model<any>;
+  model?: (name: string, schema?: mongoose.Schema, collection?: string) => Model<any>;
 }): Model<SimpleDispositif> => {
   if (conn.models.Dispositif) {
     return conn.models.Dispositif as Model<SimpleDispositif>;

--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -24,18 +24,22 @@ const toObjectIds = (values: string[]): mongoose.Types.ObjectId[] => {
     .map((value) => new mongoose.Types.ObjectId(value));
 };
 
-/** Safely execute an aggregate with speedgoose cache, falling back to plain exec(). */
-export const executeCachedPipeline = async <T = any>(
-  aggregateQuery: mongoose.Aggregate<T[]>,
-): Promise<T[]> => {
-  const q = aggregateQuery as mongoose.Aggregate<T[]> & { cachePipeline?: () => Promise<T[]> };
-  return typeof q.cachePipeline === "function" ? q.cachePipeline() : q.exec();
+/**
+ * Safely execute an aggregate with speedgoose cache, falling back to plain exec().
+ * Parameter typed as `any` because speedgoose augments Aggregate with extra type params.
+ */
+export const executeCachedPipeline = async <T = any>(aggregateQuery: any): Promise<T[]> => {
+  return typeof aggregateQuery.cachePipeline === "function"
+    ? aggregateQuery.cachePipeline()
+    : aggregateQuery.exec();
 };
 
-/** Safely execute a query with speedgoose cache, falling back to plain exec(). */
-export const executeCachedQuery = async <T = any>(query: mongoose.Query<T, any>): Promise<T> => {
-  const q = query as mongoose.Query<T, any> & { cacheQuery?: () => Promise<T> };
-  return typeof q.cacheQuery === "function" ? q.cacheQuery() : q.exec();
+/**
+ * Safely execute a query with speedgoose cache, falling back to plain exec().
+ * Parameter typed as `any` because speedgoose augments Query with extra type params.
+ */
+export const executeCachedQuery = async <T = any>(query: any): Promise<T> => {
+  return typeof query.cacheQuery === "function" ? query.cacheQuery() : query.exec();
 };
 
 /**

--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -2,6 +2,7 @@ import { type SearchClient, searchClient } from "@algolia/client-search";
 import type { SimpleDispositif } from "@refugies-info/api-types";
 import type { AgeOptions, FrenchOptions, PublicOptions, StatusOptions } from "data/searchFilters";
 import mongoose, { type FilterQuery, type Model, type PipelineStage } from "mongoose";
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
 import type { ParsedUrlQuery } from "querystring";
 
 interface SearchQuery extends ParsedUrlQuery {
@@ -21,6 +22,43 @@ const toObjectIds = (values: string[]): mongoose.Types.ObjectId[] => {
   return values
     .filter((value) => mongoose.Types.ObjectId.isValid(value))
     .map((value) => new mongoose.Types.ObjectId(value));
+};
+
+const executeCachedPipeline = async <T = any>(aggregateQuery: any): Promise<T[]> => {
+  return typeof aggregateQuery.cachePipeline === "function"
+    ? aggregateQuery.cachePipeline()
+    : aggregateQuery.exec();
+};
+
+const executeCachedQuery = async <T = any>(query: any): Promise<T> => {
+  return typeof query.cacheQuery === "function" ? query.cacheQuery() : query.exec();
+};
+
+const getDispositifModel = (conn: {
+  models: Record<string, Model<any>>;
+  model?: (name: string, schema?: any, collection?: string) => Model<any>;
+}): Model<SimpleDispositif> => {
+  if (conn.models.Dispositif) {
+    return conn.models.Dispositif as Model<SimpleDispositif>;
+  }
+
+  if (typeof conn.model === "function") {
+    return conn.model(
+      "Dispositif",
+      new mongoose.Schema({}, { strict: false }),
+      "dispositifs",
+    ) as Model<SimpleDispositif>;
+  }
+
+  throw new Error("Dispositif model is not registered on the mongoose connection");
+};
+
+const getNeedModel = (Dispositif: Model<SimpleDispositif>): Model<any> => {
+  if (Dispositif.db.models.Need) {
+    return Dispositif.db.models.Need;
+  }
+
+  return Dispositif.db.model("Need", new mongoose.Schema({}, { strict: false }), "needs");
 };
 
 export const getQueryParamAsArray = (param: string | string[] | undefined): string[] => {
@@ -437,20 +475,22 @@ const buildSuggestionsQuery = async (
     };
     // Remove theme-related conditions from $or since we want secondary-only
     delete suggestionsMatch.$or;
-    return Dispositif.aggregate([
-      { $match: { ...suggestionsMatch, status: "Actif" } },
-      { $sort: { nbVues: -1 } },
-      { $limit: 8 },
-      { $project: RESULTS_PROJECTION },
-      ...buildTranslationStages(locale),
-    ]).cachePipeline();
+    return executeCachedPipeline(
+      Dispositif.aggregate([
+        { $match: { ...suggestionsMatch, status: "Actif" } },
+        { $sort: { nbVues: -1 } },
+        { $limit: 8 },
+        { $project: RESULTS_PROJECTION },
+        ...buildTranslationStages(locale),
+      ]),
+    );
   }
 
   if (needs.length > 0) {
     const needIds = toObjectIds(needs);
     if (needIds.length === 0) return [];
     // Find needs' parent themes, then get items from those themes without the selected needs
-    const Need = Dispositif.db.models.Need || (await import("@refugies-info/mongo")).NeedModel;
+    const Need = getNeedModel(Dispositif);
     const selectedNeeds = await Need.find({ _id: { $in: needIds } }, { theme: 1 }).lean();
     const parentThemeIds = [
       ...new Set(selectedNeeds.map((n) => (n as unknown as { theme: unknown }).theme)),
@@ -458,19 +498,21 @@ const buildSuggestionsQuery = async (
 
     if (parentThemeIds.length === 0) return [];
 
-    return Dispositif.aggregate([
-      {
-        $match: {
-          status: "Actif",
-          theme: { $in: parentThemeIds },
-          needs: { $nin: needIds },
+    return executeCachedPipeline(
+      Dispositif.aggregate([
+        {
+          $match: {
+            status: "Actif",
+            theme: { $in: parentThemeIds },
+            needs: { $nin: needIds },
+          },
         },
-      },
-      { $sort: { nbVues: -1 } },
-      { $limit: 8 },
-      { $project: RESULTS_PROJECTION },
-      ...buildTranslationStages(locale),
-    ]).cachePipeline();
+        { $sort: { nbVues: -1 } },
+        { $limit: 8 },
+        { $project: RESULTS_PROJECTION },
+        ...buildTranslationStages(locale),
+      ]),
+    );
   }
 
   return [];
@@ -487,13 +529,15 @@ const buildNoResultsFallback = async (
   Dispositif: Model<SimpleDispositif>,
   locale: string,
 ): Promise<SimpleDispositif[]> => {
-  return Dispositif.aggregate([
-    { $match: { status: "Actif", typeContenu: "demarche" } },
-    { $sort: { nbVues: -1 } },
-    { $limit: 12 },
-    { $project: RESULTS_PROJECTION },
-    ...buildTranslationStages(locale),
-  ]).cachePipeline();
+  return executeCachedPipeline(
+    Dispositif.aggregate([
+      { $match: { status: "Actif", typeContenu: "demarche" } },
+      { $sort: { nbVues: -1 } },
+      { $limit: 12 },
+      { $project: RESULTS_PROJECTION },
+      ...buildTranslationStages(locale),
+    ]),
+  );
 };
 
 /**
@@ -501,13 +545,30 @@ const buildNoResultsFallback = async (
  * Follows the same pattern as computeSearchCounts in /api/search/counts.ts.
  */
 export const computeSearchResults = async (
-  conn: { models: Record<string, Model<any>> },
+  conn: {
+    models: Record<string, Model<any>>;
+    model?: (name: string, schema?: any, collection?: string) => Model<any>;
+  },
   queryParams: QueryParams,
   options: SearchResultsOptions,
 ): Promise<SearchResponse> => {
-  // Use the Dispositif model from the connection (registered by @refugies-info/mongo
-  // in production via dbConnect(), or by test fixtures in tests).
-  const Dispositif = conn.models.Dispositif as Model<SimpleDispositif>;
+  // During next build, page-data collection may invoke getServerSideProps for
+  // /recherche. Return empty results instead of querying DB + Algolia.
+  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
+    return {
+      results: [],
+      suggestions: [],
+      noResults: [],
+      total: 0,
+      programCount: 0,
+      procedureCount: 0,
+      onlineCount: 0,
+      page: options.page,
+      pageCount: 0,
+    };
+  }
+
+  const Dispositif = getDispositifModel(conn);
 
   const algoliaIds = await resolveAlgoliaIds(queryParams.search);
   const baseMatch = buildBaseMatch(queryParams, algoliaIds);
@@ -519,12 +580,14 @@ export const computeSearchResults = async (
   const aggregation = buildSearchAggregation(baseMatch, options);
 
   const [results, total, typeCounts, suggestions] = await Promise.all([
-    Dispositif.aggregate(aggregation).cachePipeline(),
-    Dispositif.countDocuments(baseMatch).cacheQuery(),
-    Dispositif.aggregate([
-      { $match: baseMatch },
-      { $group: { _id: "$typeContenu", count: { $sum: 1 } } },
-    ]).cachePipeline(),
+    executeCachedPipeline(Dispositif.aggregate(aggregation)),
+    executeCachedQuery<number>(Dispositif.countDocuments(baseMatch)),
+    executeCachedPipeline(
+      Dispositif.aggregate([
+        { $match: baseMatch },
+        { $group: { _id: "$typeContenu", count: { $sum: 1 } } },
+      ]),
+    ),
     buildSuggestionsQuery(Dispositif, baseMatch, queryParams, options.locale || "fr"),
   ]);
 

--- a/apps/client/src/pages/api/search/counts.ts
+++ b/apps/client/src/pages/api/search/counts.ts
@@ -1,4 +1,6 @@
+import mongoose from "mongoose";
 import type { NextApiRequest, NextApiResponse } from "next";
+import { PHASE_PRODUCTION_BUILD } from "next/constants";
 import dbConnect from "~/lib/db";
 import {
   buildBaseMatch,
@@ -31,13 +33,43 @@ export interface SearchCountsResponse {
   total: number;
 }
 
+const executeCachedPipeline = async <T = any>(aggregateQuery: any): Promise<T[]> => {
+  return typeof aggregateQuery.cachePipeline === "function"
+    ? aggregateQuery.cachePipeline()
+    : aggregateQuery.exec();
+};
+
+const getDispositifModel = (conn: any) => {
+  if (conn.models.Dispositif) {
+    return conn.models.Dispositif;
+  }
+
+  if (typeof conn.model === "function") {
+    return conn.model("Dispositif", new mongoose.Schema({}, { strict: false }), "dispositifs");
+  }
+
+  throw new Error("Dispositif model is not registered on the mongoose connection");
+};
+
 export const computeSearchCounts = async (
   conn: any,
   queryParams: QueryParams,
 ): Promise<SearchCountsResponse> => {
-  // Use the Dispositif model from the connection (registered by @refugies-info/mongo
-  // in production via dbConnect(), or by test fixtures in tests).
-  const Dispositif = conn.models.Dispositif;
+  if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {
+    return {
+      themes: {},
+      needs: {},
+      frenchLevels: {},
+      ageRanges: {},
+      publics: {},
+      languages: {},
+      statuses: {},
+      types: { dispositif: 0, demarche: 0, online: 0 },
+      total: 0,
+    };
+  }
+
+  const Dispositif = getDispositifModel(conn);
 
   let algoliaIds: string[] | undefined;
   if (queryParams.search) {
@@ -321,7 +353,7 @@ export const computeSearchCounts = async (
   ];
   (facet as any).total = [{ $match: baseMatch }, { $count: "count" }];
 
-  const results = await Dispositif.aggregate([{ $facet: facet }]).cachePipeline();
+  const results = await executeCachedPipeline(Dispositif.aggregate([{ $facet: facet }]));
   const data = results[0] || {};
 
   const toMap = (arr: Array<{ id: string; count: number }> | undefined): Record<string, number> => {

--- a/apps/client/src/pages/api/search/counts.ts
+++ b/apps/client/src/pages/api/search/counts.ts
@@ -1,10 +1,12 @@
-import mongoose from "mongoose";
+import type { Model } from "mongoose";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { PHASE_PRODUCTION_BUILD } from "next/constants";
 import dbConnect from "~/lib/db";
 import {
   buildBaseMatch,
   buildQueryParams,
+  executeCachedPipeline,
+  getDispositifModel,
   getSearchClient,
   type QueryParams,
 } from "~/lib/search-helpers";
@@ -33,26 +35,11 @@ export interface SearchCountsResponse {
   total: number;
 }
 
-const executeCachedPipeline = async <T = any>(aggregateQuery: any): Promise<T[]> => {
-  return typeof aggregateQuery.cachePipeline === "function"
-    ? aggregateQuery.cachePipeline()
-    : aggregateQuery.exec();
-};
-
-const getDispositifModel = (conn: any) => {
-  if (conn.models.Dispositif) {
-    return conn.models.Dispositif;
-  }
-
-  if (typeof conn.model === "function") {
-    return conn.model("Dispositif", new mongoose.Schema({}, { strict: false }), "dispositifs");
-  }
-
-  throw new Error("Dispositif model is not registered on the mongoose connection");
-};
-
 export const computeSearchCounts = async (
-  conn: any,
+  conn: {
+    models: Record<string, Model<any>>;
+    model?: (name: string, schema?: any, collection?: string) => Model<any>;
+  },
   queryParams: QueryParams,
 ): Promise<SearchCountsResponse> => {
   if (process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD) {


### PR DESCRIPTION
## Summary
- **db.ts**: wrap `@refugies-info/mongo` dynamic import + `initCache()` in try/catch so `dbConnect()` never hard-fails at runtime; keep `PHASE_PRODUCTION_BUILD` guard for build phase
- **search-helpers.ts**: remove eager `NeedModel` import; add `getDispositifModel`/`getNeedModel` fallbacks that register lightweight `strict:false` models when shared models are unavailable; wrap all `.cachePipeline()`/`.cacheQuery()` calls in safe wrappers (`executeCachedPipeline`/`executeCachedQuery`) that fall back to plain `.exec()` when speedgoose is not attached; add build-phase guard returning empty `SearchResponse`
- **counts.ts**: same fallback model + cache-safe patterns; build-phase guard returns empty `SearchCountsResponse`

## Context
After deploying PR #3558 (Redis/VPC wiring) and #3560 (build-time fix), the frontend staging build succeeds but runtime `/api/search` requests still 500 with `Unsupported field type` when `@refugies-info/mongo` schema loading fails in the client runtime. This PR adds graceful degradation so search API routes serve uncached results from lightweight fallback models instead of crashing.

## Test plan
- [x] `pnpm lint:client` passes
- [x] `pnpm -C apps/client build` succeeds locally
- [ ] Deploy to `frontend-stag` and verify no 500s on `/api/search?...departments=Seine-Saint-Denis`
- [ ] Verify search results still return correct data (runtime with shared models should use canonical models + cache as before)

👾 Generated with [Letta Code](https://letta.com)