### PR TITLE
[client] use typed lean<T> for Need query, remove as unknown cast

### DIFF
--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -503,10 +503,11 @@ const buildSuggestionsQuery = async (
     if (needIds.length === 0) return [];
     // Find needs' parent themes, then get items from those themes without the selected needs
     const Need = getNeedModel(Dispositif);
-    const selectedNeeds = await Need.find({ _id: { $in: needIds } }, { theme: 1 }).lean();
-    const parentThemeIds = [
-      ...new Set(selectedNeeds.map((n) => (n as unknown as { theme: unknown }).theme)),
-    ];
+    type LeanNeedWithTheme = { theme: mongoose.Types.ObjectId };
+    const selectedNeeds = await Need.find({ _id: { $in: needIds } }, { theme: 1 }).lean<
+      LeanNeedWithTheme[]
+    >();
+    const parentThemeIds = [...new Set(selectedNeeds.map((n) => n.theme))];
 
     if (parentThemeIds.length === 0) return [];
 


### PR DESCRIPTION
## Summary
- Replace `.lean()` + `(n as unknown as { theme: unknown }).theme` cast in `buildSuggestionsQuery` with `.lean<LeanNeedWithTheme[]>()` using a local type alias
- Type-only improvement suggested by Gemini on staging PR #3563

## Test plan
- [x] `pnpm check:types:client` passes

👾 Generated with [Letta Code](https://letta.com)