### PR TITLE
Erreur 404 sur les fiches RCO provenant du playground

### DIFF
--- a/apps/server/src/workflows/dispositif/getContentById/getContentById.ts
+++ b/apps/server/src/workflows/dispositif/getContentById/getContentById.ts
@@ -163,7 +163,7 @@ export const getContentById = async (
   const allRoles = await getRoles();
   const participantsWithRoles = (dispositif.participants || []).map((p) => ({
     ...pick(p, ["_id", "username", "picture"]),
-    roles: p.roles.filter((r) => !!r).map((r) => getRoleName(r, allRoles)),
+    roles: (p.roles || []).filter((r) => !!r).map((r) => getRoleName(r, allRoles)),
   }));
 
   const originalDispositifObject = originalDispositif.toObject();

--- a/apps/server/src/workflows/dispositif/getContentById/getContentById.ts
+++ b/apps/server/src/workflows/dispositif/getContentById/getContentById.ts
@@ -161,7 +161,7 @@ export const getContentById = async (
   const dataLanguage = isDispositifTranslatedIn(originalDispositif as any, locale) ? locale : "fr"; // find translation in published version only
 
   const allRoles = await getRoles();
-  const participantsWithRoles = dispositif.participants.map((p) => ({
+  const participantsWithRoles = (dispositif.participants || []).map((p) => ({
     ...pick(p, ["_id", "username", "picture"]),
     roles: p.roles.filter((r) => !!r).map((r) => getRoleName(r, allRoles)),
   }));


### PR DESCRIPTION
# Problème

Les dispositifs créés via webhook (origin=RCO) renvoyaient une 500 quand on accédait à leur page détaillée via l'API `GET /dispositifs/:id`.

```
TypeError: Cannot read properties of undefined (reading 'map')
at getContentById.ts:164
```

## Cause racine

Régression de la migration Zod du 13-14 mars.

**Avant (Typegoose)** : les tableaux Mongoose avaient un `default: []` automatique → `participants` était toujours un tableau (même vide).

**Après (Zod)** : `z.array(zId("User")).optional()` → le champ reste `undefined` s'il n'est pas fourni.

Les dispositifs RI ont toujours un champ `participants` (même vide), mais les RCO créés par webhook n'ont pas ce champ du tout.

## Fix

```typescript
// Avant (crash sur RCO)
const participantsWithRoles = dispositif.participants.map((p) => ({
  ...pick(p, ["_id", "username", "picture"]),
  roles: p.roles.filter((r) => !!r).map((r) => getRoleName(r, allRoles)),
}));

// Après (défensif)
const participantsWithRoles = (dispositif.participants || []).map((p) => ({
  ...pick(p, ["_id", "username", "picture"]),
  roles: (p.roles || []).filter((r) => !!r).map((r) => getRoleName(r, allRoles)),
}));
```

## Pourquoi c'est safe

| Cas | Avant | Après |
|-----|-------|-------|
| RI avec participants | `[user1, user2]` → OK | `[user1, user2]` → OK |
| RI sans participants | `[]` → OK | `[]` → OK |
| RCO sans participants | `undefined` → **CRASH** | `[]` → OK |

Le fix est purement défensif — aucun comportement existant n'est modifié, seul le cas crashant est corrigé.

## Impact

- **Fichiers modifiés** : `apps/server/src/workflows/dispositif/getContentById/getContentById.ts`
- **Front** : déjà défensif (`Contributors.tsx` utilise `dispositif?.participants || []`)
- **Tests** : à ajouter si nécessaire (dispositif sans participants)