### PR TITLE
[workspace] setup release-please for automated versioning

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,29 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+          target-branch: dev
+
+      - name: Output release info
+        if: ${{ steps.release.outputs.releases_created }}
+        run: |
+          echo "releases_created=${{ steps.release.outputs.releases_created }}" >> $GITHUB_OUTPUT
+          echo "paths_released=${{ steps.release.outputs.paths_released }}" >> $GITHUB_OUTPUT

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,10 @@
+{
+  "apps/client": "2.2.1",
+  "apps/server": "2.2.1",
+  "apps/mobile": "2.2.1",
+  "packages/api-types": "2.2.1",
+  "packages/ui": "2.2.1",
+  "packages/mongo": "2.2.1",
+  "packages/typescript-config": "2.2.1",
+  "packages/markdown-utils": "2.2.1"
+}

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/client",
-  "version": "0.1.0",
+  "version": "2.2.1",
   "description": "Plateforme dédiée à l'intégration des réfugiés en France",
   "author": "Soufiane Lamrissi",
   "homepage": "https://refugies.info",

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,10 +1,12 @@
 /* eslint-disable no-undef */
 /* eslint-env node */
 
+const pkg = require("./package.json");
+
 import { withAppBuildGradle, withGradleProperties } from "expo/config-plugins";
 import deepLinks from "./androidDeepLinks";
 
-const APP_VERSION = "2.2.1";
+const APP_VERSION = pkg.version;
 
 const withCustomGradleProperties = (config) => {
   return withGradleProperties(config, (config) => {

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -109,7 +109,7 @@
     "typescript": "~5.8.3"
   },
   "private": true,
-  "version": "0.0.0",
+  "version": "2.2.1",
   "name": "@refugies-info/mobile",
   "engines": {
     "node": "24.14.0"

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/server",
-  "version": "0.1.0",
+  "version": "2.2.1",
   "description": "Plateforme dédiée aux réfugiés",
   "author": "Soufiane Lamrissi",
   "homepage": "https://refugies.info",

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/api-types",
-  "version": "1.0.51",
+  "version": "2.2.1",
   "description": "Types defined in the API to be used by the frontend",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/markdown-utils/package.json
+++ b/packages/markdown-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/markdown-utils",
-  "version": "1.0.0",
+  "version": "2.2.1",
   "description": "Shared markdown remark plugins and directive utilities for web client and mobile app",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/mongo",
-  "version": "0.0.0",
+  "version": "2.2.1",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/typescript-config",
-  "version": "0.0.0",
+  "version": "2.2.1",
   "private": true,
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/ui",
-  "version": "1.0.0",
+  "version": "2.2.1",
   "sideEffects": [
     "**/*.css"
   ],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "packages": {
+    "apps/client": {
+      "release-type": "node",
+      "package-name": "@refugies-info/client"
+    },
+    "apps/server": {
+      "release-type": "node",
+      "package-name": "@refugies-info/server"
+    },
+    "apps/mobile": {
+      "release-type": "node",
+      "package-name": "@refugies-info/mobile"
+    },
+    "packages/api-types": {
+      "release-type": "node",
+      "package-name": "@refugies-info/api-types"
+    },
+    "packages/ui": {
+      "release-type": "node",
+      "package-name": "@refugies-info/ui"
+    },
+    "packages/mongo": {
+      "release-type": "node",
+      "package-name": "@refugies-info/mongo"
+    },
+    "packages/typescript-config": {
+      "release-type": "node",
+      "package-name": "@refugies-info/typescript-config"
+    },
+    "packages/markdown-utils": {
+      "release-type": "node",
+      "package-name": "@refugies-info/markdown-utils"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Set up [release-please](https://github.com/googleapis/release-please) for automated version bumping and CHANGELOG generation
- All packages aligned at version `2.2.1` (highest released mobile app version)
- Mobile `app.config.js` now reads version from `package.json` so release-please can manage app store versions

## Changes
- Added `release-please-config.json` for monorepo manifest mode
- Added `.release-please-manifest.json` with current versions
- Added `.github/workflows/release-please.yml` for dev branch releases
- Updated mobile `app.config.js` to read version from `package.json`
- Aligned all package versions to `2.2.1`

## How it works
1. Release-please watches the `dev` branch for conventional commits
2. When releasable commits are found, it creates a grouped release PR
3. When the release PR is merged, it:
   - Bumps all package versions together
   - Creates GitHub releases with tags
   - Generates CHANGELOG.md for each package
4. The existing staging/production release flow (`pnpm pr:stg`/`pnpm pr:prod`) remains unchanged

## Mobile app store versioning
- iOS buildNumber and Android versionCode are still handled by EAS automatically
- App version (2.2.1 → 2.2.2 etc.) is now managed by release-please
- Both iOS and Android builds will use the same version from `package.json`

## Test plan
- [ ] Merge this PR
- [ ] Create a test commit with conventional commit message (e.g., `feat(client): test feature`)
- [ ] Verify release-please creates a release PR targeting `v2.2.2`
- [ ] Merge the release PR
- [ ] Verify GitHub release is created with tag `v2.2.2`
- [ ] Verify CHANGELOG.md files are generated

## Files changed
| File | Action |
|------|--------|
| `release-please-config.json` | Created |
| `.release-please-manifest.json` | Created |
| `.github/workflows/release-please.yml` | Created |
| `apps/mobile/app.config.js` | Modified |
| All `package.json` files | Version aligned to 2.2.1 |

👾 Generated with [Letta Code](https://letta.com)