### PR TITLE
[server] Fix /traduction/statistics causing cascading 503 errors

### DIFF
--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -367,7 +367,7 @@ export const getStaticProps = wrapper.getStaticProps((store) => async ({ locale 
       ...(await serverSideTranslations(getLanguageFromLocale(locale), ["common"])),
       translationStatistics,
     },
-    revalidate: 60,
+    revalidate: 60 * 60, // 1 hour — this data changes infrequently
   };
 });
 

--- a/apps/server/src/modules/users/users.repository.ts
+++ b/apps/server/src/modules/users/users.repository.ts
@@ -50,6 +50,15 @@ export type UserWithPopulatedStructures = Omit<
   roles: Role[];
 };
 
+/**
+ * Shape of user data returned for translation statistics.
+ */
+export type UserForTranslationStats = {
+  roles: { nom: string }[];
+  last_connected: Date;
+  selectedLanguages: { _id: LangueId }[];
+};
+
 export const getAllUsersForAdminFromDB = async (neededFields: FilterQuery<User>) =>
   UserModel.find({ status: UserStatus.ACTIVE }, neededFields).populate<{
     selectedLanguages: { langueCode: string; langueFr: string; _id: LangueId }[];
@@ -67,7 +76,7 @@ export const getAllUsersForAdminFromDB = async (neededFields: FilterQuery<User>)
  * Only populates roles + selectedLanguages (no structures/departments).
  * Cached via speedgoose to avoid repeated full table scans.
  */
-export const getUsersForTranslationStats = () =>
+export const getUsersForTranslationStats = (): Promise<UserForTranslationStats[]> =>
   UserModel.find(
     { status: UserStatus.ACTIVE },
     { roles: 1, last_connected: 1, selectedLanguages: 1 },
@@ -77,9 +86,8 @@ export const getUsersForTranslationStats = () =>
       { path: "selectedLanguages", select: "_id" },
     ])
     .lean()
-    .cacheQuery() as unknown as Promise<
-    { roles: { nom: string }[]; last_connected: Date; selectedLanguages: { _id: LangueId }[] }[]
-  >;
+    // Type cast is safe as UserForTranslationStats accurately reflects selected and populated fields
+    .cacheQuery() as unknown as Promise<UserForTranslationStats[]>;
 
 // update
 export const updateUserInDB = async (

--- a/apps/server/src/modules/users/users.repository.ts
+++ b/apps/server/src/modules/users/users.repository.ts
@@ -62,6 +62,25 @@ export const getAllUsersForAdminFromDB = async (neededFields: FilterQuery<User>)
     { path: "departments" },
   ]) as unknown as Promise<UserWithPopulatedStructures[]>;
 
+/**
+ * Lightweight user query for translation statistics.
+ * Only populates roles + selectedLanguages (no structures/departments).
+ * Cached via speedgoose to avoid repeated full table scans.
+ */
+export const getUsersForTranslationStats = () =>
+  UserModel.find(
+    { status: UserStatus.ACTIVE },
+    { roles: 1, last_connected: 1, selectedLanguages: 1 },
+  )
+    .populate([
+      { path: "roles", select: "nom" },
+      { path: "selectedLanguages", select: "_id" },
+    ])
+    .lean()
+    .cacheQuery() as unknown as Promise<
+    { roles: { nom: string }[]; last_connected: Date; selectedLanguages: { _id: LangueId }[] }[]
+  >;
+
 // update
 export const updateUserInDB = async (
   id: Id,

--- a/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
+++ b/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
@@ -13,9 +13,12 @@ import {
 } from "~/modules/dispositif/dispositif.business";
 import { getActiveContentsFiltered } from "~/modules/dispositif/dispositif.repository";
 import { getActiveLanguagesFromDB } from "~/modules/langues/langues.repository";
-import { getAllUsersForAdminFromDB } from "~/modules/users/users.repository";
+import { getUsersForTranslationStats } from "~/modules/users/users.repository";
 
 const ONE_MONTH = 30 * 24 * 60 * 60 * 1000;
+
+const hasRole = (user: { roles: { nom: string }[] }, roleName: string): boolean =>
+  Array.isArray(user.roles) && user.roles.some((role) => role.nom === roleName);
 
 const countWordsInDispositif = (dispositif: Dispositif): number => {
   const languages = getAvailableLanguages(dispositif);
@@ -31,58 +34,59 @@ const countWordsInDispositif = (dispositif: Dispositif): number => {
 const getTranslationStatistics = ({
   facets = [],
 }: TranslationStatisticsRequest): Promise<Statistics> =>
-  Promise.all([
-    getActiveLanguagesFromDB(),
-    getAllUsersForAdminFromDB({ roles: 1, last_connected: 1, selectedLanguages: 1 }),
-  ]).then(async ([languages, users]) => {
-    logger.info("[getTranslationStatistics] get translations statistics");
-    const noFacet = facets.length === 0;
-    const stats: Statistics = {};
-    const trads = (users as any[]).filter((user) => user.hasRole(RoleName.TRAD));
-    // nbTranslators
-    if (noFacet || facets.includes("nbTranslators") || facets.includes("nbActiveTranslators")) {
-      stats.nbTranslators = trads.length;
-    }
+  Promise.all([getActiveLanguagesFromDB(), getUsersForTranslationStats()]).then(
+    async ([languages, users]) => {
+      logger.info("[getTranslationStatistics] get translations statistics");
+      const noFacet = facets.length === 0;
+      const stats: Statistics = {};
+      const trads = users.filter((user) => hasRole(user, RoleName.TRAD));
+      // nbTranslators
+      if (noFacet || facets.includes("nbTranslators") || facets.includes("nbActiveTranslators")) {
+        stats.nbTranslators = trads.length;
+      }
 
-    // nbRedactors
-    if (noFacet || facets.includes("nbRedactors")) {
-      const redactors = (users as any[]).filter((user) => user.hasRole(RoleName.CONTRIB));
-      stats.nbRedactors = redactors.length;
-    }
+      // nbRedactors
+      if (noFacet || facets.includes("nbRedactors")) {
+        const redactors = users.filter((user) => hasRole(user, RoleName.CONTRIB));
+        stats.nbRedactors = redactors.length;
+      }
 
-    // nbWordsTranslated
-    // getActiveContentsFiltered uses speedgoose .cacheQuery() — DB hit only on first call
-    // or after a Dispositif write (SpeedGooseCacheAutoCleaner auto-invalidates)
-    if (noFacet || facets.includes("nbWordsTranslated")) {
-      const dispositifs = await getActiveContentsFiltered({}, {});
-      stats.nbWordsTranslated = dispositifs.reduce(
-        (acc, dispositif) => acc + countWordsInDispositif(dispositif),
-        0,
-      );
-    }
+      // nbWordsTranslated
+      // TODO: Pre-compute nbWordsTranslated as a stored counter (updated on content save/publish)
+      // to eliminate O(dispositifs × languages) word counting. This is the most expensive facet —
+      // it loads every active dispositif and counts words across all translations in-memory.
+      // getActiveContentsFiltered uses speedgoose .cacheQuery() — DB hit only on first call
+      // or after a Dispositif write (SpeedGooseCacheAutoCleaner auto-invalidates)
+      if (noFacet || facets.includes("nbWordsTranslated")) {
+        const dispositifs = await getActiveContentsFiltered({}, {});
+        stats.nbWordsTranslated = dispositifs.reduce(
+          (acc, dispositif) => acc + countWordsInDispositif(dispositif),
+          0,
+        );
+      }
 
-    // nbActiveTranslators
-    if (noFacet || facets.includes("nbActiveTranslators")) {
-      const now = Date.now();
-      const activeTranslators = (trads as any[]).filter(
-        (user) =>
-          user.hasRole(RoleName.TRAD) && now - new Date(user.last_connected).getTime() <= ONE_MONTH,
-      );
-      const nbActiveTranslators = languages
-        .filter((ln: any) => ln.i18nCode !== "fr")
-        .map((language: any) => {
-          const languageId = language._id.toString();
-          const count = activeTranslators.filter((user) =>
-            user.selectedLanguages
-              .map((l: any) => l._id.toString())
-              .includes(languageId.toString()),
-          ).length;
-          return { languageId, count };
-        });
-      stats.nbActiveTranslators = nbActiveTranslators;
-    }
+      // nbActiveTranslators
+      if (noFacet || facets.includes("nbActiveTranslators")) {
+        const now = Date.now();
+        const activeTranslators = trads.filter(
+          (user) => now - new Date(user.last_connected).getTime() <= ONE_MONTH,
+        );
+        const nbActiveTranslators = languages
+          .filter((ln: any) => ln.i18nCode !== "fr")
+          .map((language: any) => {
+            const languageId = language._id.toString();
+            const count = activeTranslators.filter((user) =>
+              user.selectedLanguages
+                .map((l: any) => l._id.toString())
+                .includes(languageId.toString()),
+            ).length;
+            return { languageId, count };
+          });
+        stats.nbActiveTranslators = nbActiveTranslators;
+      }
 
-    return stats;
-  });
+      return stats;
+    },
+  );
 
 export default getTranslationStatistics;


### PR DESCRIPTION
## Summary

The `/traduction/statistics` endpoint was taking **32+ seconds**, monopolizing MongoDB connections and causing **cascading 503 errors** on all other endpoints (~80 errors in bursts every 5-10 min in production).

### Root cause
1. **`/traduire` ISR revalidated every 60s** — far too aggressive for near-static data
2. **`getAllUsersForAdminFromDB` populated `structures` + `departments`** — not needed by statistics, but adds massive query overhead (4 populates, full documents)
3. **No caching on user query** — hit MongoDB on every call
4. **`nbWordsTranslated` is O(dispositifs × languages)** — loads all content and counts words in-memory (deferred to follow-up PR)

### Fixes
- **Increase `/traduire` revalidate** from 60s → 1 hour (60× reduction in calls)
- **Add `getUsersForTranslationStats()`** — lightweight dedicated query that:
  - Only projects `roles`, `last_connected`, `selectedLanguages`
  - Only populates `roles` (select: `nom`) and `selectedLanguages` (select: `_id`)
  - Drops `structures` and `departments` populates entirely
  - Uses `.lean()` + `.cacheQuery()` for speedgoose caching
- **Replace `hasRole()` Mongoose method** with inline role check (cached POJOs don't have instance methods)
- **TODO added** for pre-computing `nbWordsTranslated` as a stored counter

### Expected impact
| Metric | Before | After |
|---|---|---|
| Calls/hour | ~60 | ~1 |
| User query populates | 4 (incl. full structures/departments) | 2 (minimal fields) |
| User query caching | ❌ None | ✅ speedgoose |
| Estimated response time | 32s+ (timeout) | <1s (cached) / ~2s (miss) |

## Test plan
- [ ] Verify `/traduire` page still renders translation statistics correctly
- [ ] Verify homepage and mission-et-impact pages still show translator/redactor counts
- [ ] Monitor production logs after deploy for absence of 503 bursts
- [ ] Follow-up: create issue for `nbWordsTranslated` stored counter

🐾 Generated with [Letta Code](https://letta.com)