### PR TITLE
[server] pre-compute nbWordsTranslated as stored counter

### DIFF
--- a/apps/server/src/modules/adminOptions/adminOptions.repository.ts
+++ b/apps/server/src/modules/adminOptions/adminOptions.repository.ts
@@ -8,3 +8,24 @@ export const createAdminOption = async (adminOption: AdminOptions) =>
 
 export const updateAdminOption = async (key: string, value: unknown) =>
   AdminOptionsModel.findOneAndUpdate({ key }, { value }, { upsert: true, new: true });
+
+const WORDS_TRANSLATED_KEY = "nbWordsTranslated";
+
+/** Read the pre-computed translated-words counter. Returns 0 if not yet initialised. */
+export const getWordsTranslatedCounter = async (): Promise<number> => {
+  const doc = await AdminOptionsModel.findOne({ key: WORDS_TRANSLATED_KEY }).lean();
+  return (doc?.value as number) ?? 0;
+};
+
+/**
+ * Atomically increment (positive delta) or decrement (negative delta) the counter.
+ * Uses upsert so it is safe to call before the backfill migration has run.
+ */
+export const incrementWordsTranslatedCounter = async (delta: number): Promise<void> => {
+  if (delta === 0) return;
+  await AdminOptionsModel.findOneAndUpdate(
+    { key: WORDS_TRANSLATED_KEY },
+    { $inc: { value: delta } },
+    { upsert: true, setDefaultsOnInsert: true },
+  );
+};

--- a/apps/server/src/workflows/translation/deleteTranslations/deleteTranslations.ts
+++ b/apps/server/src/workflows/translation/deleteTranslations/deleteTranslations.ts
@@ -1,14 +1,35 @@
 import type { Languages } from "@refugies-info/api-types";
 import { type Dispositif, DispositifModel, TraductionsModel } from "@refugies-info/mongo";
+import { countDispositifWords } from "~/libs/wordCounter";
+import logger from "~/logger";
+import { incrementWordsTranslatedCounter } from "~/modules/adminOptions/adminOptions.repository";
 import type { DeleteResult } from "~/types/interface";
 
-const deleteTranslations = (
+const deleteTranslations = async (
   dispositifId: string,
   locale: Languages,
-): Promise<[Dispositif, DeleteResult]> =>
-  Promise.all([
+): Promise<[Dispositif, DeleteResult]> => {
+  // Fetch word count of the translation being removed before deleting it
+  const existing = await DispositifModel.findById(dispositifId, {
+    [`translations.${locale}`]: 1,
+  }).lean();
+  const existingContent = (existing?.translations as any)?.[locale]?.content;
+  const wordsDelta = existingContent ? -countDispositifWords(existingContent) : 0;
+
+  const result = await Promise.all([
     DispositifModel.findByIdAndUpdate(dispositifId, { $unset: { [`translations.${locale}`]: "" } }),
     TraductionsModel.deleteMany({ dispositifId, language: locale }),
   ]);
+
+  if (wordsDelta !== 0) {
+    incrementWordsTranslatedCounter(wordsDelta).catch((error) => {
+      logger.error("[deleteTranslations] error while updating words counter", {
+        error: error.message,
+      });
+    });
+  }
+
+  return result;
+};
 
 export default deleteTranslations;

--- a/apps/server/src/workflows/translation/deleteTranslations/deleteTranslations.ts
+++ b/apps/server/src/workflows/translation/deleteTranslations/deleteTranslations.ts
@@ -22,11 +22,13 @@ const deleteTranslations = async (
   ]);
 
   if (wordsDelta !== 0) {
-    incrementWordsTranslatedCounter(wordsDelta).catch((error) => {
+    try {
+      await incrementWordsTranslatedCounter(wordsDelta);
+    } catch (error) {
       logger.error("[deleteTranslations] error while updating words counter", {
-        error: error.message,
+        error: (error as Error).message,
       });
-    });
+    }
   }
 
   return result;

--- a/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
+++ b/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
@@ -3,15 +3,9 @@ import {
   type Statistics,
   type TranslationStatisticsRequest,
 } from "@refugies-info/api-types";
-import type { Dispositif } from "@refugies-info/mongo";
 
-import { countDispositifWords } from "~/libs/wordCounter";
 import logger from "~/logger";
-import {
-  getAvailableLanguages,
-  getDispositifTranslation,
-} from "~/modules/dispositif/dispositif.business";
-import { getActiveContentsFiltered } from "~/modules/dispositif/dispositif.repository";
+import { getWordsTranslatedCounter } from "~/modules/adminOptions/adminOptions.repository";
 import { getActiveLanguagesFromDB } from "~/modules/langues/langues.repository";
 import { getUsersForTranslationStats } from "~/modules/users/users.repository";
 
@@ -19,17 +13,6 @@ const ONE_MONTH = 30 * 24 * 60 * 60 * 1000;
 
 const hasRole = (user: { roles: { nom: string }[] }, roleName: string): boolean =>
   Array.isArray(user.roles) && user.roles.some((role) => role.nom === roleName);
-
-const countWordsInDispositif = (dispositif: Dispositif): number => {
-  const languages = getAvailableLanguages(dispositif);
-  return languages
-    .map((ln) => {
-      if (ln === "fr") return 0;
-      const translation = getDispositifTranslation(dispositif, ln as any, false);
-      return countDispositifWords(translation?.content as any);
-    })
-    .reduce((acc, count) => acc + count, 0);
-};
 
 const getTranslationStatistics = ({
   facets = [],
@@ -40,6 +23,7 @@ const getTranslationStatistics = ({
       const noFacet = facets.length === 0;
       const stats: Statistics = {};
       const trads = users.filter((user) => hasRole(user, RoleName.TRAD));
+
       // nbTranslators
       if (noFacet || facets.includes("nbTranslators") || facets.includes("nbActiveTranslators")) {
         stats.nbTranslators = trads.length;
@@ -51,18 +35,9 @@ const getTranslationStatistics = ({
         stats.nbRedactors = redactors.length;
       }
 
-      // nbWordsTranslated
-      // TODO: Pre-compute nbWordsTranslated as a stored counter (updated on content save/publish)
-      // to eliminate O(dispositifs × languages) word counting. This is the most expensive facet —
-      // it loads every active dispositif and counts words across all translations in-memory.
-      // getActiveContentsFiltered uses speedgoose .cacheQuery() — DB hit only on first call
-      // or after a Dispositif write (SpeedGooseCacheAutoCleaner auto-invalidates)
+      // nbWordsTranslated — reads pre-computed stored counter (O(1), no full scan)
       if (noFacet || facets.includes("nbWordsTranslated")) {
-        const dispositifs = await getActiveContentsFiltered({}, {});
-        stats.nbWordsTranslated = dispositifs.reduce(
-          (acc, dispositif) => acc + countWordsInDispositif(dispositif),
-          0,
-        );
+        stats.nbWordsTranslated = await getWordsTranslatedCounter();
       }
 
       // nbActiveTranslators

--- a/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
+++ b/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
@@ -1,6 +1,7 @@
 import type {
   DemarcheContent,
   DispositifContent,
+  FlexibleDispositifContent,
   Languages,
   TranslationContent,
 } from "@refugies-info/api-types";
@@ -14,7 +15,7 @@ import { cloneDeep, set } from "lodash";
 import { countDispositifWords } from "~/libs/wordCounter";
 import logger from "~/logger";
 import { incrementWordsTranslatedCounter } from "~/modules/adminOptions/adminOptions.repository";
-import { isDispositif } from "~/modules/dispositif/dispositif.business";
+import { getDispositifTranslation, isDispositif } from "~/modules/dispositif/dispositif.business";
 import {
   deleteLineBreaks,
   deleteLineBreaksInInfosections,
@@ -60,11 +61,15 @@ const validateTranslation = (
 ) => {
   const isFirstValidation = !dispositif.translations[language]; // else, expert is just changing validated translation
 
-  // Compute word count delta for the stored counter
-  const newWords = countDispositifWords(translation.translated.content as any);
-  const oldWords = isFirstValidation
-    ? 0
-    : countDispositifWords((dispositif.translations[language] as any)?.content);
+  // Compute word count delta for the stored counter.
+  // getDispositifTranslation handles both plain-object and Mongoose Map representations safely.
+  const newWords = countDispositifWords(
+    translation.translated.content as FlexibleDispositifContent,
+  );
+  const oldContent = isFirstValidation
+    ? undefined
+    : getDispositifTranslation(dispositif, language, false)?.content;
+  const oldWords = oldContent ? countDispositifWords(oldContent as FlexibleDispositifContent) : 0;
   const wordsDelta = newWords - oldWords;
 
   return DispositifModel.updateOne(

--- a/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
+++ b/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
@@ -11,7 +11,9 @@ import {
   type Traductions,
 } from "@refugies-info/mongo";
 import { cloneDeep, set } from "lodash";
+import { countDispositifWords } from "~/libs/wordCounter";
 import logger from "~/logger";
+import { incrementWordsTranslatedCounter } from "~/modules/adminOptions/adminOptions.repository";
 import { isDispositif } from "~/modules/dispositif/dispositif.business";
 import {
   deleteLineBreaks,
@@ -57,6 +59,14 @@ const validateTranslation = (
   username: string,
 ) => {
   const isFirstValidation = !dispositif.translations[language]; // else, expert is just changing validated translation
+
+  // Compute word count delta for the stored counter
+  const newWords = countDispositifWords(translation.translated.content as any);
+  const oldWords = isFirstValidation
+    ? 0
+    : countDispositifWords((dispositif.translations[language] as any)?.content);
+  const wordsDelta = newWords - oldWords;
+
   return DispositifModel.updateOne(
     { _id: dispositif._id },
     {
@@ -98,6 +108,11 @@ const validateTranslation = (
             })
           : null,
         isFirstValidation ? sendPublishedTradMailToTraductors(language, dispositif) : null,
+        incrementWordsTranslatedCounter(wordsDelta).catch((error) => {
+          logger.error("[validateTranslations] error while updating words counter", {
+            error: error.message,
+          });
+        }),
       ]),
     )
     .catch(async (err) => {

--- a/migrations/1774298379363_BackfillWordsTranslatedCounter.ts
+++ b/migrations/1774298379363_BackfillWordsTranslatedCounter.ts
@@ -1,0 +1,92 @@
+import type { MigrationInterface } from "mongo-migrate-ts";
+import type { Db } from "mongodb";
+
+/**
+ * Backfill migration: compute nbWordsTranslated from existing dispositif translations
+ * and store it as a counter in the adminoptions collection.
+ *
+ * The counter is subsequently kept in sync by hooks in:
+ * - validateTranslation (increment on publish)
+ * - deleteTranslations (decrement on removal)
+ */
+
+/** Basic word counter — mirrors traductions.business.ts logic */
+const countWords = (str?: unknown): number => {
+  if (typeof str !== "string" || !str) return 0;
+  return str
+    .replace(/<\/?[^>]+(>|$)/g, "")
+    .split(/\s+/)
+    .filter((w) => !!w).length;
+};
+
+const countInfoSections = (sections?: Record<string, { title?: string; text?: string }>): number =>
+  Object.values(sections || {}).reduce(
+    (acc, { title, text }) => acc + countWords(title) + countWords(text),
+    0,
+  );
+
+const countTranslationContent = (content?: Record<string, unknown>): number => {
+  if (!content) return 0;
+  // Markdown content
+  if (content.markdown) {
+    return (
+      countWords(content.titreInformatif) +
+      countWords(content.titreMarque) +
+      countWords(content.abstract) +
+      countWords(content.markdown)
+    );
+  }
+  // Structured content
+  return (
+    countWords(content.titreInformatif) +
+    countWords(content.titreMarque) +
+    countWords(content.abstract) +
+    countWords(content.what) +
+    countInfoSections(content.how as any) +
+    countInfoSections((content as any).next) +
+    countInfoSections((content as any).why)
+  );
+};
+
+const WORDS_TRANSLATED_KEY = "nbWordsTranslated";
+const ACTIVE_STATUSES = ["Actif", "En attente admin"];
+
+export class Migration1774298379363 implements MigrationInterface {
+  public async up(db: Db): Promise<void> {
+    const dispositifs = db.collection("dispositifs");
+
+    // Load all active dispositifs, projecting only translations
+    const docs = await dispositifs
+      .find({ status: { $in: ACTIVE_STATUSES } }, { projection: { translations: 1 } })
+      .toArray();
+
+    let total = 0;
+    for (const doc of docs) {
+      const translations = (doc.translations ?? {}) as Record<
+        string,
+        { content?: Record<string, unknown> }
+      >;
+      for (const [lang, translation] of Object.entries(translations)) {
+        if (lang === "fr") continue; // only count non-French translations
+        total += countTranslationContent(translation?.content);
+      }
+    }
+
+    await db
+      .collection("adminoptions")
+      .updateOne(
+        { key: WORDS_TRANSLATED_KEY },
+        { $set: { key: WORDS_TRANSLATED_KEY, value: total } },
+        { upsert: true },
+      );
+
+    console.log(
+      `[Migration1774298379363] Backfilled nbWordsTranslated = ${total} from ${docs.length} active dispositifs.`,
+    );
+  }
+
+  public async down(db: Db): Promise<void> {
+    await db.collection("adminoptions").deleteOne({ key: WORDS_TRANSLATED_KEY });
+    console.log("[Migration1774298379363] Removed nbWordsTranslated counter from adminoptions.");
+  }
+}


### PR DESCRIPTION
## Problem

The `/traduction/statistics` endpoint computed `nbWordsTranslated` live by loading **all active dispositifs** and counting words across every non-FR translation in-memory — O(N×L), taking 14–29s on production.

During Next.js builds, multiple workers hit this endpoint simultaneously on a cold speedgoose cache. The latency caused 503s on Cloud Run, which were silently swallowed in `getStaticProps`, baking **zero counts** into the static `/traduire` page.

## Solution

Replace the live scan with an **atomic counter stored in `adminoptions`**, kept in sync via hooks:

| Event | Action |
|---|---|
| Translation published (`validateTranslation`) | `+= newWords − oldWords` |
| Translation removed (`deleteTranslations`) | `-= wordsOfRemovedTranslation` |
| Statistics read (`getTranslationStatistics`) | Single `findOne` — O(1) |

A backfill migration populates the initial counter value from existing data.

## Changes

- **`adminOptions.repository.ts`** — `getWordsTranslatedCounter()` + `incrementWordsTranslatedCounter(delta)` helpers
- **`validateTranslation.ts`** — hook to update counter on every publish (handles both first-time and expert updates)
- **`deleteTranslations.ts`** — hook to decrement counter before `$unset`
- **`getTranslationStatistics.ts`** — replaces O(N×L) computation with O(1) counter read; removes now-unused imports
- **`migrations/1774298379363_BackfillWordsTranslatedCounter.ts`** — one-time backfill from active dispositifs

## Deployment order

1. Deploy this backend change
2. `pnpm migrate up` — populates the counter (< 1s)
3. Rebuild frontend — statistics endpoint now responds in < 100ms

## Test plan

- [ ] `pnpm check:types:server` passes ✅ (verified locally)
- [ ] `pnpm lint:server` passes ✅ (verified locally)
- [ ] After running migration, `db.adminoptions.findOne({ key: "nbWordsTranslated" })` returns a non-zero value
- [ ] `/api/traduction/statistics` responds in < 200ms (vs 14–29s before)
- [ ] `/traduire` page shows correct non-zero word count after frontend rebuild

👾 Generated with [Letta Code](https://letta.com)