### PR TITLE
[server] Add validatedAndPublished to MENS email restrictions

### DIFF
--- a/apps/server/src/modules/mail/data.ts
+++ b/apps/server/src/modules/mail/data.ts
@@ -51,5 +51,6 @@ export const STRUCTURE_PREFS: Record<string, Record<TemplateName, boolean>> = {
     ficheArchived: false,
     publishedFicheToCreator: false,
     publishedFicheToStructureMembers: false,
+    validatedAndPublished: false,
   },
 };


### PR DESCRIPTION
## Summary
Adds `validatedAndPublished: false` to the STRUCTURE_PREFS for réseau MENS, blocking the "Les mises à jour de votre fiche ont été publiées" email template.

## Root Cause
The MENS structure's mail preferences only blocked:
- `publishedFicheToStructureMembers`
- `publishedFicheToCreator`  
- `ficheArchived`

But when a dispositif is **updated and republished**, it uses the `validatedAndPublished` template instead. This template was missing from the blocked list, allowing MENS members to receive update notifications.

## Fix
```typescript
"63985164fd1bf4e22792ef6e": {
  ...DEFAULT_MAIL_PREFS,
  ficheArchived: false,
  publishedFicheToCreator: false,
  publishedFicheToStructureMembers: false,
  validatedAndPublished: false,  // <-- Added
},
```

## Testing
- Verified user `64aad4d22e7872e398e7b8cd` is a confirmed MENS member
- Confirmed dispositif `63a09096e05318191f09690d` triggered `validatedAndPublished` email

Fixes RI-1154

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>