### PR TITLE
[server] Add debug logging for MENS email filtering (RI-1154)

### DIFF
--- a/apps/server/src/modules/mail/__tests__/helpers.test.ts
+++ b/apps/server/src/modules/mail/__tests__/helpers.test.ts
@@ -148,3 +148,55 @@ describe("consentsToEmail", () => {
     });
   });
 });
+
+/**
+ * RI-1154: Regression test for MENS members receiving validatedAndPublished emails
+ *
+ * These tests verify that the MENS email blocking logic is working.
+ * If the structure-level preference check is disabled (simulating the bug),
+ * these tests will FAIL, demonstrating the bug.
+ */
+describe("RI-1154: validatedAndPublished should be blocked for MENS members", () => {
+  it("should block validatedAndPublished for MENS member (regression test)", async () => {
+    // User IS a confirmed member of MENS structure
+    mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
+
+    // This is the email that was incorrectly sent (subject: "Les mises à jour de votre fiche ont été publiées")
+    const result = await consentsToEmail(
+      MENS_MEMBER_USER_ID,
+      "validatedAndPublished",
+      MENS_STRUCTURE_ID,
+    );
+
+    // Should be BLOCKED - MENS inherits validatedAndPublished: false from DEFAULT_MAIL_PREFS
+    // If this returns true, the MENS blocking logic is broken!
+    expect(result).toBe(false);
+  });
+
+  it("should block validatedAndPublished for actual MENS member user ID from production", async () => {
+    // Using the actual user ID from production incident: 64aad4d22e7872e398e7b8cd
+    const actualMensMemberId = "64aad4d22e7872e398e7b8cd" as unknown as UserId;
+
+    mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
+
+    const result = await consentsToEmail(
+      actualMensMemberId,
+      "validatedAndPublished",
+      MENS_STRUCTURE_ID,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("should verify validatedAndPublished is false in DEFAULT_MAIL_PREFS", () => {
+    // This documents that validatedAndPublished should be blocked by default
+    expect(DEFAULT_MAIL_PREFS.validatedAndPublished).toBe(false);
+  });
+
+  it("should verify MENS structure inherits validatedAndPublished: false", () => {
+    // MENS STRUCTURE_PREFS spreads DEFAULT_MAIL_PREFS, so it should inherit the false value
+    const mensPrefs = STRUCTURE_PREFS["63985164fd1bf4e22792ef6e"];
+    expect(mensPrefs).toBeDefined();
+    expect(mensPrefs.validatedAndPublished).toBe(false);
+  });
+});

--- a/apps/server/src/modules/mail/helpers.ts
+++ b/apps/server/src/modules/mail/helpers.ts
@@ -1,5 +1,6 @@
 import type { StructureId, UserId } from "@refugies-info/mongo";
 import { StructureModel } from "@refugies-info/mongo";
+import logger from "~/logger";
 import type { TemplateName } from "../../connectors/sendgrid/sendgrid.types";
 import { STRUCTURE_PREFS, USER_PREFS } from "./data";
 
@@ -21,9 +22,26 @@ export const consentsToEmail = async (
   structureId?: StructureId,
 ): Promise<boolean> => {
   const id = userId.toString();
+  const structIdStr = structureId?.toString();
+
+  logger.info("[consentsToEmail] ENTRY", {
+    userId: id,
+    templateName,
+    structureId: structIdStr,
+    hasStructureId: !!structureId,
+  });
 
   // 1. Check for a user-level block. A `false` here is a definitive "no".
-  if (USER_PREFS[id]?.[templateName] === false) {
+  const userPref = USER_PREFS[id]?.[templateName];
+  logger.info("[consentsToEmail] User pref check", {
+    userId: id,
+    templateName,
+    userPref,
+    hasUserPref: userPref !== undefined,
+  });
+
+  if (userPref === false) {
+    logger.info("[consentsToEmail] BLOCKED by user pref", { userId: id, templateName });
     return false;
   }
 
@@ -32,18 +50,62 @@ export const consentsToEmail = async (
   //    - user is actually a member of that structure
   if (structureId) {
     const structId = structureId.toString();
+    const structPrefs = STRUCTURE_PREFS[structId];
+    const structPref = structPrefs?.[templateName];
+
+    logger.info("[consentsToEmail] Checking structure prefs", {
+      structId,
+      templateName,
+      structurePref: structPref,
+      hasStructurePref: structPref !== undefined,
+    });
 
     // Verify user is a member of this structure
-    const membership = await StructureModel.findOne(
-      { _id: structId, "membres.userId": id },
-      { _id: 1 },
-    ).lean();
+    const query = { _id: structId, "membres.userId": id };
+    logger.info("[consentsToEmail] Membership query", { query });
 
-    if (membership && STRUCTURE_PREFS[structId]?.[templateName] === false) {
-      return false;
+    const membership = await StructureModel.findOne(query, { _id: 1 }).lean();
+
+    logger.info("[consentsToEmail] Membership result", {
+      structId,
+      userId: id,
+      isMember: !!membership,
+      membership,
+    });
+
+    if (membership) {
+      logger.info("[consentsToEmail] Structure pref value", {
+        structId,
+        templateName,
+        structPref,
+      });
+
+      if (structPref === false) {
+        logger.info("[consentsToEmail] BLOCKED by structure pref", {
+          structId,
+          userId: id,
+          templateName,
+        });
+        return false;
+      }
+    } else {
+      logger.info("[consentsToEmail] User not a member, skipping structure pref check", {
+        structId,
+        userId: id,
+      });
     }
+  } else {
+    logger.info("[consentsToEmail] No structureId provided, skipping structure pref check");
   }
 
   // 3. Check for explicit user-level allow, or default to true
-  return USER_PREFS[id]?.[templateName] ?? true;
+  const finalDecision = userPref ?? true;
+  logger.info("[consentsToEmail] ALLOWED (default)", {
+    userId: id,
+    templateName,
+    finalDecision,
+    reason: userPref === true ? "explicit user allow" : "default true",
+  });
+
+  return finalDecision;
 };

--- a/apps/server/src/modules/mail/mail.service.ts
+++ b/apps/server/src/modules/mail/mail.service.ts
@@ -672,6 +672,12 @@ interface ValidatedAndPublished {
 }
 
 export const sendValidatedAndPublishedMailService = async (data: ValidatedAndPublished) => {
+  logger.info("[sendValidatedAndPublishedMailService] ENTRY", {
+    userId: data.userId?.toString(),
+    email: data.email,
+    structureId: data.structureId?.toString(),
+    hasStructureId: !!data.structureId,
+  });
   if (await consentsToEmail(data.userId, "validatedAndPublished", data.structureId)) {
     try {
       logger.info("[sendValidatedAndPublishedMailService] received");


### PR DESCRIPTION
## Summary
Adds comprehensive debug logging and regression tests to trace why `validatedAndPublished` emails are being sent to MENS members when they should be blocked.

## Debug Logging Added

### `consentsToEmail()` in helpers.ts:
- Entry with all parameters (userId, templateName, structureId)
- User pref check results
- StructureId presence check
- Membership query details and results
- Structure pref values
- Final decision with reasoning

### `sendValidatedAndPublishedMailService()` in mail.service.ts:
- Entry with userId, email, structureId

## Regression Tests for RI-1154

1. **should block validatedAndPublished for MENS member** - General regression test
2. **should block for actual production user ID** - Uses real user ID (64aad4d22e7872e398e7b8cd)
3. **should verify DEFAULT_MAIL_PREFS.validatedAndPublished is false** - Documents expected config
4. **should verify MENS structure inherits validatedAndPublished: false** - Verifies STRUCTURE_PREFS

All 24 tests pass locally, confirming code logic is correct.

## Purpose
This PR is for **debugging RI-1154**. The tests serve as:
1. **Documentation** of expected behavior
2. **Regression prevention** - will fail if logic is broken in future
3. **Verification** that the fix works correctly

The debug logging will help trace exactly where the email filtering fails in production.

## After Deployment
Once deployed to staging or production:
1. Publish/update a dispositif with MENS as mainSponsor
2. Check logs in GCP Logging for `[consentsToEmail]` entries
3. Trace the decision path to find the root cause

## Cleanup
After the root cause is identified and fixed, the debug logging should be removed or reduced.

Related to RI-1154

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>