### PR TITLE
[server] Add regression tests for RI-1154 MENS email blocking

### DIFF
--- a/apps/server/src/modules/mail/__tests__/helpers.test.ts
+++ b/apps/server/src/modules/mail/__tests__/helpers.test.ts
@@ -148,3 +148,53 @@ describe("consentsToEmail", () => {
     });
   });
 });
+
+/**
+ * RI-1154: Regression test for MENS members receiving validatedAndPublished emails
+ *
+ * Bug: validatedAndPublished emails were being sent to MENS members when they should
+ * be blocked (inherited from DEFAULT_MAIL_PREFS.validatedAndPublished = false).
+ */
+describe("RI-1154: validatedAndPublished should be blocked for MENS members", () => {
+  it("should block validatedAndPublished for MENS member (regression test)", async () => {
+    // User IS a confirmed member of MENS structure
+    mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
+
+    // This is the email that was incorrectly sent (subject: "Les mises à jour de votre fiche ont été publiées")
+    const result = await consentsToEmail(
+      MENS_MEMBER_USER_ID,
+      "validatedAndPublished",
+      MENS_STRUCTURE_ID,
+    );
+
+    // Should be BLOCKED - MENS inherits validatedAndPublished: false from DEFAULT_MAIL_PREFS
+    expect(result).toBe(false);
+  });
+
+  it("should block validatedAndPublished for actual MENS member user ID from production", async () => {
+    // Using the actual user ID from production incident: 64aad4d22e7872e398e7b8cd
+    const actualMensMemberId = "64aad4d22e7872e398e7b8cd" as unknown as UserId;
+
+    mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
+
+    const result = await consentsToEmail(
+      actualMensMemberId,
+      "validatedAndPublished",
+      MENS_STRUCTURE_ID,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("should verify validatedAndPublished is false in DEFAULT_MAIL_PREFS", () => {
+    // This documents that validatedAndPublished should be blocked by default
+    expect(DEFAULT_MAIL_PREFS.validatedAndPublished).toBe(false);
+  });
+
+  it("should verify MENS structure inherits validatedAndPublished: false", () => {
+    // MENS STRUCTURE_PREFS spreads DEFAULT_MAIL_PREFS, so it should inherit the false value
+    const mensPrefs = STRUCTURE_PREFS["63985164fd1bf4e22792ef6e"];
+    expect(mensPrefs).toBeDefined();
+    expect(mensPrefs.validatedAndPublished).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds regression tests to verify that `validatedAndPublished` emails are correctly blocked for MENS structure members.

## Tests Added

1. **should block validatedAndPublished for MENS member** - General regression test
2. **should block for actual production user ID** - Uses the real user ID (64aad4d22e7872e398e7b8cd) from the incident
3. **should verify DEFAULT_MAIL_PREFS.validatedAndPublished is false** - Documents expected config
4. **should verify MENS inherits validatedAndPublished: false** - Verifies STRUCTURE_PREFS configuration

## Test Results

All tests **PASS** locally:
```
Tests: 24 passed, 24 total
```

This confirms the code logic is correct. The production issue (email sent despite correct code) suggests:
- Runtime data issue (e.g., `structureId` not being passed)
- Different code running in production
- Async/timing issue during execution

## Next Steps

These tests serve as:
1. **Documentation** of expected behavior
2. **Regression prevention** - will fail if the logic is broken in the future
3. **Verification** that the fix (when found) works correctly

Deploy alongside PR #3602 (debug logging) to trace the root cause in production.

Related to RI-1154

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>