### PR TITLE
[server] Fix startup race condition causing 500/503 errors

### DIFF
--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -85,7 +85,7 @@ app.get("*", (_req, res) => {
 const startServer = async () => {
   try {
     await connectWithRetry();
-    const port = process.env.PORT;
+    const port = process.env.PORT || 8080;
     app.listen(port, () => logger.info(`Listening on port ${port}`));
   } catch (e) {
     logger.error("[server] Failed to start", { error: e });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -30,7 +30,7 @@ mongoose.set("debug", true);
 mongoose.set("strictQuery", true);
 const db_path = MONGODB_URI;
 
-const connectWithRetry = async () => {
+const connectWithRetry = async (): Promise<void> => {
   return mongoose
     .connect(db_path)
     .then(async () => {
@@ -43,10 +43,10 @@ const connectWithRetry = async () => {
         message: e.message,
         error: e,
       });
-      setTimeout(connectWithRetry, 5000);
+      // Retry after 5 seconds
+      return new Promise((resolve) => setTimeout(() => resolve(connectWithRetry()), 5000));
     });
 };
-connectWithRetry().catch((e) => logger.error("[mongoose] error", { error: e }));
 
 //Body Parser
 app.use(compression());
@@ -80,5 +80,17 @@ app.use(serverErrorHandler);
 app.get("*", (_req, res) => {
   res.status(404).json({ message: "Not found" });
 });
-const port = process.env.PORT;
-app.listen(port, () => logger.info(`Listening on port ${port}`));
+
+// Start server only after DB and cache are ready
+const startServer = async () => {
+  try {
+    await connectWithRetry();
+    const port = process.env.PORT;
+    app.listen(port, () => logger.info(`Listening on port ${port}`));
+  } catch (e) {
+    logger.error("[server] Failed to start", { error: e });
+    process.exit(1);
+  }
+};
+
+startServer();


### PR DESCRIPTION
## Summary

- **Root cause**: Server started accepting requests before Mongoose connection and Speedgoose cache were initialized
- **Symptom**: Requests arriving during the ~20 second startup window would fail with `TypeError: cacheQuery is not a function` (500s) or timeout waiting for response (503s)
- **Fix**: Wrap server startup in async `startServer()` function that awaits `connectWithRetry()` before calling `app.listen()`

## Evidence

Analyzed 100 error logs from the last 12 hours on staging:

| Burst | Time (UTC) | 500s | 503s | Instance |
|-------|------------|------|------|----------|
| 1 | 04:04-04:05 | 3 | 14 | `008c15ff08c54ab...` |
| 2 | 05:27-05:28 | 0 | 40 | `008c15ff084389...` |
| 3 | 10:41-10:42 | 20 | 22 | `008c15ff0862af...` |

All three bursts align with container startup timing:

```
04:04:41 - Listening on port 8080  ← Server accepting requests!
04:04:48 - Mongoose connected to MongoDB
04:05:00 - Speedgoose cache initialized  ← 19 seconds AFTER listening!
```

## Changes

1. **`connectWithRetry()` now properly chains retry promises** - changed from `setTimeout(callback)` to `setTimeout(() => resolve(connectWithRetry()))`
2. **Server startup is now sequential** - `await connectWithRetry()` before `app.listen()`
3. **Graceful failure** - exits with code 1 if initialization fails

## Test plan

- [ ] Verify staging deployment with this fix
- [ ] Monitor Cloud Run logs for `cacheQuery is not a function` errors
- [ ] Check startup latency in Cloud Run metrics

## Related

- Closes #3601 (initial diagnosis was incorrect - connection pool size is NOT the issue)
- See `research/server-startup-race-condition.md` for full analysis

🐾 Generated with [Letta Code](https://letta.com)