### PR TITLE
[server] fix: remove membership check for structure-level email prefs (RI-1154)

### DIFF
--- a/apps/server/src/modules/mail/__tests__/helpers.test.ts
+++ b/apps/server/src/modules/mail/__tests__/helpers.test.ts
@@ -4,32 +4,11 @@ import { consentsToEmail } from "../helpers";
 
 // Test IDs
 const MENS_STRUCTURE_ID = "63985164fd1bf4e22792ef6e" as unknown as StructureId;
-const MENS_MEMBER_USER_ID = "mens_member_user_id" as unknown as UserId;
 const AGIR_USER_ID = "65f8245fd9babd17f5825aac" as unknown as UserId;
 const UNKNOWN_USER_ID = "000000000000000000000000" as unknown as UserId;
 const UNKNOWN_STRUCTURE_ID = "000000000000000000000001" as unknown as StructureId;
 
-// Mock StructureModel.findOne
-const mockLean = jest.fn();
-const mockFindOne = jest.fn();
-
-jest.mock("@refugies-info/mongo", () => ({
-  ...jest.requireActual("@refugies-info/mongo"),
-  StructureModel: {
-    findOne: jest.fn(() => ({ lean: mockLean })),
-  },
-}));
-
-// Import after mock
-import { StructureModel } from "@refugies-info/mongo";
-
 describe("consentsToEmail", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    // Default: user is NOT a member
-    mockLean.mockResolvedValue(null);
-  });
-
   describe("user-level preferences (USER_PREFS)", () => {
     it("should block when user-level preference is false", async () => {
       // AGIR user has DEFAULT_MAIL_PREFS which blocks newUserWelcome
@@ -44,41 +23,48 @@ describe("consentsToEmail", () => {
   });
 
   describe("structure-level preferences (STRUCTURE_PREFS)", () => {
-    it("should block when user is member and structure-level preference is false", async () => {
-      // User IS a member of MENS
-      mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
-
+    it("should block when structure-level preference is false (regardless of membership)", async () => {
+      // MENS blocks validatedAndPublished by default
       const result = await consentsToEmail(
-        MENS_MEMBER_USER_ID,
+        UNKNOWN_USER_ID,
+        "validatedAndPublished",
+        MENS_STRUCTURE_ID,
+      );
+      expect(result).toBe(false);
+    });
+
+    it("should block publishedFicheToStructureMembers for MENS", async () => {
+      const result = await consentsToEmail(
+        UNKNOWN_USER_ID,
         "publishedFicheToStructureMembers",
         MENS_STRUCTURE_ID,
       );
       expect(result).toBe(false);
     });
 
-    it("should block publishedFicheToCreator for MENS member", async () => {
-      mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
-
+    it("should block publishedFicheToCreator for MENS", async () => {
       const result = await consentsToEmail(
-        MENS_MEMBER_USER_ID,
+        UNKNOWN_USER_ID,
         "publishedFicheToCreator",
         MENS_STRUCTURE_ID,
       );
       expect(result).toBe(false);
     });
 
-    it("should allow resetPassword for MENS member (transactional)", async () => {
-      mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
-
-      const result = await consentsToEmail(MENS_MEMBER_USER_ID, "resetPassword", MENS_STRUCTURE_ID);
+    it("should allow resetPassword for MENS (transactional)", async () => {
+      const result = await consentsToEmail(UNKNOWN_USER_ID, "resetPassword", MENS_STRUCTURE_ID);
       expect(result).toBe(true);
     });
 
-    it("should block ficheArchived for MENS member", async () => {
-      mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
-
-      const result = await consentsToEmail(MENS_MEMBER_USER_ID, "ficheArchived", MENS_STRUCTURE_ID);
+    it("should block ficheArchived for MENS", async () => {
+      const result = await consentsToEmail(UNKNOWN_USER_ID, "ficheArchived", MENS_STRUCTURE_ID);
       expect(result).toBe(false);
+    });
+
+    it("should allow when structureId is provided but no pref exists for that template", async () => {
+      // Unknown structure has no prefs
+      const result = await consentsToEmail(UNKNOWN_USER_ID, "newUserWelcome", UNKNOWN_STRUCTURE_ID);
+      expect(result).toBe(true);
     });
   });
 
@@ -89,11 +75,9 @@ describe("consentsToEmail", () => {
       expect(result).toBe(false);
     });
 
-    it("should block when structure-level is false and user is member", async () => {
-      mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
-
+    it("should block when structure-level is false", async () => {
       const result = await consentsToEmail(
-        MENS_MEMBER_USER_ID,
+        UNKNOWN_USER_ID,
         "publishedFicheToStructureMembers",
         MENS_STRUCTURE_ID,
       );
@@ -101,29 +85,15 @@ describe("consentsToEmail", () => {
     });
   });
 
-  describe("membership verification", () => {
-    it("should NOT apply structure prefs if user is NOT a member", async () => {
-      // User is NOT a member of MENS (default mock returns null)
-      // Even though MENS blocks publishedFicheToStructureMembers, user should get the email
-      const result = await consentsToEmail(
-        UNKNOWN_USER_ID,
-        "publishedFicheToStructureMembers",
-        MENS_STRUCTURE_ID,
-      );
+  describe("no structureId provided", () => {
+    it("should skip structure-level check when no structureId", async () => {
+      const result = await consentsToEmail(UNKNOWN_USER_ID, "newUserWelcome");
       expect(result).toBe(true);
     });
 
-    it("should query membership when structureId is provided", async () => {
-      await consentsToEmail(UNKNOWN_USER_ID, "newUserWelcome", MENS_STRUCTURE_ID);
-      expect(StructureModel.findOne).toHaveBeenCalledWith(
-        { _id: MENS_STRUCTURE_ID.toString(), "membres.userId": UNKNOWN_USER_ID.toString() },
-        { _id: 1 },
-      );
-    });
-
-    it("should NOT query DB when structureId is not provided", async () => {
-      await consentsToEmail(UNKNOWN_USER_ID, "newUserWelcome");
-      expect(StructureModel.findOne).not.toHaveBeenCalled();
+    it("should still check user-level prefs when no structureId", async () => {
+      const result = await consentsToEmail(AGIR_USER_ID, "newUserWelcome");
+      expect(result).toBe(false);
     });
   });
 
@@ -133,18 +103,9 @@ describe("consentsToEmail", () => {
       expect(result).toBe(true);
     });
 
-    it("should default to true for unknown users with unknown structureId (not a member)", async () => {
+    it("should default to true for unknown users with unknown structureId", async () => {
       const result = await consentsToEmail(UNKNOWN_USER_ID, "newUserWelcome", UNKNOWN_STRUCTURE_ID);
       expect(result).toBe(true);
-    });
-  });
-
-  describe("performance: skip DB query when user-level blocks", () => {
-    it("should not query DB when user-level preference is false", async () => {
-      // AGIR user has newUserWelcome=false in USER_PREFS - should NOT query DB
-      const result = await consentsToEmail(AGIR_USER_ID, "newUserWelcome");
-      expect(result).toBe(false);
-      expect(StructureModel.findOne).not.toHaveBeenCalled();
     });
   });
 });
@@ -153,31 +114,24 @@ describe("consentsToEmail", () => {
  * RI-1154: Regression test for MENS members receiving validatedAndPublished emails
  *
  * These tests verify that the MENS email blocking logic is working.
- * If the structure-level preference check is disabled (simulating the bug),
- * these tests will FAIL, demonstrating the bug.
+ * The key insight: structure-level prefs apply REGARDLESS of membership.
  */
-describe("RI-1154: validatedAndPublished should be blocked for MENS members", () => {
-  it("should block validatedAndPublished for MENS member (regression test)", async () => {
-    // User IS a confirmed member of MENS structure
-    mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
-
+describe("RI-1154: validatedAndPublished should be blocked for MENS", () => {
+  it("should block validatedAndPublished for MENS (regression test)", async () => {
     // This is the email that was incorrectly sent (subject: "Les mises à jour de votre fiche ont été publiées")
     const result = await consentsToEmail(
-      MENS_MEMBER_USER_ID,
+      UNKNOWN_USER_ID,
       "validatedAndPublished",
       MENS_STRUCTURE_ID,
     );
 
     // Should be BLOCKED - MENS inherits validatedAndPublished: false from DEFAULT_MAIL_PREFS
-    // If this returns true, the MENS blocking logic is broken!
     expect(result).toBe(false);
   });
 
   it("should block validatedAndPublished for actual MENS member user ID from production", async () => {
     // Using the actual user ID from production incident: 64aad4d22e7872e398e7b8cd
     const actualMensMemberId = "64aad4d22e7872e398e7b8cd" as unknown as UserId;
-
-    mockLean.mockResolvedValue({ _id: MENS_STRUCTURE_ID });
 
     const result = await consentsToEmail(
       actualMensMemberId,

--- a/apps/server/src/modules/mail/helpers.ts
+++ b/apps/server/src/modules/mail/helpers.ts
@@ -1,5 +1,4 @@
 import type { StructureId, UserId } from "@refugies-info/mongo";
-import { StructureModel } from "@refugies-info/mongo";
 import logger from "~/logger";
 import type { TemplateName } from "../../connectors/sendgrid/sendgrid.types";
 import { STRUCTURE_PREFS, USER_PREFS } from "./data";
@@ -13,7 +12,7 @@ import { STRUCTURE_PREFS, USER_PREFS } from "./data";
  *
  * @param userId - The user's ID
  * @param templateName - The email template name
- * @param structureId - For structure-related emails: checks prefs only if user is a member
+ * @param structureId - For structure-related emails: checks structure-level prefs
  * @returns true if user consents, false otherwise
  */
 export const consentsToEmail = async (
@@ -45,9 +44,7 @@ export const consentsToEmail = async (
     return false;
   }
 
-  // 2. Check structure-level preferences ONLY if:
-  //    - structureId is provided, AND
-  //    - user is actually a member of that structure
+  // 2. Check structure-level preferences if structureId is provided
   if (structureId) {
     const structId = structureId.toString();
     const structPrefs = STRUCTURE_PREFS[structId];
@@ -60,39 +57,13 @@ export const consentsToEmail = async (
       hasStructurePref: structPref !== undefined,
     });
 
-    // Verify user is a member of this structure
-    const query = { _id: structId, "membres.userId": id };
-    logger.info("[consentsToEmail] Membership query", { query });
-
-    const membership = await StructureModel.findOne(query, { _id: 1 }).lean();
-
-    logger.info("[consentsToEmail] Membership result", {
-      structId,
-      userId: id,
-      isMember: !!membership,
-      membership,
-    });
-
-    if (membership) {
-      logger.info("[consentsToEmail] Structure pref value", {
-        structId,
-        templateName,
-        structPref,
-      });
-
-      if (structPref === false) {
-        logger.info("[consentsToEmail] BLOCKED by structure pref", {
-          structId,
-          userId: id,
-          templateName,
-        });
-        return false;
-      }
-    } else {
-      logger.info("[consentsToEmail] User not a member, skipping structure pref check", {
+    if (structPref === false) {
+      logger.info("[consentsToEmail] BLOCKED by structure pref", {
         structId,
         userId: id,
+        templateName,
       });
+      return false;
     }
   } else {
     logger.info("[consentsToEmail] No structureId provided, skipping structure pref check");


### PR DESCRIPTION
## Summary
- Remove unnecessary membership verification from `consentsToEmail()` 
- Structure-level email preferences now apply unconditionally when `structureId` is provided
- Fixes RI-1154: MENS members were receiving `validatedAndPublished` emails despite structure-level blocking preference

## Root Cause
The membership check query was returning `false` for users who were in the `membresToSendMail` list, causing the structure-level blocking preference to be skipped. The issue was that structure-level prefs should apply **regardless of membership** - if we're sending an email on behalf of a structure, that structure's rules should be followed.

## Changes
- `apps/server/src/modules/mail/helpers.ts`: Remove `StructureModel` import and membership query
- `apps/server/src/modules/mail/__tests__/helpers.test.ts`: Update tests to reflect new behavior

## Test plan
- [x] All existing tests pass
- [x] Manual verification with production logs confirms the fix
- [ ] Deploy to staging and verify MENS members no longer receive blocked emails

Fixes RI-1154

👾 Generated with [Letta Code](https://letta.com)