### PR TITLE
[workspace] switch release-please to single-package config

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,10 +1,3 @@
 {
-  "apps/client": "2.3.1",
-  "apps/server": "2.3.2",
-  "apps/mobile": "2.3.0",
-  "packages/api-types": "2.3.0",
-  "packages/ui": "2.3.0",
-  "packages/mongo": "2.3.0",
-  "packages/typescript-config": "2.3.0",
-  "packages/markdown-utils": "2.3.0"
+  ".": "2.3.2"
 }

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/client",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Plateforme dédiée à l'intégration des réfugiés en France",
   "author": "Soufiane Lamrissi",
   "homepage": "https://refugies.info",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -109,7 +109,7 @@
     "typescript": "~5.8.3"
   },
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.2",
   "name": "@refugies-info/mobile",
   "engines": {
     "node": "24.14.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "karfur",
-  "version": "0.1.0",
+  "version": "2.3.2",
   "description": "Plateforme dédiée aux réfugiés",
   "author": "Soufiane Lamrissi",
   "homepage": "https://accueil-integration-refugies.fr",

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/api-types",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "Types defined in the API to be used by the frontend",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/markdown-utils/package.json
+++ b/packages/markdown-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/markdown-utils",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "description": "Shared markdown remark plugins and directive utilities for web client and mobile app",
   "main": "src/index.ts",
   "scripts": {

--- a/packages/mongo/package.json
+++ b/packages/mongo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/mongo",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "scripts": {

--- a/packages/typescript-config/package.json
+++ b/packages/typescript-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/typescript-config",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "private": true,
   "publishConfig": {
     "access": "public"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refugies-info/ui",
-  "version": "2.3.0",
+  "version": "2.3.2",
   "sideEffects": [
     "**/*.css"
   ],

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,37 +1,19 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "packages": {
-    "apps/client": {
+    ".": {
       "release-type": "node",
-      "package-name": "@refugies-info/client"
-    },
-    "apps/server": {
-      "release-type": "node",
-      "package-name": "@refugies-info/server"
-    },
-    "apps/mobile": {
-      "release-type": "node",
-      "package-name": "@refugies-info/mobile"
-    },
-    "packages/api-types": {
-      "release-type": "node",
-      "package-name": "@refugies-info/api-types"
-    },
-    "packages/ui": {
-      "release-type": "node",
-      "package-name": "@refugies-info/ui"
-    },
-    "packages/mongo": {
-      "release-type": "node",
-      "package-name": "@refugies-info/mongo"
-    },
-    "packages/typescript-config": {
-      "release-type": "node",
-      "package-name": "@refugies-info/typescript-config"
-    },
-    "packages/markdown-utils": {
-      "release-type": "node",
-      "package-name": "@refugies-info/markdown-utils"
+      "package-name": "@refugies-info/karfur",
+      "extra-files": [
+        "apps/client/package.json",
+        "apps/server/package.json",
+        "apps/mobile/package.json",
+        "packages/api-types/package.json",
+        "packages/ui/package.json",
+        "packages/mongo/package.json",
+        "packages/typescript-config/package.json",
+        "packages/markdown-utils/package.json"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Switch from multi-package to single-package release-please config
- PR titles will now include version: `"chore(dev): release 2.4.0"` instead of generic `"chore: release dev"`
- Unifies all package versions to 2.3.2 (single CHANGELOG.md at root)

## Changes
- Single package entry at root with `extra-files` for all package.jsons
- Matches the pattern used in ragtime and other etalab-ia repos

## Context
See #3604 for the generic title issue. The ragtime repo uses a single package entry with `extra-files`, which makes release-please include the version in the PR title.

## Test plan
- [ ] Merge this PR
- [ ] Make a conventional commit to `dev`
- [ ] Verify next release-please PR has version in title

👾 Generated with [Letta Code](https://letta.com)