### PR TITLE
[server] prevent 500 when appuser notificationsSettings is missing

### DIFF
--- a/apps/server/src/modules/appusers/appusers.repository.ts
+++ b/apps/server/src/modules/appusers/appusers.repository.ts
@@ -5,6 +5,13 @@ import {
   type NotificationsSettings,
 } from "@refugies-info/mongo";
 
+const DEFAULT_NOTIFICATIONS_SETTINGS: NotificationsSettings = {
+  global: true,
+  local: true,
+  demarches: true,
+  themes: {},
+};
+
 export const getAllAppUsers = async () => AppUserModel.find();
 
 export const getAppUsersBatch = async (skip: number, batchSize: number) =>
@@ -39,14 +46,18 @@ export const updateNotificationsSettings = async (
   if (!appUser) {
     return null;
   }
+
+  // Use default settings if notificationsSettings is undefined (field is optional in schema)
+  const currentSettings = appUser.notificationsSettings || DEFAULT_NOTIFICATIONS_SETTINGS;
+
   if (payload.themes) {
-    const themes = { ...appUser.notificationsSettings.themes, ...payload.themes };
+    const themes = { ...currentSettings.themes, ...payload.themes };
     appUser.notificationsSettings = {
-      ...appUser.notificationsSettings,
+      ...currentSettings,
       themes,
     };
   } else {
-    appUser.notificationsSettings = { ...appUser.notificationsSettings, ...payload };
+    appUser.notificationsSettings = { ...currentSettings, ...payload };
   }
   await appUser.save();
   return appUser.notificationsSettings;

--- a/apps/server/src/modules/appusers/appusers.repository.ts
+++ b/apps/server/src/modules/appusers/appusers.repository.ts
@@ -50,15 +50,16 @@ export const updateNotificationsSettings = async (
   // Use default settings if notificationsSettings is undefined (field is optional in schema)
   const currentSettings = appUser.notificationsSettings || DEFAULT_NOTIFICATIONS_SETTINGS;
 
-  if (payload.themes) {
-    const themes = { ...currentSettings.themes, ...payload.themes };
-    appUser.notificationsSettings = {
-      ...currentSettings,
-      themes,
-    };
-  } else {
-    appUser.notificationsSettings = { ...currentSettings, ...payload };
-  }
+  const { themes: payloadThemes, ...otherPayload } = payload;
+
+  appUser.notificationsSettings = {
+    ...currentSettings,
+    ...otherPayload,
+    themes: {
+      ...currentSettings.themes,
+      ...(payloadThemes || {}),
+    },
+  };
   await appUser.save();
   return appUser.notificationsSettings;
 };


### PR DESCRIPTION
## Summary
- add a default notifications settings object in appusers repository
- guard `updateNotificationsSettings` against legacy appusers where `notificationsSettings` is undefined
- keep existing merge behavior for `themes` and partial payload updates while preventing runtime crashes

## Test plan
- [x] `pnpm lint:server`
- [x] `pnpm check:types:server`
- [ ] Reproduce with a legacy appuser document without `notificationsSettings` and verify `POST /appuser/notification_settings` returns 200

👾 Generated with [Letta Code](https://letta.com)