### PR TITLE
Erreur 500 sur les fiches RCO

### DIFF
--- a/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
+++ b/apps/client/src/components/Pages/dispositif/Breadcrumb/BreadcrumbDetails.tsx
@@ -97,7 +97,7 @@ const BreadcrumbDetails = ({ dispositif }: Props) => {
               </>
             )}
 
-            {dispositif.needs.length === 1 && need && (
+            {dispositif.needs?.length === 1 && need && (
               <>
                 <li>
                   <Link

--- a/apps/client/src/lib/recherche/queryContents.ts
+++ b/apps/client/src/lib/recherche/queryContents.ts
@@ -171,7 +171,7 @@ const filterSuggestions = (
       // Only the current themes
       .filter((dispositif) => relatedThemesIds.includes(dispositif.theme as string))
       // Only the ones that DOES NOT have the current selected needs
-      .filter((dispositif) => !dispositif.needs.some((need) => selectedNeedsIds.includes(need)));
+      .filter((dispositif) => !dispositif.needs?.some((need) => selectedNeedsIds.includes(need)));
 
     // Returns the results here to stop the filtering process
     return suggestions.sort((a, b) => b.nbVues - a.nbVues).slice(0, 8);

--- a/packages/api-types/src/generics.ts
+++ b/packages/api-types/src/generics.ts
@@ -287,7 +287,7 @@ export interface SimpleDispositif {
   status: DispositifStatus;
   theme?: Id;
   secondaryThemes?: Id[];
-  needs: Id[];
+  needs?: Id[];
   metadatas?: Metadatas;
   created_at?: Date;
   publishedAt?: Date;

--- a/packages/api-types/src/modules/dispositif.ts
+++ b/packages/api-types/src/modules/dispositif.ts
@@ -88,7 +88,7 @@ export interface ContentForApp {
   abstract: string;
   theme: Id;
   secondaryThemes: Id[];
-  needs: Id[];
+  needs?: Id[];
   nbVues: number;
   nbVuesMobile: number;
   typeContenu: ContentType;
@@ -253,7 +253,7 @@ export type BaseGetDispositifResponse = {
   mainSponsor?: ContentStructure | null;
   theme?: Id;
   secondaryThemes?: Id[];
-  needs: Id[];
+  needs?: Id[];
   sponsors?: (Sponsor | ContentStructure)[];
   avis: {
     created_at: Date;
@@ -391,7 +391,7 @@ export interface GetAllDispositifsResponse {
   status: DispositifStatus;
   theme?: Id;
   secondaryThemes?: Id[];
-  needs: Id[];
+  needs?: Id[];
   created_at?: Date;
   publishedAt?: Date;
   publishedAtAuthor: Author;


### PR DESCRIPTION
Le composant BreadcrumbDetails.tsx accède à dispositif.needs.length sans guard (ligne 100). Or les fiches RCO créées via webhook n'ont pas forcément de  champ needs — le champ est undefined.

C'est une régression de la migration Typegoose → Zod (mars 2026) : avant, Mongoose ajoutait automatiquement default: [] sur les champs array.
Avec les schémas Zod (z.array(...).optional()), le champ reste undefined si non fourni.

Fix : dispositif.needs?.length (optional chaining).

Fixes : RI-1156