### PR TITLE
[workspace] prevent concurrent release workflow overlap

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,10 @@ on:
       - dev
   workflow_dispatch:
 
+concurrency:
+  group: release-please-${{ github.repository }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -20,6 +20,10 @@ on:
       - production
   workflow_dispatch:
 
+concurrency:
+  group: release-pipeline-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # ─── Detect which components changed ───────────────────────────────────────
   detect-changes:


### PR DESCRIPTION
## Summary
- add a concurrency group to `release-please.yml` so only one Release Please run executes at a time
- add a branch-scoped concurrency group to `release_pipeline.yaml` so staging/production release pipelines cannot overlap on the same branch
- keep `cancel-in-progress: false` so in-flight release jobs complete deterministically instead of being interrupted

## Test plan
- [x] Reviewed workflow diffs for both files
- [ ] Observe next staging release to confirm queued (not concurrent) behavior

👾 Generated with [Letta Code](https://letta.com)