### PR TITLE
[server] fix 500 on draft structure tabs

### DIFF
--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -201,10 +201,10 @@ export const getStructureDispositifs = async (
     .then(async (dispositifs) => {
       const usernames = await Promise.all(
         dispositifs.map(async (dispositif) =>
-          dispositif.suggestions.length > 0
+          (dispositif.suggestions || []).length > 0
             ? await getUsersById<{ _id: ObjectId; username: string }>(
                 uniq(
-                  dispositif.suggestions
+                  (dispositif.suggestions || [])
                     .map((s: (typeof dispositif.suggestions)[number]) => s.userId)
                     .filter((id: unknown) => !!id),
                 ),
@@ -220,7 +220,7 @@ export const getStructureDispositifs = async (
     .then(({ dispositifs, usernames }) =>
       dispositifs.map((dispositif) => {
         const translation = getDispositifTranslation(dispositif, locale);
-        const suggestions: SuggestionAPIType[] = dispositif.suggestions.map(
+        const suggestions: SuggestionAPIType[] = (dispositif.suggestions || []).map(
           (s: (typeof dispositif.suggestions)[number]) => {
             return {
               ...(pick(s, ["created_at", "read", "suggestion", "suggestionId", "section"]) as any),
@@ -236,7 +236,7 @@ export const getStructureDispositifs = async (
           ...omit(dispositif, ["translations", "merci", "mainSponsor"]),
           availableLanguages: getAvailableLanguages(dispositif),
           hasDraftVersion: dispositif.hasDraftVersion,
-          nbMercis: dispositif.merci.length,
+          nbMercis: (dispositif.merci || []).length,
           suggestions,
           themeSortIndex: dispositif.sortThemeIndex,
           origin: dispositif.origin ?? "RI",


### PR DESCRIPTION
## Summary
- guard optional draft arrays in `getStructureDispositifs` to avoid reading `.length` on undefined
- use safe fallbacks for `suggestions` mapping and `nbMercis` computation
- fixes backend 500s on `/structures/:id` impacting BO tabs (Fiches / Structure / Notifications)

## Test plan
- [x] `pnpm lint:server`
- [x] `pnpm --filter @refugies-info/server check:types`
- [ ] Verify in staging: open BO with draft dispositifs without structure/suggestions and confirm no 500

👾 Generated with [Letta Code](https://letta.com)