### PR TITLE
fix(client): serialize sitemap locale requests to reduce backend overload

### DIFF
--- a/apps/client/src/pages/sitemap.tsx
+++ b/apps/client/src/pages/sitemap.tsx
@@ -47,16 +47,16 @@ export const getServerSideProps: GetServerSideProps = async ({ res, locales = []
       API.getDispositifs({ type: ContentType.DEMARCHE, locale: loc }),
     ]);
 
-    dispositifs.forEach((d) => {
-      allUrls.push(
-        `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/dispositif/[id]", loc).replace("[id]", d._id.toString())}`,
-      );
-    });
-    demarches.forEach((d) => {
-      allUrls.push(
-        `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/demarche/[id]", loc).replace("[id]", d._id.toString())}`,
-      );
-    });
+    allUrls.push(
+      ...dispositifs.map(
+        (d) =>
+          `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/dispositif/[id]", loc).replace("[id]", d._id.toString())}`,
+      ),
+      ...demarches.map(
+        (d) =>
+          `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/demarche/[id]", loc).replace("[id]", d._id.toString())}`,
+      ),
+    );
   }
 
   // Set cache headers - cache for 1 day, revalidate after 1 hour

--- a/apps/client/src/pages/sitemap.tsx
+++ b/apps/client/src/pages/sitemap.tsx
@@ -37,26 +37,27 @@ Sitemap.getLayout = (page: ReactElement) => page;
 export const getServerSideProps: GetServerSideProps = async ({ res, locales = [] }) => {
   const availableLocales = locales.filter((ln) => ln !== "default");
 
-  // Fetch URLs for each locale in parallel
-  const urlPromises = availableLocales.map(async (loc) => {
-    const dispositifs = await API.getDispositifs({ type: ContentType.DISPOSITIF, locale: loc });
-    const demarches = await API.getDispositifs({ type: ContentType.DEMARCHE, locale: loc });
-    const localeUrls: string[] = [];
+  // Fetch URLs for each locale sequentially to avoid backend overload
+  // Previously used Promise.all which fired 16 requests (8 locales × 2 types) simultaneously
+  const allUrls: string[] = [];
+  for (const loc of availableLocales) {
+    // Process dispositifs and demarches for this locale (2 concurrent requests max)
+    const [dispositifs, demarches] = await Promise.all([
+      API.getDispositifs({ type: ContentType.DISPOSITIF, locale: loc }),
+      API.getDispositifs({ type: ContentType.DEMARCHE, locale: loc }),
+    ]);
+
     dispositifs.forEach((d) => {
-      localeUrls.push(
+      allUrls.push(
         `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/dispositif/[id]", loc).replace("[id]", d._id.toString())}`,
       );
     });
     demarches.forEach((d) => {
-      localeUrls.push(
+      allUrls.push(
         `${process.env.NEXT_PUBLIC_REACT_APP_SITE_URL}/${loc}${getPath("/demarche/[id]", loc).replace("[id]", d._id.toString())}`,
       );
     });
-    return localeUrls;
-  });
-
-  const allUrlsArrays = await Promise.all(urlPromises);
-  const allUrls = allUrlsArrays.flat();
+  }
 
   // Set cache headers - cache for 1 day, revalidate after 1 hour
   res?.setHeader("Cache-Control", "public, s-maxage=3600, stale-while-revalidate=86400");


### PR DESCRIPTION
## Summary

Change from Promise.all (16 concurrent requests) to sequential for...of loop (2 concurrent requests per locale) to prevent backend overload during cold starts.

## Problem

The sitemap page was firing 8 locales × 2 content types = 16 simultaneous API requests via Promise.all, causing:
- Cache stampedes on cold starts
- 503 errors when backend instances were initializing
- Backend overload during peak traffic

## Solution

Serialize locale processing so only 2 requests (dispositifs + demarches) are in flight per locale at any time. This reduces instantaneous load from 16 to 2 concurrent requests.

## Changes

- Modified apps/client/src/pages/sitemap.tsx to use for...of loop instead of Promise.all
- Added explanatory comments about the serialization strategy

## Testing

- [ ] Verify sitemap page loads correctly
- [ ] Check that all locale URLs are still generated
- [ ] Monitor backend logs for reduced 503 errors during cold starts

## Related

- Follow-up to server startup race condition fix (PR #3608)
- Part of sitemap optimization plan (Phase 1 of 4)