### PR TITLE
fix(mobile): update redux state before persisting favorites

### DIFF
--- a/apps/mobile/src/services/redux/User/user.saga.ts
+++ b/apps/mobile/src/services/redux/User/user.saga.ts
@@ -424,8 +424,10 @@ export function* addUserFavorite(
     logger.info("[addFavorite] saga", action.payload);
     const favorites = yield select(userFavorites);
     const newFavorites = [...(favorites || []), action.payload];
-    yield call(saveItemInAsyncStorage, "FAVORITES", JSON.stringify(newFavorites));
+    // Update Redux state FIRST for immediate UI feedback
     yield put(setUserFavoritesActionCreator(newFavorites));
+    // Then persist to AsyncStorage and sync with API
+    yield call(saveItemInAsyncStorage, "FAVORITES", JSON.stringify(newFavorites));
   } catch (error: unknown) {
     if (error instanceof Error) {
       logger.error("Error while adding favorite", { error: error.message });
@@ -440,8 +442,10 @@ export function* removeUserFavorite(
     logger.info("[removeFavorite] saga", action.payload);
     const favorites = yield select(userFavorites);
     const newFavorites = (favorites || []).filter((f: string) => f !== action.payload);
-    yield call(saveItemInAsyncStorage, "FAVORITES", JSON.stringify(newFavorites));
+    // Update Redux state FIRST for immediate UI feedback
     yield put(setUserFavoritesActionCreator(newFavorites));
+    // Then persist to AsyncStorage and sync with API
+    yield call(saveItemInAsyncStorage, "FAVORITES", JSON.stringify(newFavorites));
   } catch (error: unknown) {
     if (error instanceof Error) {
       logger.error("Error while removing favorite", { error: error.message });
@@ -452,8 +456,10 @@ export function* removeUserFavorite(
 export function* removeUserAllFavorites(): SagaIterator {
   try {
     logger.info("[removeAllFavorites] saga");
-    yield call(saveItemInAsyncStorage, "FAVORITES", JSON.stringify([]));
+    // Update Redux state FIRST for immediate UI feedback
     yield put(setUserFavoritesActionCreator([]));
+    // Then persist to AsyncStorage and sync with API
+    yield call(saveItemInAsyncStorage, "FAVORITES", JSON.stringify([]));
   } catch (error: unknown) {
     if (error instanceof Error) {
       logger.error("Error while removing favorites", { error: error.message });


### PR DESCRIPTION
## Summary
- Reorder operations in `addUserFavorite`, `removeUserFavorite`, and `removeUserAllFavorites` sagas.
- Update Redux state **before** calling `saveItemInAsyncStorage` (and syncing with API).
- Fixes issue where adding/removing favorites doesn't update the UI immediately without an app reload (RI-1072).

## Test plan
- [ ] Add a favorite, verify the UI updates immediately.
- [ ] Remove a favorite, verify the UI updates immediately.
- [ ] Clear all favorites, verify the UI updates immediately.

👾 Generated with [Letta Code](https://letta.com)