### PR TITLE
Restore default empty arrays lost during Zod migration

### DIFF
--- a/migrations/1749000000000_FixZodMigrationIssues.ts
+++ b/migrations/1749000000000_FixZodMigrationIssues.ts
@@ -1,0 +1,58 @@
+import type { MigrationInterface } from "mongo-migrate-ts";
+import type { Db } from "mongodb";
+
+/**
+ * Migration: Fix sessions format for Zod schema compatibility
+ *
+ * Converts metadatas.sessions from array format to SessionsMetadata object:
+ *   sessions: [] → sessions: { items: [] }
+ *
+ * This fixes the 422 error on autosave when editing drafts.
+ * The previous migration (MigrateSessionsToObject) only covered dispositifs,
+ * this one also covers dispositifs_draft.
+ */
+export class FixZodMigrationIssues1749000000000 implements MigrationInterface {
+  public async up(db: Db): Promise<void | never> {
+    console.log("[FixSessionsFormat] Starting migration...");
+
+    // Fix sessions in dispositifs_draft
+    const draftsResult = await db
+      .collection("dispositifs_draft")
+      .updateMany(
+        { "metadatas.sessions": { $type: "array" } },
+        { $set: { "metadatas.sessions": { items: [] } } },
+      );
+    console.log(`[FixSessionsFormat] Fixed ${draftsResult.modifiedCount} dispositifs_draft`);
+
+    // Fix sessions in dispositifs (in case previous migration missed some)
+    const dispositifsResult = await db
+      .collection("dispositifs")
+      .updateMany(
+        { "metadatas.sessions": { $type: "array" } },
+        { $set: { "metadatas.sessions": { items: [] } } },
+      );
+    console.log(`[FixSessionsFormat] Fixed ${dispositifsResult.modifiedCount} dispositifs`);
+
+    console.log("[FixSessionsFormat] Migration completed!");
+  }
+
+  public async down(db: Db): Promise<void | never> {
+    console.log("[FixSessionsFormat] Rolling back...");
+
+    await db
+      .collection("dispositifs")
+      .updateMany(
+        { "metadatas.sessions.items": { $exists: true, $size: 0 } },
+        { $set: { "metadatas.sessions": [] } },
+      );
+
+    await db
+      .collection("dispositifs_draft")
+      .updateMany(
+        { "metadatas.sessions.items": { $exists: true, $size: 0 } },
+        { $set: { "metadatas.sessions": [] } },
+      );
+
+    console.log("[FixSessionsFormat] Rollback completed!");
+  }
+}

--- a/packages/mongo/src/schemas/Dispositif.ts
+++ b/packages/mongo/src/schemas/Dispositif.ts
@@ -207,14 +207,14 @@ export const DispositifZodSchema = z.object({
 
   mainSponsor: zId("Structure").optional(),
   theme: zId("Theme").optional(),
-  secondaryThemes: z.array(zId("Theme")).optional(),
-  needs: z.array(zId("Need")).optional(),
+  secondaryThemes: z.array(zId("Theme")).default([]),
+  needs: z.array(zId("Need")).default([]),
   // PATCHED: Union in array not supported, relaxed for Mongoose
-  sponsors: z.array(z.any()).optional(),
+  sponsors: z.array(z.any()).default([]),
   externalLink: z.string().optional(),
 
   creatorId: zId("User"),
-  participants: z.array(zId("User")).optional(),
+  participants: z.array(zId("User")).default([]),
 
   lastAdminUpdate: z.date().optional(),
   lastModificationAuthor: zId("User"),
@@ -241,9 +241,9 @@ export const DispositifZodSchema = z.object({
   // PATCHED: z.record() → Map in Mongoose, relaxed for compatibility
   notificationsSent: z.any().optional(),
 
-  suggestions: z.array(SuggestionZodSchema).optional(),
-  merci: z.array(MerciZodSchema).optional(),
-  avis: z.array(AvisZodSchema).optional(),
+  suggestions: z.array(SuggestionZodSchema).default([]),
+  merci: z.array(MerciZodSchema).default([]),
+  avis: z.array(AvisZodSchema).default([]),
   webOnly: z.boolean().optional(),
 
   // PATCHED: z.record() → Map in Mongoose, relaxed for compatibility


### PR DESCRIPTION
## TL;DR

La migration Typegoose -> Zod (PR #3348, 13 mars) a perdu les `default: []` implicites sur tous les champs tableau du schema Dispositif. Resultat : tout dispositif cree apres le 13 mars sans ces champs a `undefined` au lieu de `[]`, ce qui provoque des `Cannot read properties of undefined` quand le code fait `.length`, `.map()`, etc.

## Root cause

**Avant (Typegoose)** :
```typescript
@prop({ type: () => [Suggestion] })
public suggestions?: Suggestion[];
// -> Mongoose ajoutait automatiquement default: []
```

**Apres (Zod, PR #3348)** :
```typescript
suggestions: z.array(SuggestionZodSchema).optional(),
// -> Pas de default. Si le champ n'est pas fourni -> undefined
```

**Pourquoi ca n'a explose que 12 jours plus tard ?**
Les anciens documents en base ont deja `merci: []`, `suggestions: []` etc. — Mongoose avait mis les defaults a la creation. Seuls les **nouveaux** documents crees apres le 13 mars sont touches. Et il faut qu'ils passent par un chemin de code qui accede sans garde (ex: `getStructureDispositifs`) pour que ca crash.

**Timeline** :
- 19 mars : `participants.map()` dans `getContentById`
- 25 mars : `needs.length` dans `BreadcrumbDetails.tsx`
- 25 mars : `suggestions.length` + `merci.length` dans `getStructureDispositifs` -> **500 en prod**, onglet Structure + Notifications HS

## Le fix

`.optional()` -> `.default([])` sur les 7 champs tableau :

```diff
- secondaryThemes: z.array(zId("Theme")).optional(),
- needs: z.array(zId("Need")).optional(),
- sponsors: z.array(z.any()).optional(),
- participants: z.array(zId("User")).optional(),
- suggestions: z.array(SuggestionZodSchema).optional(),
- merci: z.array(MerciZodSchema).optional(),
- avis: z.array(AvisZodSchema).optional(),
+ secondaryThemes: z.array(zId("Theme")).default([]),
+ needs: z.array(zId("Need")).default([]),
+ sponsors: z.array(z.any()).default([]),
+ participants: z.array(zId("User")).default([]),
+ suggestions: z.array(SuggestionZodSchema).default([]),
+ merci: z.array(MerciZodSchema).default([]),
+ avis: z.array(AvisZodSchema).default([]),
```

**Detail technique** : `@zodyac/zod-mongoose` ne passe pas la valeur `.default()` a Mongoose. En revanche, il traduit `.default([])` en `required: true` (vs `required: false` pour `.optional()`). Et Mongoose initialise automatiquement les arrays a `[]` quand le champ est `required: true`. Verifie empiriquement.

**Limite** : les Mongoose defaults ne s'appliquent qu'a la **creation** de documents. Les anciens documents en base qui ont deja `undefined` ne sont pas corriges a la lecture (surtout via `.lean()`). Les gardes defensifs `(field || [])` ajoutes dans le commit precedent couvrent ce cas.

## Analyse d'impact

Scan complet realise sur la codebase :

| Axe | Resultat | Detail |
|-----|----------|--------|
| Webhooks | **SAFE** | Les champs concernes ne sont pas dans les schemas webhook (sauf `needs`/`secondaryThemes`/`sponsors` qui sont `.optional()`). Mongoose mettra `[]` si absent. Aucune query `$exists` sur ces champs. |
| Backend (formulaires) | **SAFE** | `formContent` vient du body HTTP, pas de Mongoose. Les truthiness checks ne sont pas impactes. |
| Client/Mobile | **SAFE** | ~20 gardes `(field \|\| [])` ou `field?.length` redondants mais inoffensifs. Aucun crash. |

## Update
```
Migration `1749000000000_FixZodMigrationIssues`
```
Après la migration Typegoose → Zod (13-14 mars), le type sessions dans api-types attend SessionsMetadata | null (objet avec items), mais certaines fiches existantes ont encore l'ancien format sessions: [] (array direct). 

Quand l'autosave envoie ces données, TSOA rejette avec 422. 
Cette migration convertit tous les sessions: [] vers sessions: { items: [] } dans dispositifs et dispositifs_draft. Complément de la migration existante MigrateSessionsToObject qui ne couvrait que dispositifs.

J'ai testé le fix en bdd pour Alice à la main sur sa fiche en prod et c'est ok.

J'ai préparé une petite migration pour corriger les éléments problématiques.

## How to test

1. Demarrer le serveur Express local
2. Creer un brouillon de dispositif rattache a une structure
3. Verifier dans MongoDB Compass que le document a bien `suggestions: []`, `merci: []`, `avis: []` (et pas `undefined`)
4. `/backend/user-dash-structure` doit charger sans 500

## Review checklist

- [x] TypeScript compile (6/6 tasks, 0 erreurs)
- [x] Pas d'impact sur les webhooks
- [x] Pas d'impact sur le mobile
- [x] Comportement verifie empiriquement (Mongoose + @zodyac/zod-mongoose)
