### PR TITLE
fix(migration): preserve existing sessions array data during migration

### DIFF
--- a/migrations/1749000000000_FixZodMigrationIssues.ts
+++ b/migrations/1749000000000_FixZodMigrationIssues.ts
@@ -16,22 +16,17 @@ export class FixZodMigrationIssues1749000000000 implements MigrationInterface {
   public async up(db: Db): Promise<void | never> {
     console.log("[FixSessionsFormat] Starting migration...");
 
-    // Fix sessions in dispositifs_draft
+    // Fix sessions in dispositifs_draft and dispositifs
     // Use aggregation pipeline to preserve existing array elements
-    const draftsResult = await db
-      .collection("dispositifs_draft")
-      .updateMany({ "metadatas.sessions": { $type: "array" } }, [
-        { $set: { "metadatas.sessions": { items: "$metadatas.sessions" } } },
-      ]);
-    console.log(`[FixSessionsFormat] Fixed ${draftsResult.modifiedCount} dispositifs_draft`);
-
-    // Fix sessions in dispositifs (in case previous migration missed some)
-    const dispositifsResult = await db
-      .collection("dispositifs")
-      .updateMany({ "metadatas.sessions": { $type: "array" } }, [
-        { $set: { "metadatas.sessions": { items: "$metadatas.sessions" } } },
-      ]);
-    console.log(`[FixSessionsFormat] Fixed ${dispositifsResult.modifiedCount} dispositifs`);
+    const collectionsToMigrate = ["dispositifs_draft", "dispositifs"];
+    for (const collectionName of collectionsToMigrate) {
+      const result = await db
+        .collection(collectionName)
+        .updateMany({ "metadatas.sessions": { $type: "array" } }, [
+          { $set: { "metadatas.sessions": { items: "$metadatas.sessions" } } },
+        ]);
+      console.log(`[FixSessionsFormat] Fixed ${result.modifiedCount} ${collectionName}`);
+    }
 
     console.log("[FixSessionsFormat] Migration completed!");
   }
@@ -39,23 +34,17 @@ export class FixZodMigrationIssues1749000000000 implements MigrationInterface {
   public async down(db: Db): Promise<void | never> {
     console.log("[FixSessionsFormat] Rolling back...");
 
-    // Rollback dispositifs - only for empty items arrays
-    const dispositifsResult = await db
-      .collection("dispositifs")
-      .updateMany(
-        { "metadatas.sessions.items": { $exists: true, $size: 0 } },
-        { $set: { "metadatas.sessions": [] } },
-      );
-    console.log(`[FixSessionsFormat] Rolled back ${dispositifsResult.modifiedCount} dispositifs`);
-
-    // Rollback dispositifs_draft - only for empty items arrays
-    const draftsResult = await db
-      .collection("dispositifs_draft")
-      .updateMany(
-        { "metadatas.sessions.items": { $exists: true, $size: 0 } },
-        { $set: { "metadatas.sessions": [] } },
-      );
-    console.log(`[FixSessionsFormat] Rolled back ${draftsResult.modifiedCount} dispositifs_draft`);
+    // Rollback: convert sessions object back to array format
+    // Use aggregation pipeline to be symmetric with up migration
+    const collectionsToRollback = ["dispositifs", "dispositifs_draft"];
+    for (const collectionName of collectionsToRollback) {
+      const result = await db
+        .collection(collectionName)
+        .updateMany({ "metadatas.sessions.items": { $exists: true, $type: "array" } }, [
+          { $set: { "metadatas.sessions": "$metadatas.sessions.items" } },
+        ]);
+      console.log(`[FixSessionsFormat] Rolled back ${result.modifiedCount} ${collectionName}`);
+    }
 
     console.log("[FixSessionsFormat] Rollback completed!");
   }

--- a/migrations/1749000000000_FixZodMigrationIssues.ts
+++ b/migrations/1749000000000_FixZodMigrationIssues.ts
@@ -6,6 +6,7 @@ import type { Db } from "mongodb";
  *
  * Converts metadatas.sessions from array format to SessionsMetadata object:
  *   sessions: [] → sessions: { items: [] }
+ *   sessions: [a, b] → sessions: { items: [a, b] }
  *
  * This fixes the 422 error on autosave when editing drafts.
  * The previous migration (MigrateSessionsToObject) only covered dispositifs,
@@ -16,21 +17,20 @@ export class FixZodMigrationIssues1749000000000 implements MigrationInterface {
     console.log("[FixSessionsFormat] Starting migration...");
 
     // Fix sessions in dispositifs_draft
+    // Use aggregation pipeline to preserve existing array elements
     const draftsResult = await db
       .collection("dispositifs_draft")
-      .updateMany(
-        { "metadatas.sessions": { $type: "array" } },
-        { $set: { "metadatas.sessions": { items: [] } } },
-      );
+      .updateMany({ "metadatas.sessions": { $type: "array" } }, [
+        { $set: { "metadatas.sessions": { items: "$metadatas.sessions" } } },
+      ]);
     console.log(`[FixSessionsFormat] Fixed ${draftsResult.modifiedCount} dispositifs_draft`);
 
     // Fix sessions in dispositifs (in case previous migration missed some)
     const dispositifsResult = await db
       .collection("dispositifs")
-      .updateMany(
-        { "metadatas.sessions": { $type: "array" } },
-        { $set: { "metadatas.sessions": { items: [] } } },
-      );
+      .updateMany({ "metadatas.sessions": { $type: "array" } }, [
+        { $set: { "metadatas.sessions": { items: "$metadatas.sessions" } } },
+      ]);
     console.log(`[FixSessionsFormat] Fixed ${dispositifsResult.modifiedCount} dispositifs`);
 
     console.log("[FixSessionsFormat] Migration completed!");
@@ -39,19 +39,23 @@ export class FixZodMigrationIssues1749000000000 implements MigrationInterface {
   public async down(db: Db): Promise<void | never> {
     console.log("[FixSessionsFormat] Rolling back...");
 
-    await db
+    // Rollback dispositifs - only for empty items arrays
+    const dispositifsResult = await db
       .collection("dispositifs")
       .updateMany(
         { "metadatas.sessions.items": { $exists: true, $size: 0 } },
         { $set: { "metadatas.sessions": [] } },
       );
+    console.log(`[FixSessionsFormat] Rolled back ${dispositifsResult.modifiedCount} dispositifs`);
 
-    await db
+    // Rollback dispositifs_draft - only for empty items arrays
+    const draftsResult = await db
       .collection("dispositifs_draft")
       .updateMany(
         { "metadatas.sessions.items": { $exists: true, $size: 0 } },
         { $set: { "metadatas.sessions": [] } },
       );
+    console.log(`[FixSessionsFormat] Rolled back ${draftsResult.modifiedCount} dispositifs_draft`);
 
     console.log("[FixSessionsFormat] Rollback completed!");
   }


### PR DESCRIPTION
## Summary
- Fix critical data loss issue in migration: use aggregation pipeline to preserve existing `sessions` array elements instead of replacing with empty arrays
- Add logging to `down` migration for `modifiedCount` (consistency with `up` migration)
- Update JSDoc to clarify that non-empty arrays are preserved

## Review Comments Addressed
Addresses Gemini Code Assist review comments on PR #3639:
- **Critical**: Filter `{ "metadatas.sessions": { $type: "array" } }` was too broad and would discard any existing array elements
- **Medium**: `down` migration was missing logging for `modifiedCount`

## Changes
```diff
- { $set: { "metadatas.sessions": { items: [] } } }
+ [{ $set: { "metadatas.sessions": { items: "$metadatas.sessions" } } }]
```

The aggregation pipeline uses `"$metadatas.sessions"` to reference the existing array value, preserving it as `items` in the new object structure.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm check:types` passes
- [ ] Verify migration works correctly on staging (after merge to dev and staging release)

👾 Generated with [Letta Code](https://letta.com)