### PR TITLE
fix(server): increase Node.js heap size to prevent OOM crashes

### DIFF
--- a/apps/server/cloudbuild.yaml
+++ b/apps/server/cloudbuild.yaml
@@ -39,6 +39,7 @@ steps:
           --service-account ${_SA} \
           --set-env-vars MINIMUM_APP_VERSION=${_MINIMUM_APP_VERSION} \
           --set-env-vars NODE_ENV=${_NODE_ENV} \
+          --set-env-vars NODE_OPTIONS="--max-old-space-size=1536" \
           --set-secrets accountSid=accountSid:latest \
           --set-secrets AIRTABLE_BASE_CONTENU=${_AIRTABLE_BASE_CONTENU_VAR}:latest \
           --set-secrets AIRTABLE_BASE_TRAD=${_AIRTABLE_BASE_TRAD_VAR}:latest \

--- a/apps/server/cloudbuild.yaml
+++ b/apps/server/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
           --service-account ${_SA} \
           --set-env-vars MINIMUM_APP_VERSION=${_MINIMUM_APP_VERSION} \
           --set-env-vars NODE_ENV=${_NODE_ENV} \
-          --set-env-vars NODE_OPTIONS="--max-old-space-size=1536" \
+          --set-env-vars NODE_OPTIONS="--max-old-space-size=3584" \
           --set-secrets accountSid=accountSid:latest \
           --set-secrets AIRTABLE_BASE_CONTENU=${_AIRTABLE_BASE_CONTENU_VAR}:latest \
           --set-secrets AIRTABLE_BASE_TRAD=${_AIRTABLE_BASE_TRAD_VAR}:latest \

--- a/apps/server/cloudbuild.yaml
+++ b/apps/server/cloudbuild.yaml
@@ -39,7 +39,7 @@ steps:
           --service-account ${_SA} \
           --set-env-vars MINIMUM_APP_VERSION=${_MINIMUM_APP_VERSION} \
           --set-env-vars NODE_ENV=${_NODE_ENV} \
-          --set-env-vars NODE_OPTIONS="--max-old-space-size=3584" \
+          --set-env-vars NODE_OPTIONS="--max-old-space-size=${_NODE_HEAP_SIZE}" \
           --set-secrets accountSid=accountSid:latest \
           --set-secrets AIRTABLE_BASE_CONTENU=${_AIRTABLE_BASE_CONTENU_VAR}:latest \
           --set-secrets AIRTABLE_BASE_TRAD=${_AIRTABLE_BASE_TRAD_VAR}:latest \


### PR DESCRIPTION
## Summary

Fixes 500 errors on `/appuser/notification_settings` and other endpoints caused by JavaScript heap out of memory crashes.

## Root Cause

Production Cloud Run containers have **2GB memory**, but Node.js defaults to a **~1.4GB heap limit**. Under load with speedgoose caching and multiple concurrent requests, the process hits this limit and crashes with:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

## Fix

Add `NODE_OPTIONS="--max-old-space-size=1536"` to the Cloud Run deployment configuration, increasing the heap limit to ~1.5GB (leaving ~500MB for other overhead).

## Changes

- `apps/server/cloudbuild.yaml`: Add `--set-env-vars NODE_OPTIONS="--max-old-space-size=1536"`

## Testing

This change will apply to the next deployment. Monitor Cloud Run logs for:
- Reduced "Allocation failed" errors
- Lower 500 error rates on all endpoints

## Related

- Fixes 500 errors on `/appuser/notification_settings` (reported today)
- Related to speedgoose caching memory usage (added in commit b2eb21196)

👾 Generated with [Letta Code](https://letta.com)