### PR TITLE
fix(client): update live chat availability from 2 to 4 days per week

### DIFF
--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -1229,7 +1229,7 @@ exports[`publier renders publier 1`] = `
                   <p
                     class="mb-0"
                   >
-                    Le live chat est accessible en bas à droite de votre écran (deux jours par semaine). Posez toutes vos questions : nous sommes réactifs et c’est un vrai humain qui traite vos demandes !
+                    Le live chat est accessible en bas à droite de votre écran (quatre jours par semaine). Posez toutes vos questions : nous sommes réactifs et c’est un vrai humain qui traite vos demandes !
                   </p>
                 </div>
               </div>

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -775,7 +775,7 @@ exports[`traduire renders traduire 1`] = `
                   class="[&_p]:text-large"
                 >
                   <p>
-                    Le live chat est accessible en bas à droite de votre écran (deux jours par semaine). Posez toutes vos questions : nous sommes réactifs et c’est un vrai humain qui traite vos demandes !
+                    Le live chat est accessible en bas à droite de votre écran (quatre jours par semaine). Posez toutes vos questions : nous sommes réactifs et c’est un vrai humain qui traite vos demandes !
                   </p>
                 </div>
               </div>

--- a/apps/client/src/pages/publier.tsx
+++ b/apps/client/src/pages/publier.tsx
@@ -372,7 +372,7 @@ const RecensezVotreAction = (props: Props) => {
                 onClick={() => window.$crisp.push(["do", "chat:open"])}
               >
                 <p className="mb-0">
-                  Le live chat est accessible en bas à droite de votre écran (deux jours par
+                  Le live chat est accessible en bas à droite de votre écran (quatre jours par
                   semaine). Posez toutes vos questions : nous sommes réactifs et c’est un vrai
                   humain qui traite vos demandes !
                 </p>
@@ -409,7 +409,7 @@ const RecensezVotreAction = (props: Props) => {
                   },
                   {
                     title: "Je ne suis pas à l'aise avec le numérique, est-ce facile ?",
-                    text: "Nous avons conçu cet outil avec des utilisateurs afin d’assurer l’expérience la plus fluide et intuitive possible. Des tutoriels sont là pour vous guider tout au long de l’expérience. Et si vous avez une question ou une remarque, n'hésitez pas à nous contacter directement via le live chat en bas à droite de l'écran (disponible 2 jours par semaine). Nous nous ferons une joie de vous aider !",
+                    text: "Nous avons conçu cet outil avec des utilisateurs afin d’assurer l’expérience la plus fluide et intuitive possible. Des tutoriels sont là pour vous guider tout au long de l’expérience. Et si vous avez une question ou une remarque, n'hésitez pas à nous contacter directement via le live chat en bas à droite de l'écran (disponible 4 jours par semaine). Nous nous ferons une joie de vous aider !",
                   },
                   {
                     title: "En combien de temps ma fiche sera publiée ?",

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -284,7 +284,7 @@ const RecensezVotreAction = (props: Props) => {
                 onClick={() => window.$crisp.push(["do", "chat:open"])}
               >
                 <p>
-                  Le live chat est accessible en bas à droite de votre écran (deux jours par
+                  Le live chat est accessible en bas à droite de votre écran (quatre jours par
                   semaine). Posez toutes vos questions : nous sommes réactifs et c’est un vrai
                   humain qui traite vos demandes !
                 </p>


### PR DESCRIPTION
## Summary
- Update live chat availability message from "2 jours par semaine" to "4 jours par semaine" on /publier and /traduire pages

## Changes
- `apps/client/src/pages/traduire.tsx`: "deux jours par semaine" → "quatre jours par semaine"
- `apps/client/src/pages/publier.tsx`: "deux jours par semaine" → "quatre jours par semaine" (line 375)
- `apps/client/src/pages/publier.tsx`: "2 jours par semaine" → "4 jours par semaine" (line 412)

## Test plan
- [ ] Verify text displays correctly on /publier page
- [ ] Verify text displays correctly on /traduire page

Refs: RI-1162