### PR TITLE
fix(client): filter online resources by metadatas.location instead of typeContenu

### DIFF
--- a/apps/client/src/__fixtures__/seed-data/dispositifs.ts
+++ b/apps/client/src/__fixtures__/seed-data/dispositifs.ts
@@ -131,7 +131,7 @@ export const seedDispositifs = async (conn: Connection) => {
         },
       },
       status: "Actif",
-      typeContenu: "online",
+      typeContenu: "dispositif",
     },
     {
       theme: TA,
@@ -232,7 +232,7 @@ export const seedDispositifs = async (conn: Connection) => {
           fr: { title: `Formation ${i + 6}`, abstract: `Description de la formation ${i + 6}` },
         },
         status: "Actif",
-        typeContenu: i % 3 === 0 ? "dispositif" : i % 3 === 1 ? "demarche" : "online",
+        typeContenu: i % 3 === 0 ? "dispositif" : "demarche",
       };
     }),
     // Inactive entry should be filtered out globally

--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -586,6 +586,9 @@ export const computeSearchResults = async (
   const algoliaIds = await resolveAlgoliaIds(queryParams.search);
   const baseMatch = buildBaseMatch(queryParams, algoliaIds);
 
+  // Keep a clean copy for count calculations (before type filter is applied)
+  const baseMatchForCounts = { ...baseMatch };
+
   if (options.type && options.type !== "all") {
     if (options.type === "ressource") {
       baseMatch["metadatas.location"] = "online";
@@ -601,7 +604,7 @@ export const computeSearchResults = async (
     executeCachedQuery<number>(Dispositif.countDocuments(baseMatch)),
     executeCachedPipeline(
       Dispositif.aggregate([
-        { $match: baseMatch },
+        { $match: baseMatchForCounts },
         { $group: { _id: "$typeContenu", count: { $sum: 1 } } },
       ]),
     ),
@@ -610,6 +613,15 @@ export const computeSearchResults = async (
 
   const getCount = (type: string) =>
     typeCounts.find((t: { _id: string; count: number }) => t._id === type)?.count || 0;
+
+  // Count online resources by metadatas.location (not typeContenu)
+  const onlineCountResult = await executeCachedPipeline<{ count: number }>(
+    Dispositif.aggregate([
+      { $match: { ...baseMatchForCounts, "metadatas.location": "online" } },
+      { $count: "count" },
+    ]),
+  );
+  const onlineCount = onlineCountResult[0]?.count || 0;
 
   // When no results, provide top démarches as fallback
   const noResults =
@@ -622,7 +634,7 @@ export const computeSearchResults = async (
     total,
     programCount: getCount("dispositif"),
     procedureCount: getCount("demarche"),
-    onlineCount: getCount("online"),
+    onlineCount,
     page: options.page,
     pageCount: Math.ceil(total / options.limit),
   };

--- a/apps/client/src/lib/search-helpers.ts
+++ b/apps/client/src/lib/search-helpers.ts
@@ -587,7 +587,11 @@ export const computeSearchResults = async (
   const baseMatch = buildBaseMatch(queryParams, algoliaIds);
 
   if (options.type && options.type !== "all") {
-    baseMatch.typeContenu = options.type;
+    if (options.type === "ressource") {
+      baseMatch["metadatas.location"] = "online";
+    } else {
+      baseMatch.typeContenu = options.type;
+    }
   }
 
   const aggregation = buildSearchAggregation(baseMatch, options);

--- a/apps/client/src/pages/api/search/counts.ts
+++ b/apps/client/src/pages/api/search/counts.ts
@@ -340,6 +340,13 @@ export const computeSearchCounts = async (
   ];
   (facet as any).total = [{ $match: baseMatch }, { $count: "count" }];
 
+  // Count online resources by metadatas.location (not typeContenu)
+  // Production data has typeContenu: "dispositif" or "demarche" with metadatas.location: "online"
+  (facet as any).online = [
+    { $match: { ...baseMatch, "metadatas.location": "online" } },
+    { $count: "count" },
+  ];
+
   const results = await executeCachedPipeline(Dispositif.aggregate([{ $facet: facet }]));
   const data = results[0] || {};
 
@@ -365,7 +372,7 @@ export const computeSearchCounts = async (
     types: {
       dispositif: data.types?.find((t: any) => t._id === "dispositif")?.count || 0,
       demarche: data.types?.find((t: any) => t._id === "demarche")?.count || 0,
-      online: data.types?.find((t: any) => t._id === "online")?.count || 0,
+      online: data.online?.[0]?.count || 0,
     },
     total: data.total?.[0]?.count || 0,
   };


### PR DESCRIPTION
## Summary
- Fixed "Ressources en ligne" filter returning no results
- Backend now correctly filters by `metadatas.location: "online"` instead of non-existent `typeContenu: "online"`
- Fixed test data to match production schema

## Root Cause
Production data has:
- `typeContenu: "dispositif"` or `"demarche"` (never `"online"`)
- `metadatas.location: "online"` identifies online resources

The old code incorrectly looked for `typeContenu === "online"` which never exists.

## Test plan
- [ ] Manual test: navigate to /recherche and click "Ressources en ligne" tab
- [ ] Verify online resources are displayed
- [ ] Verify counts match displayed results

Fixes RI-1161

👾 Generated with [Letta Code](https://letta.com)