### PR TITLE
fix(ci): skip EAS fingerprint computation to workaround brace_expansion bug

### DIFF
--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -236,6 +236,8 @@ jobs:
     if: needs.detect-changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'staging' && 'staging-mobile' || 'master-mobile' }}
+    env:
+      EAS_SKIP_AUTO_FINGERPRINT: "1"
     steps:
       - name: Check for EXPO_TOKEN
         run: |


### PR DESCRIPTION
## Summary

- Adds `EAS_SKIP_AUTO_FINGERPRINT: "1"` environment variable to the `deploy-mobile` job
- Workaround for EAS CLI bug: `(0 , brace_expansion_1.default) is not a function`

## Context

The mobile build workflow failed with:

```
✖ Failed to compute project fingerprint
(0 , brace_expansion_1.default) is not a function
```

This is a known bug in EAS CLI's fingerprint computation. The error message itself suggests the workaround: `⏩ To skip this step, set the environment variable: EAS_SKIP_AUTO_FINGERPRINT=1`

## Test plan

- [ ] Merge to `dev`
- [ ] Merge `dev` → `staging` 
- [ ] Verify mobile build succeeds in the release pipeline

👾 Generated with [Letta Code](https://letta.com)