### PR TITLE
fix(mobile): convert app.config.js to pure CommonJS

### DIFF
--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -3,8 +3,8 @@
 
 const pkg = require("./package.json");
 
-import { withAppBuildGradle, withGradleProperties } from "expo/config-plugins";
-import deepLinks from "./androidDeepLinks";
+const { withAppBuildGradle, withGradleProperties } = require("expo/config-plugins");
+const deepLinks = require("./androidDeepLinks");
 
 const APP_VERSION = pkg.version;
 
@@ -59,7 +59,7 @@ const withDisableStrictLinting = (config) => {
   });
 };
 
-export default {
+module.exports = {
   name: "Réfugiés.info",
   owner: "refugies-info",
   slug: "refugies-info-app",


### PR DESCRIPTION
## Summary
- Convert `app.config.js` from mixed ESM/CommonJS to pure CommonJS
- Fixes the `brace_expansion` ESM interop bug in EAS CLI 18.x that causes iOS builds to fail

## Problem
EAS CLI 18.x has a bug with ESM/CommonJS interop that causes:
```
(0 , brace_expansion_1.default) is not a function
```
during iOS build config introspection. The `EAS_SKIP_AUTO_FINGERPRINT: 1` workaround (#3656) only helped Android.

## Solution
Convert the config file to pure CommonJS:
- `import { ... } from "expo/config-plugins"` → `const { ... } = require(...)`
- `import deepLinks from "./androidDeepLinks"` → `const deepLinks = require(...)`
- `export default {` → `module.exports = {`

## Test plan
- [ ] Verify the config parses correctly with `node -e "require('./app.config.js')"`
- [ ] Merge to dev and trigger staging release pipeline
- [ ] Verify iOS build succeeds on EAS

Related: #3656

👾 Generated with [Letta Code](https://letta.com)