### PR TITLE
fix(mobile): use fs.readFileSync for package.json to avoid brace_expansion error

### DIFF
--- a/apps/mobile/androidDeepLinks.js
+++ b/apps/mobile/androidDeepLinks.js
@@ -19,34 +19,21 @@ const deepLinks = [
     host: "refugies.info",
     path: "/",
   },
-  ...urlTranslations.map(
-    (
-      url, // https://refugies.info/dispositif/
-    ) => ({
-      scheme: "https",
-      host: "refugies.info",
-      pathPattern: url[0],
-    }),
-  ),
-  ...urlTranslations.map(
-    (
-      url, // https://refugies.info/fr/dispositif/
-    ) => ({
-      scheme: "https",
-      host: "refugies.info",
-      pathPattern: "/.*" + url[0],
-    }),
-  ),
-  ...urlTranslations.map(
-    (
-      url, // https://refugies.info/en/program/
-    ) => ({
-      scheme: "https",
-      host: "refugies.info",
-      pathPattern: "/.*" + url[1],
-    }),
-  ),
+  ...urlTranslations.map((url) => ({
+    scheme: "https",
+    host: "refugies.info",
+    pathPattern: url[0],
+  })),
+  ...urlTranslations.map((url) => ({
+    scheme: "https",
+    host: "refugies.info",
+    pathPattern: "/.*" + url[0],
+  })),
+  ...urlTranslations.map((url) => ({
+    scheme: "https",
+    host: "refugies.info",
+    pathPattern: "/.*" + url[1],
+  })),
 ];
 
-// eslint-disable-next-line no-undef
 module.exports = deepLinks;

--- a/apps/mobile/app.config.js
+++ b/apps/mobile/app.config.js
@@ -1,10 +1,15 @@
 /* eslint-disable no-undef */
 /* eslint-env node */
 
-const pkg = require("./package.json");
+const fs = require("fs");
+const path = require("path");
 
 const { withAppBuildGradle, withGradleProperties } = require("expo/config-plugins");
 const deepLinks = require("./androidDeepLinks");
+
+// Use fs.readFileSync instead of require() to avoid module resolution issues
+const pkgPath = path.join(__dirname, "package.json");
+const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
 
 const APP_VERSION = pkg.version;
 


### PR DESCRIPTION
## Summary
- Replace `require("./package.json")` with `fs.readFileSync` + `JSON.parse` to avoid the brace_expansion module resolution error during EAS CLI config introspection

## Problem
iOS builds were failing with:
```
(0 , brace_expansion_1.default) is not a function
    Error: build command failed.
```

The `require("./package.json")` pattern was triggering a module resolution chain that involved the `brace_expansion` package, which has issues with how TypeScript transpiles certain imports.

## Solution
Using `fs.readFileSync` to read package.json directly avoids the problematic module resolution chain entirely.

## Test plan
- [ ] Verify `npx expo config --json --type introspect` works without errors
- [ ] Push to staging and verify iOS build succeeds

👾 Generated with [Letta Code](https://letta.com)