### PR TITLE
fix(workspace): narrow brace-expansion override to ^2.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "react-server-dom-webpack": ">=19.0.2",
       "node-forge": ">=1.4.0",
       "handlebars": ">=4.7.9",
-      "brace-expansion": ">=2.0.3",
+      "brace-expansion": "^2.0.3",
       "jsonwebtoken>jws": "^3.2.3",
       "google-auth-library>jws": "^4.0.1",
       "gtoken>jws": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,7 @@ overrides:
   react-server-dom-webpack: '>=19.0.2'
   node-forge: '>=1.4.0'
   handlebars: '>=4.7.9'
-  brace-expansion: '>=2.0.3'
+  brace-expansion: ^2.0.3
   jsonwebtoken>jws: ^3.2.3
   google-auth-library>jws: ^4.0.1
   gtoken>jws: ^4.0.1
@@ -5837,12 +5837,11 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@2.0.0:
     resolution: {integrity: sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==}
-
-  balanced-match@4.0.4:
-    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
-    engines: {node: 18 || 20 || >=22}
 
   bare-events@2.6.1:
     resolution: {integrity: sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==}
@@ -5907,9 +5906,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.0.3:
+    resolution: {integrity: sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -17931,9 +17929,9 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@2.0.0: {}
+  balanced-match@1.0.2: {}
 
-  balanced-match@4.0.4: {}
+  balanced-match@2.0.0: {}
 
   bare-events@2.6.1:
     optional: true
@@ -18008,9 +18006,9 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@5.0.5:
+  brace-expansion@2.0.3:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -22293,7 +22291,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 2.0.3
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
- The `>=2.0.3` pnpm override for `brace-expansion` (added in #3657 for Dependabot alert) resolved to **v5.0.5**, which has a different CJS export shape
- This broke EAS CLI's bundled `@expo/config` fallback path during iOS mobile builds: `(0 , brace_expansion_1.default) is not a function`
- Changed override to `^2.0.3` which resolves to **v2.0.3** — still fixes the Dependabot DoS alert while staying in the v2.x range that EAS CLI expects

## Root cause analysis
1. `>=2.0.3` override → pnpm resolves to latest compatible = `5.0.5`
2. `brace-expansion@5.x` has different CommonJS exports than `1.x`/`2.x`
3. EAS CLI's compiled TypeScript calls `brace_expansion_1.default()` which doesn't exist in v5
4. First hits during fingerprint computation (worked around with `EAS_SKIP_AUTO_FINGERPRINT=1`)
5. Then hits again in iOS config reading fallback path → fatal

## Test plan
- [ ] Merge to dev, then create staging release PR
- [ ] Verify "Build Mobile" step passes in the release pipeline
- [ ] Production PR #3654 should then also pass

🐾 Generated with [Letta Code](https://letta.com)