### PR TITLE
feat(skill): add investigating-server-errors skill for 5xx error debugging

### DIFF
--- a/.skills/investigating-server-errors/SKILL.md
+++ b/.skills/investigating-server-errors/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: investigating-server-errors
+description: Investigates HTTP 5xx errors in Node.js backends on GCP Cloud Run. Use when users report server errors, need post-deployment verification, or ask to check production health. Triggers on "500 errors", "server errors", "investigate errors", "check logs", or post-deployment checks.
+---
+
+# Investigating Server Errors
+
+Systematic workflow for tracing HTTP 5xx errors to root cause in Node.js/Express backends deployed on GCP Cloud Run.
+
+## When to Use
+
+- User reports seeing 500/502/503/504 errors
+- Post-deployment verification (proactive check)
+- Sentry alerts or error monitoring notifications
+- User shares error screenshots or log snippets
+
+## Investigation Workflow
+
+### Step 1: Identify the Endpoint
+
+Extract from user's report:
+- **HTTP method**: GET, POST, PUT, DELETE
+- **Path**: `/api/resource/endpoint`
+- **Status code**: 500, 502, 503, or 504
+- **Timing**: When did errors start? Recent deployment?
+
+### Step 2: Find Code Path
+
+Locate the controller and trace downstream:
+
+```bash
+# Find route definition (tsoa decorators)
+grep -rn "@Route\|@Get\|@Post\|@Put\|@Delete" apps/server/src/controllers/ | grep "endpoint-name"
+
+# Trace to service/repository
+grep -rn "functionName" apps/server/src/workflows/ apps/server/src/modules/
+```
+
+Common patterns:
+- `apps/server/src/controllers/*Controller.ts` - Route definitions
+- `apps/server/src/workflows/*/` - Business logic
+- `apps/server/src/modules/*/` - Repository/database layer
+
+### Step 3: Check Deployment Status
+
+Determine if a fix might already be deployed:
+
+```bash
+# Check latest production commit
+git log --oneline production | head -5
+
+# Check if fix commit is in production
+git merge-base --is-ancestor <fix-commit> production && echo "Fix deployed" || echo "Fix NOT deployed"
+
+# See commits in staging but not production
+git log --oneline production..staging | head -20
+
+# Show file content at different branches
+git show production:path/to/file.ts
+git show staging:path/to/file.ts
+git show dev:path/to/file.ts
+```
+
+### Step 4: Query Cloud Run Logs
+
+Check for errors since deployment or specific timeframe:
+
+```bash
+# 5xx errors on specific endpoint since deployment
+gcloud logging read '
+resource.type="cloud_run_revision"
+resource.labels.service_name="backend-prod"
+resource.labels.location="europe-west1"
+httpRequest.requestUrl=~"endpoint-path"
+httpRequest.status>=500
+timestamp >= "2026-03-29T10:35:00Z"
+' --project=refugies-info --limit=50 --format='json'
+
+# Backend stderr errors (all 5xx)
+gcloud logging read '
+resource.type="cloud_run_revision"
+resource.labels.service_name="backend-prod"
+resource.labels.location="europe-west1"
+logName="projects/refugies-info/logs/run.googleapis.com%2Fstderr"
+severity>=ERROR
+timestamp >= "'$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)'"
+' --project=refugies-info --limit=50 --format='value(timestamp,textPayload)'
+```
+
+Service names:
+- `backend-prod` / `frontend-prod` - Production
+- `backend-stag` / `frontend-stag` - Staging
+
+### Step 5: Analyze Error Patterns
+
+Common 500 error causes in this codebase:
+
+| Pattern | Cause | Fix |
+|---------|-------|-----|
+| `Cannot read property 'X' of undefined` | Missing field in DB document | Add default value fallback |
+| `... is not a function` | Import issue or undefined method | Check imports, add null checks |
+| Spread operator on `undefined` | Optional field not initialized | `const x = value \|\| {}` |
+| MongoDB connection timeout | DB pool exhaustion | Check connection limits, slow queries |
+
+### Step 6: Verify Fix (if deployed)
+
+```bash
+# Check Cloud Run deployment timestamp
+gcloud run services describe backend-prod --region=europe-west1 --project=refugies-info --format='value(metadata.annotations.serving.knative.dev/lastModifier)'
+
+# Query for errors after fix deployment - should return empty if fixed
+gcloud logging read '...' --limit=10
+```
+
+## Quick Reference
+
+See [references/gcp-logging-queries.md](references/gcp-logging-queries.md) for copy-paste log queries.
+
+See [references/common-patterns.md](references/common-patterns.md) for codebase-specific error patterns.

--- a/.skills/investigating-server-errors/SKILL.md
+++ b/.skills/investigating-server-errors/SKILL.md
@@ -67,16 +67,18 @@ Check for errors since deployment or specific timeframe:
 
 ```bash
 # 5xx errors on specific endpoint since deployment
+# Note: Replace TIMESTAMP with actual ISO timestamp (e.g., 2023-10-26T10:35:00Z)
 gcloud logging read '
 resource.type="cloud_run_revision"
 resource.labels.service_name="backend-prod"
 resource.labels.location="europe-west1"
 httpRequest.requestUrl=~"endpoint-path"
 httpRequest.status>=500
-timestamp >= "2026-03-29T10:35:00Z"
+timestamp >= "YYYY-MM-DDTHH:MM:SSZ"
 ' --project=refugies-info --limit=50 --format='json'
 
 # Backend stderr errors (all 5xx)
+# Note: Use GNU date syntax on Linux: date -d '1 hour ago' -u +'%Y-%m-%dT%H:%M:%SZ'
 gcloud logging read '
 resource.type="cloud_run_revision"
 resource.labels.service_name="backend-prod"
@@ -117,3 +119,8 @@ gcloud logging read '...' --limit=10
 See [references/gcp-logging-queries.md](references/gcp-logging-queries.md) for copy-paste log queries.
 
 See [references/common-patterns.md](references/common-patterns.md) for codebase-specific error patterns.
+
+## Platform Notes
+
+- **macOS**: Uses BSD `date` with `-v` flag (e.g., `date -u -v-1H`)
+- **Linux**: Uses GNU `date` with `-d` flag (e.g., `date -d '1 hour ago' -u`)

--- a/.skills/investigating-server-errors/references/common-patterns.md
+++ b/.skills/investigating-server-errors/references/common-patterns.md
@@ -1,0 +1,97 @@
+# Common Error Patterns in Karfur
+
+Codebase-specific error patterns and their solutions.
+
+## Mongoose / MongoDB Patterns
+
+### Undefined Field on Legacy Documents
+
+**Symptom**: `Cannot read property 'X' of undefined` or spread operator fails on optional field
+
+**Example**: AppUser documents created before `notificationsSettings` field existed:
+
+```typescript
+// OLD CODE - fails when notificationsSettings is undefined
+appUser.notificationsSettings = { ...appUser.notificationsSettings, ...payload };
+
+// FIXED CODE - provides default before spread
+const DEFAULT_NOTIFICATIONS_SETTINGS = {
+  global: true,
+  local: true,
+  demarches: true,
+  themes: {},
+};
+const currentSettings = appUser.notificationsSettings || DEFAULT_NOTIFICATIONS_SETTINGS;
+appUser.notificationsSettings = { ...currentSettings, ...payload };
+```
+
+**Fix Pattern**: 
+1. Define constant with defaults
+2. Use `||` fallback before destructuring/spreading
+3. Apply nested merge for sub-objects (e.g., `themes`)
+
+### Field Type Mismatch
+
+**Symptom**: Query returns no results or cast errors
+
+**Example**: `membres.userId` stored as strings in MongoDB, queried as ObjectIds:
+
+```typescript
+// Check actual types in MongoDB
+// Commands like: db.structuresapp.findOne({}, {membres: 1})
+
+// Use string comparison if field stores strings
+structure.membres.filter(m => m.userId === userIdString)
+```
+
+## TSOA / Controller Patterns
+
+### Route Definition Mismatches
+
+Endpoints defined with TSOA decorators:
+
+```typescript
+@Route("appuser")
+export class AppUsersController extends Controller {
+  @Get("/notification_settings")
+  public async notificationSettings(...) { }
+}
+```
+
+To find a controller by endpoint path:
+1. Search `apps/server/src/controllers/` for the base path
+2. Look for `@Get`, `@Post`, etc. with the specific endpoint
+3. Trace to workflow function in `apps/server/src/workflows/`
+
+## Error Response Patterns
+
+### NotFoundError vs Null Returns
+
+- Repository functions return `null` for missing documents
+- Workflow functions throw `NotFoundError("message")` for API responses
+- Controllers don't catch — errors bubble to global handler
+
+## Git / Deployment Patterns
+
+### Checking Fix Status
+
+```bash
+# Is commit in production?
+git merge-base --is-ancestor <commit> production && echo "YES" || echo "NO"
+
+# What commits are in staging but not production?
+git log --oneline production..staging | head -20
+
+# Show file at specific branch
+git show <branch>:path/to/file.ts
+```
+
+### Recent Deployment Commits
+
+```bash
+# Production commits affecting server
+git log --oneline production -- apps/server/src/ | head -20
+
+# Staging commits since production
+git log --oneline production..staging -- apps/server/src/
+```

--- a/.skills/investigating-server-errors/references/gcp-logging-queries.md
+++ b/.skills/investigating-server-errors/references/gcp-logging-queries.md
@@ -6,6 +6,7 @@ Copy-paste queries for common error investigation scenarios.
 
 ```bash
 # Replace "endpoint-path" with actual path (e.g., "notification_settings")
+# Replace "TIMESTAMP" with ISO datetime (e.g., "2023-10-26T10:35:00Z")
 gcloud logging read '
 resource.type="cloud_run_revision"
 resource.labels.service_name="backend-prod"
@@ -34,6 +35,7 @@ timestamp >= "'$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)'"
 
 ```bash
 # Errors with structured jsonPayload
+# Replace "TIMESTAMP" with actual ISO datetime
 gcloud logging read '
 resource.type="cloud_run_revision"
 resource.labels.service_name="backend-prod"
@@ -41,15 +43,17 @@ resource.labels.location="europe-west1"
 logName="projects/refugies-info/logs/run.googleapis.com%2Fstderr"
 severity>=ERROR
 jsonPayload.message=~"error-pattern"
-timestamp >= "2026-03-29T10:00:00Z"
+timestamp >= "TIMESTAMP"
 ' --project=refugies-info --limit=50 --format='json' | jq -r '.[] | "\(.timestamp) | \(.jsonPayload.message)"'
 ```
 
 ## Timestamp Tips
 
-- **Specific time**: `"2026-03-29T10:35:00Z"`
+- **Specific time**: `"2023-10-26T10:35:00Z"`
 - **Last hour (macOS)**: `"'$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)'"`
+- **Last hour (Linux)**: `"'$(date -d '1 hour ago' -u +'%Y-%m-%dT%H:%M:%SZ')'"`
 - **Last 15 minutes (macOS)**: `"'$(date -u -v-15M +%Y-%m-%dT%H:%M:%SZ)'"`
+- **Last 15 minutes (Linux)**: `"'$(date -d '15 minutes ago' -u +'%Y-%m-%dT%H:%M:%SZ')'"`
 
 ## Service Names
 

--- a/.skills/investigating-server-errors/references/gcp-logging-queries.md
+++ b/.skills/investigating-server-errors/references/gcp-logging-queries.md
@@ -1,0 +1,78 @@
+# GCP Logging Queries
+
+Copy-paste queries for common error investigation scenarios.
+
+## Backend 5xx Errors by Endpoint
+
+```bash
+# Replace "endpoint-path" with actual path (e.g., "notification_settings")
+gcloud logging read '
+resource.type="cloud_run_revision"
+resource.labels.service_name="backend-prod"
+resource.labels.location="europe-west1"
+httpRequest.requestUrl=~"ENDPOINT_PATH"
+httpRequest.status>=500
+timestamp >= "TIMESTAMP"
+' --project=refugies-info --limit=50 --format='table(timestamp,httpRequest.status,httpRequest.requestMethod,httpRequest.requestUrl)'
+```
+
+## Stderr Errors (Stack Traces)
+
+```bash
+# All stderr errors in last hour
+gcloud logging read '
+resource.type="cloud_run_revision"
+resource.labels.service_name="backend-prod"
+resource.labels.location="europe-west1"
+logName="projects/refugies-info/logs/run.googleapis.com%2Fstderr"
+severity>=ERROR
+timestamp >= "'$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)'"
+' --project=refugies-info --limit=50 --format='table(timestamp,textPayload)'
+```
+
+## JSON Payload Errors
+
+```bash
+# Errors with structured jsonPayload
+gcloud logging read '
+resource.type="cloud_run_revision"
+resource.labels.service_name="backend-prod"
+resource.labels.location="europe-west1"
+logName="projects/refugies-info/logs/run.googleapis.com%2Fstderr"
+severity>=ERROR
+jsonPayload.message=~"error-pattern"
+timestamp >= "2026-03-29T10:00:00Z"
+' --project=refugies-info --limit=50 --format='json' | jq -r '.[] | "\(.timestamp) | \(.jsonPayload.message)"'
+```
+
+## Timestamp Tips
+
+- **Specific time**: `"2026-03-29T10:35:00Z"`
+- **Last hour (macOS)**: `"'$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ)'"`
+- **Last 15 minutes (macOS)**: `"'$(date -u -v-15M +%Y-%m-%dT%H:%M:%SZ)'"`
+
+## Service Names
+
+| Environment | Backend | Frontend |
+|-------------|---------|----------|
+| Production | `backend-prod` | `frontend-prod` |
+| Staging | `backend-stag` | `frontend-stag` |
+
+Note: Do NOT use `backend-staging` or `frontend-staging` — these are incorrect.
+
+## Cloud Run Deployment Info
+
+```bash
+# Check service deployment timestamp
+gcloud run services describe backend-prod \
+  --region=europe-west1 \
+  --project=refugies-info \
+  --format='value(status.conditions)'
+
+# View recent revisions
+gcloud run revisions list \
+  --service=backend-prod \
+  --region=europe-west1 \
+  --project=refugies-info \
+  --limit=5
+```


### PR DESCRIPTION
## Summary

Add new Letta Code skill to systematically investigate HTTP 5xx errors in Node.js backends on GCP Cloud Run.

The skill includes:
- **SKILL.md**: Complete 6-step investigation workflow
- **gcp-logging-queries.md**: Copy-paste `gcloud logging read` commands
- **common-patterns.md**: Karfur-specific error patterns (Mongoose undefined fields, spread operator failures, etc.)

## Test plan

- [ ] Review skill structure follows Letta Code conventions
- [ ] Verify commands in gcp-logging-queries.md use correct service names (`backend-prod`, not `backend-staging`)
- [ ] Check common-patterns.md references actual karfur patterns

## Context

Created from investigation of 500 errors on `/api/appuser/notification_settings` endpoint (fixed in PR #3617). The skill captures the exact steps that worked:
1. Identify endpoint from user report
2. Trace code path (controller → workflow → repository)
3. Check if fix is already deployed via `git merge-base --is-ancestor`
4. Query Cloud Run logs with proper timestamps
5. Analyze error patterns (undefined spreads, missing fields)
6. Verify fix is live

👾 Generated with [Letta Code](https://letta.com)