### PR TITLE
fix(server): translation avancement 0% and publish failure due to Mongoose Maps

### DIFF
--- a/apps/server/src/modules/traductions/traductions.business.ts
+++ b/apps/server/src/modules/traductions/traductions.business.ts
@@ -3,6 +3,7 @@ import type { TranslationContent } from "@refugies-info/mongo";
 import {
   type Dispositif,
   isDocument,
+  type LeanTraductions,
   type Traductions,
   TraductionsStatus,
   TraductionsType,
@@ -76,7 +77,7 @@ export const getTraductionWordsCount = (traduction: Traductions): number => {
   return countDispositifWords(traduction.translated.content as any);
 };
 
-export const getTraductionUser = (traduction: Traductions): User => {
+export const getTraductionUser = (traduction: Traductions | LeanTraductions): User => {
   if (!traduction.userId || !isDocument(traduction.userId)) {
     throw new MustBePopulatedError("userId");
   }
@@ -126,7 +127,7 @@ export const computeTraductionFinished = (
   return (translationSectionsCounter - notFinished) / dispositifSectionsCounter >= 1;
 };
 
-export const getSectionsTranslated = (traduction: Traductions): string[] => {
+export const getSectionsTranslated = (traduction: Traductions | LeanTraductions): string[] => {
   const translatedSections = keys(traduction.translated);
   const notFinished = [
     ...new Set([...(traduction.toFinish || []), ...(traduction.toReview || [])]),

--- a/apps/server/src/modules/traductions/traductions.repository.ts
+++ b/apps/server/src/modules/traductions/traductions.repository.ts
@@ -15,16 +15,28 @@ import type { DeleteResult } from "~/types/interface";
 export const getTraductionsByLanguage = (
   language: string,
   neededFields: ProjectionType<Traductions>,
-) => TraductionsModel.find({ language }, neededFields);
+): Promise<Traductions[]> =>
+  TraductionsModel.find({ language }, neededFields).lean() as unknown as Promise<Traductions[]>;
 
 export const getTraductionsByLanguageAndDispositif = (
   language: Languages,
   dispositifId: DispositifId,
   neededFields: ProjectionType<Traductions> = {},
-) => TraductionsModel.find({ language, dispositifId }, neededFields).populate("userId");
+): Promise<Traductions[]> =>
+  TraductionsModel.find({ language, dispositifId }, neededFields)
+    .populate("userId")
+    .lean() as unknown as Promise<Traductions[]>;
 
-export const getValidation = (language: Languages, dispositifId: DispositifId, userId: UserId) =>
-  TraductionsModel.findOne({ language, dispositifId, userId });
+export const getValidation = (
+  language: Languages,
+  dispositifId: DispositifId,
+  userId: UserId,
+): Promise<Traductions | null> =>
+  TraductionsModel.findOne({
+    language,
+    dispositifId,
+    userId,
+  }).lean() as unknown as Promise<Traductions | null>;
 
 export const getOtherValidationForDispositif = (
   language: Languages,
@@ -36,7 +48,7 @@ export const getOtherValidationForDispositif = (
     dispositifId,
     userId: { $ne: userId },
     type: TraductionsType.VALIDATION,
-  });
+  }).lean() as unknown as Promise<Traductions | null>;
 
 export const deleteTradsInDB = (
   dispositifId: DispositifId,
@@ -58,7 +70,9 @@ export const findTraductors = (dispositifId: DispositifId, language: Languages) 
   ).lean();
 
 const updateAvancements = async (query: FilterQuery<Traductions>, dispositif: Dispositif) => {
-  const traductions: Traductions[] = await TraductionsModel.find(query);
+  const traductions: Traductions[] = (await TraductionsModel.find(
+    query,
+  ).lean()) as unknown as Traductions[];
   if (traductions.length === 0) {
     return;
   }

--- a/apps/server/src/modules/traductions/traductions.repository.ts
+++ b/apps/server/src/modules/traductions/traductions.repository.ts
@@ -15,28 +15,20 @@ import type { DeleteResult } from "~/types/interface";
 export const getTraductionsByLanguage = (
   language: string,
   neededFields: ProjectionType<Traductions>,
-): Promise<Traductions[]> =>
-  TraductionsModel.find({ language }, neededFields).lean() as unknown as Promise<Traductions[]>;
+) => TraductionsModel.find({ language }, neededFields).lean();
 
 export const getTraductionsByLanguageAndDispositif = (
   language: Languages,
   dispositifId: DispositifId,
   neededFields: ProjectionType<Traductions> = {},
-): Promise<Traductions[]> =>
-  TraductionsModel.find({ language, dispositifId }, neededFields)
-    .populate("userId")
-    .lean() as unknown as Promise<Traductions[]>;
+) => TraductionsModel.find({ language, dispositifId }, neededFields).populate("userId").lean();
 
-export const getValidation = (
-  language: Languages,
-  dispositifId: DispositifId,
-  userId: UserId,
-): Promise<Traductions | null> =>
+export const getValidation = (language: Languages, dispositifId: DispositifId, userId: UserId) =>
   TraductionsModel.findOne({
     language,
     dispositifId,
     userId,
-  }).lean() as unknown as Promise<Traductions | null>;
+  }).lean();
 
 export const getOtherValidationForDispositif = (
   language: Languages,
@@ -48,7 +40,7 @@ export const getOtherValidationForDispositif = (
     dispositifId,
     userId: { $ne: userId },
     type: TraductionsType.VALIDATION,
-  }).lean() as unknown as Promise<Traductions | null>;
+  }).lean();
 
 export const deleteTradsInDB = (
   dispositifId: DispositifId,

--- a/apps/server/src/modules/traductions/traductions.service.ts
+++ b/apps/server/src/modules/traductions/traductions.service.ts
@@ -1,5 +1,5 @@
 import type { Languages, TranslatorFeedback } from "@refugies-info/api-types";
-import type { Dispositif, Theme, Traductions, User } from "@refugies-info/mongo";
+import type { Dispositif, LeanTraductions, Theme, Traductions, User } from "@refugies-info/mongo";
 import { getAirtableTranslationTable } from "~/connectors/airtable/airtable";
 import { countDispositifWords, countDispositifWordsForSections } from "~/libs/wordCounter";
 import logger from "~/logger";
@@ -22,7 +22,7 @@ interface TradToExport {
 export const addTradToAirtable = async (
   dispositif: Dispositif,
   language: Languages,
-  translation: Traductions,
+  translation: Traductions | LeanTraductions,
   username: string,
 ) => {
   const frTranslation = getDispositifTranslation(dispositif, "fr");

--- a/apps/server/src/workflows/translation/getTraductionsForReview/getTraductionsForReview.ts
+++ b/apps/server/src/workflows/translation/getTraductionsForReview/getTraductionsForReview.ts
@@ -1,6 +1,6 @@
 import type { GetTraductionsForReview, Languages } from "@refugies-info/api-types";
 import type { DispositifId, User } from "@refugies-info/mongo";
-import { type Traductions, TraductionsType } from "@refugies-info/mongo";
+import { type LeanTraductions, type Traductions, TraductionsType } from "@refugies-info/mongo";
 import { toPicture } from "~/libs/pictureUtils";
 import { getTraductionUser } from "~/modules/traductions/traductions.business";
 import { getTraductionsByLanguageAndDispositif } from "~/modules/traductions/traductions.repository";
@@ -17,10 +17,12 @@ const getTraductionsForReview = async (
   // on garde également le nom de l'expert initial dans `validator`
   if (
     currentUser.isExpert() &&
-    translations.find((t: Traductions) => t.toReview.length > 0) &&
-    !translations.find((t: Traductions) => getTraductionUser(t)._id.toString() === currentUser.id)
+    translations.find((t: LeanTraductions) => t.toReview.length > 0) &&
+    !translations.find(
+      (t: LeanTraductions) => getTraductionUser(t)._id.toString() === currentUser.id,
+    )
   ) {
-    const trad = translations.find((t: Traductions) => t.toReview.length > 0);
+    const trad = translations.find((t: LeanTraductions) => t.toReview.length > 0);
     return [
       {
         translated: trad.translated,
@@ -51,11 +53,11 @@ const getTraductionsForReview = async (
           translation.type === TraductionsType.SUGGESTION,
       )
       // Permet d'avoir la traduction de l'utilisateur courant en première dans l'ordre d'affichage
-      .sort((translation) =>
+      .sort((translation: LeanTraductions) =>
         getTraductionUser(translation)._id.toString() === currentUser.id ? -1 : 0,
       )
       // transforme en GetTraductionsForReview
-      .map((trad) => ({
+      .map((trad: LeanTraductions) => ({
         translated: trad.translated,
         author: {
           id: getTraductionUser(trad).id,

--- a/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
+++ b/apps/server/src/workflows/translation/validateTranslation/validateTranslation.ts
@@ -9,6 +9,7 @@ import {
   type Dispositif,
   DispositifModel,
   ErrorModel,
+  type LeanTraductions,
   type Traductions,
 } from "@refugies-info/mongo";
 import { cloneDeep, set } from "lodash";
@@ -56,7 +57,7 @@ const deleteLineBreaksInTranslation = (translation: Partial<TranslationContent>)
 const validateTranslation = (
   dispositif: Dispositif,
   language: Languages,
-  translation: Traductions,
+  translation: Traductions | LeanTraductions,
   username: string,
 ) => {
   const isFirstValidation = !dispositif.translations[language]; // else, expert is just changing validated translation

--- a/packages/mongo/src/schemas/Traductions.ts
+++ b/packages/mongo/src/schemas/Traductions.ts
@@ -1,5 +1,5 @@
 import { zId, zodSchema } from "@zodyac/zod-mongoose";
-import { type Document, type Model, model, models, type Types } from "mongoose";
+import { type Document, type FlattenMaps, type Model, model, models, type Types } from "mongoose";
 import { z } from "zod";
 
 export enum TraductionsType {
@@ -39,6 +39,7 @@ export const TraductionsZodSchema = z.object({
 });
 
 export type Traductions = z.infer<typeof TraductionsZodSchema> & Document<Types.ObjectId>;
+export type LeanTraductions = FlattenMaps<Traductions> & Required<{ _id: Types.ObjectId }>;
 /**
  * TraductionId represents a unique identifier for a Traduction.
  *


### PR DESCRIPTION
## Summary
Fixes **RI-1166**: Translations showing as "À traduire" (0% progress) in the Back-Office and failing to publish after validation.

The v2.4.0 migration to `@zodyac/zod-mongoose` caused the `translated.content` field in `Traductions` to be instantiated as a Mongoose Map. This caused two major issues:
1. **Avancement calculation (`getNbWordsDone`)**: `Object.keys()` on Mongoose Maps returned internal properties (e.g. `$__parent`) instead of translation keys. Because it found 0 valid keys, the word count delta evaluated to `0 / 113` words. This forced the Back-Office status to "À traduire", hiding the "Publier" button.
2. **Publish payload corruption**: `lodash.cloneDeep(translation.translated)` in `validateTranslation` silently corrupted the payload sent to `DispositifModel.updateOne` because `cloneDeep` doesn't work on Mongoose Maps. This prevented translations from successfully saving to the `dispositifs` collection when `POST /traduction/publish` was called.

**The Fix:**
Enforces `.lean()` on `Traductions` repository read methods to return Plain Old JavaScript Objects (POJOs), restoring compatibility with `Object.keys()` and `cloneDeep()`. Downstream types are preserved via TypeScript casting.

## Test plan
- [ ] Verify translation progress calculates correctly in the Back-Office (should be >0% instead of 0%).
- [ ] Verify validated translations show as "À valider" instead of "À traduire".
- [ ] Verify that clicking "Publier" successfully persists the translation to the `dispositifs` collection.
- [x] Existing `publishDispositif` and `traduction` tests pass.

👾 Generated with [Letta Code](https://letta.com)