### PR TITLE
feat(migrations): add MongoDB Performance Advisor recommended indexes

### DIFF
--- a/migrations/1743369600000_AddPerformanceAdvisorIndexes.ts
+++ b/migrations/1743369600000_AddPerformanceAdvisorIndexes.ts
@@ -29,10 +29,14 @@ export class AddPerformanceAdvisorIndexes1743369600000 implements MigrationInter
     await db
       .collection("appusers")
       .dropIndex("expoPushToken_1_uid_1")
-      .catch(() => undefined);
+      .catch((err: { code?: number }) => {
+        if (err.code !== 27) throw err; // 27 = IndexNotFound — index may not exist yet
+      });
     await db
       .collection("dispositifs")
       .dropIndex("metadatas.frenchLevel_1_status_1_webOnly_1")
-      .catch(() => undefined);
+      .catch((err: { code?: number }) => {
+        if (err.code !== 27) throw err; // 27 = IndexNotFound — index may not exist yet
+      });
   }
 }

--- a/migrations/1743369600000_AddPerformanceAdvisorIndexes.ts
+++ b/migrations/1743369600000_AddPerformanceAdvisorIndexes.ts
@@ -1,0 +1,38 @@
+import type { MigrationInterface } from "mongo-migrate-ts";
+import type { Db } from "mongodb";
+
+/**
+ * Adds indexes recommended by MongoDB Performance Advisor
+ * to reduce disk reads for high-frequency queries.
+ */
+export class AddPerformanceAdvisorIndexes1743369600000 implements MigrationInterface {
+  public async up(db: Db): Promise<void> {
+    // Index 1: appusers - expoPushToken + uid
+    // Query pattern: Find users by expoPushToken with uid projection
+    // Impact: ~50.42 queries/hour, up to 100.1 MB disk reads saved
+    await db
+      .collection("appusers")
+      .createIndex({ expoPushToken: 1, uid: 1 }, { name: "expoPushToken_1_uid_1" });
+
+    // Index 2: dispositifs - frenchLevel + status + webOnly
+    // Query pattern: Search filtering by french level, status, and webOnly flag
+    // Impact: ~0.5 queries/hour, up to 138.7 MB disk reads saved
+    await db
+      .collection("dispositifs")
+      .createIndex(
+        { "metadatas.frenchLevel": 1, status: 1, webOnly: 1 },
+        { name: "metadatas.frenchLevel_1_status_1_webOnly_1" },
+      );
+  }
+
+  public async down(db: Db): Promise<void> {
+    await db
+      .collection("appusers")
+      .dropIndex("expoPushToken_1_uid_1")
+      .catch(() => undefined);
+    await db
+      .collection("dispositifs")
+      .dropIndex("metadatas.frenchLevel_1_status_1_webOnly_1")
+      .catch(() => undefined);
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `{ expoPushToken: 1, uid: 1 }` index on **appusers** — targets ~50 queries/hour, saves up to 100 MB in disk reads
- Adds `{ "metadatas.frenchLevel": 1, status: 1, webOnly: 1 }` index on **dispositifs** — saves up to 138 MB in disk reads
- Both indexes are named for easy management and reversible via the `down()` migration

## Test plan

- [ ] Run `pnpm migrate up` on staging after deploy and verify indexes appear in Atlas UI
- [ ] Confirm no regression on search and push-notification queries
- [ ] Rollback: `pnpm migrate down` drops both indexes cleanly

👾 Generated with [Letta Code](https://letta.com)