### PR TITLE
chore(workspace): rename wt post-create hook to pre-start

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,4 +1,4 @@
-[post-create]
+[pre-start]
 deps = "pnpm install"
 
 [post-start]


### PR DESCRIPTION
## Summary
- rename the deprecated Worktrunk hook key in `.config/wt.toml` from `[post-create]` to `[pre-start]`
- keep the existing behavior (`pnpm install` still runs when a new worktree starts)
- align repository config with current `wt` expectations to remove deprecation warnings

## Test plan
- [x] Run `wt config show` and verify `.config/wt.toml` now displays `[pre-start]`
- [x] Confirm only `.config/wt.toml` changed in this branch
- [ ] Optional: create a temporary worktree to validate hook execution end-to-end

👾 Generated with [Letta Code](https://letta.com)