### PR TITLE
fix(workspace): avoid unnecessary mobile release builds on lockfile-only noise

### DIFF
--- a/.github/workflows/release_pipeline.yaml
+++ b/.github/workflows/release_pipeline.yaml
@@ -44,7 +44,7 @@ jobs:
       # On workflow_dispatch, deploy everything. On push, use changed-files output.
       backend: ${{ steps.backend.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}
       frontend: ${{ steps.frontend.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}
-      mobile: ${{ steps.mobile.outputs.any_changed == 'true' || github.event_name == 'workflow_dispatch' }}
+      mobile: ${{ steps.mobile-paths.outputs.any_changed == 'true' || steps.mobile-lockfile.outputs.changed == 'true' || github.event_name == 'workflow_dispatch' }}
       triggering_pr_title: ${{ steps.trigger-pr.outputs.title }}
       triggering_pr_number: ${{ steps.trigger-pr.outputs.number }}
     steps:
@@ -120,16 +120,91 @@ jobs:
             pnpm-lock.yaml
             package.json
 
-      - name: Detect mobile changes
+      - name: Detect mobile source changes
         uses: tj-actions/changed-files@v47
-        id: mobile
+        id: mobile-paths
         if: github.event_name == 'push'
         with:
           files: |
             apps/mobile/**
             packages/api-types/**
-            pnpm-lock.yaml
-            package.json
+
+      - name: Detect mobile lockfile dependency changes
+        id: mobile-lockfile
+        if: github.event_name == 'push'
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$BEFORE_SHA" == "0000000000000000000000000000000000000000" ]]; then
+            echo "First push on branch — trigger mobile build."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ! git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" | grep -Fqx "pnpm-lock.yaml"; then
+            echo "pnpm-lock.yaml unchanged."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          before_lock="$(mktemp)"
+          after_lock="$(mktemp)"
+          trap 'rm -f "$before_lock" "$after_lock"' EXIT
+
+          git show "$BEFORE_SHA:pnpm-lock.yaml" > "$before_lock"
+          git show "$AFTER_SHA:pnpm-lock.yaml" > "$after_lock"
+
+          extract_importer_block() {
+            local file="$1"
+            local importer="$2"
+
+            awk -v importer="$importer" '
+              BEGIN { in_importers = 0; in_target = 0 }
+              /^importers:/ {
+                in_importers = 1
+                next
+              }
+              in_importers && /^[^[:space:]]/ {
+                in_importers = 0
+              }
+              !in_importers {
+                next
+              }
+              in_target {
+                if ($0 ~ /^  [^[:space:]][^:]*:/ && $0 != "  " importer ":") {
+                  exit
+                }
+                print
+                next
+              }
+              $0 == "  " importer ":" {
+                in_target = 1
+                print
+              }
+            ' "$file"
+          }
+
+          before_mobile="$(extract_importer_block "$before_lock" "apps/mobile")"
+          after_mobile="$(extract_importer_block "$after_lock" "apps/mobile")"
+          before_api_types="$(extract_importer_block "$before_lock" "packages/api-types")"
+          after_api_types="$(extract_importer_block "$after_lock" "packages/api-types")"
+
+          if [[ -z "$before_mobile" || -z "$after_mobile" ]]; then
+            echo "Could not resolve apps/mobile importer in lockfile diff. Triggering mobile build for safety."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$before_mobile" != "$after_mobile" || "$before_api_types" != "$after_api_types" ]]; then
+            echo "Mobile-related lockfile importer content changed."
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Lockfile changed, but mobile-related importers are unchanged."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
 
   # ─── Backend — always before frontend ──────────────────────────────────────
   deploy-backend:


### PR DESCRIPTION
## Summary
- split mobile change detection into source paths (`apps/mobile/**`, `packages/api-types/**`) and lockfile-impact detection
- add importer-level lockfile check for `apps/mobile` and `packages/api-types` so unrelated `pnpm-lock.yaml` churn no longer triggers EAS builds
- keep a fail-safe behavior: if importer extraction fails, mobile build is triggered rather than skipped

## Test plan
- [x] `pnpm lint`
- [x] `pnpm check:types`
- [ ] Validate on next `staging`/`production` push that mobile job is skipped when only unrelated lockfile sections change

👾 Generated with [Letta Code](https://letta.com)