### PR TITLE
fix(server): prevent appuser notification settings map cast errors

### DIFF
--- a/apps/server/src/modules/appusers/__tests__/appusers.repository.test.ts
+++ b/apps/server/src/modules/appusers/__tests__/appusers.repository.test.ts
@@ -1,0 +1,67 @@
+import { AppUserModel } from "@refugies-info/mongo";
+import { updateNotificationsSettings } from "~/modules/appusers/appusers.repository";
+
+describe("appusers.repository", () => {
+  beforeEach(async () => {
+    await AppUserModel.deleteMany({});
+  });
+
+  it("should merge theme updates without persisting Mongoose internal keys", async () => {
+    const uid = "appuser-notification-settings-lean-test";
+
+    await AppUserModel.create({
+      uid,
+      notificationsSettings: {
+        global: true,
+        local: true,
+        demarches: true,
+        themes: {
+          "theme-1": true,
+        },
+      },
+    });
+
+    const updated = await updateNotificationsSettings(uid, {
+      global: false,
+      themes: {
+        "theme-2": false,
+      },
+    });
+
+    expect(updated).toEqual({
+      global: false,
+      local: true,
+      demarches: true,
+      themes: {
+        "theme-1": true,
+        "theme-2": false,
+      },
+    });
+
+    const saved = await AppUserModel.findOne({ uid }).lean();
+    expect(saved?.notificationsSettings).toEqual(updated);
+
+    const themeKeys = Object.keys(saved?.notificationsSettings?.themes || {});
+    expect(themeKeys.some((key) => key.startsWith("$__"))).toBe(false);
+  });
+
+  it("should apply default settings when notificationsSettings is missing", async () => {
+    const uid = "appuser-notification-settings-defaults-test";
+
+    await AppUserModel.create({ uid });
+
+    const updated = await updateNotificationsSettings(uid, {
+      local: false,
+    });
+
+    expect(updated).toEqual({
+      global: true,
+      local: false,
+      demarches: true,
+      themes: {},
+    });
+
+    const saved = await AppUserModel.findOne({ uid }).lean();
+    expect(saved?.notificationsSettings).toEqual(updated);
+  });
+});

--- a/apps/server/src/modules/appusers/__tests__/appusers.repository.test.ts
+++ b/apps/server/src/modules/appusers/__tests__/appusers.repository.test.ts
@@ -21,14 +21,14 @@ describe("appusers.repository", () => {
       },
     });
 
-    const updated = await updateNotificationsSettings(uid, {
+    const firstUpdate = await updateNotificationsSettings(uid, {
       global: false,
       themes: {
         "theme-2": false,
       },
     });
 
-    expect(updated).toEqual({
+    expect(firstUpdate).toEqual({
       global: false,
       local: true,
       demarches: true,
@@ -38,8 +38,25 @@ describe("appusers.repository", () => {
       },
     });
 
+    const secondUpdate = await updateNotificationsSettings(uid, {
+      themes: {
+        "theme-3": true,
+      },
+    });
+
+    expect(secondUpdate).toEqual({
+      global: false,
+      local: true,
+      demarches: true,
+      themes: {
+        "theme-1": true,
+        "theme-2": false,
+        "theme-3": true,
+      },
+    });
+
     const saved = await AppUserModel.findOne({ uid }).lean();
-    expect(saved?.notificationsSettings).toEqual(updated);
+    expect(saved?.notificationsSettings).toEqual(secondUpdate);
 
     const themeKeys = Object.keys(saved?.notificationsSettings?.themes || {});
     expect(themeKeys.some((key) => key.startsWith("$__"))).toBe(false);

--- a/apps/server/src/modules/appusers/appusers.repository.ts
+++ b/apps/server/src/modules/appusers/appusers.repository.ts
@@ -31,7 +31,7 @@ export const processAppUsersByBatch = async (
 };
 
 export const getNotificationsSettings = async (uid: string) => {
-  const appUser = await AppUserModel.findOne({ uid }).lean();
+  const appUser = await AppUserModel.findOne({ uid }, { notificationsSettings: 1 }).lean();
   if (!appUser) {
     return null;
   }
@@ -42,30 +42,62 @@ export const updateNotificationsSettings = async (
   uid: string,
   payload: Partial<NotificationsSettings>,
 ) => {
-  const appUser = await AppUserModel.findOne({ uid }).lean();
+  const appUser = await AppUserModel.findOne({ uid }, { notificationsSettings: 1 }).lean();
   if (!appUser) {
     return null;
   }
 
-  // Use default settings if notificationsSettings is undefined (field is optional in schema)
-  const currentSettings = appUser.notificationsSettings || DEFAULT_NOTIFICATIONS_SETTINGS;
-
+  const currentSettings = appUser.notificationsSettings || ({} as Partial<NotificationsSettings>);
   const { themes: payloadThemes, ...otherPayload } = payload;
 
   const notificationsSettings: NotificationsSettings = {
+    ...DEFAULT_NOTIFICATIONS_SETTINGS,
     ...currentSettings,
     ...otherPayload,
     themes: {
-      ...currentSettings.themes,
+      ...(currentSettings.themes || {}),
       ...(payloadThemes || {}),
     },
   };
 
-  await AppUserModel.updateOne(
-    { uid },
-    { $set: { notificationsSettings } },
-    { runValidators: true },
-  );
+  const notificationsSettingsUpdate: Record<string, boolean | Record<string, boolean>> = {};
+
+  if (otherPayload.global !== undefined) {
+    notificationsSettingsUpdate["notificationsSettings.global"] = otherPayload.global;
+  }
+  if (otherPayload.local !== undefined) {
+    notificationsSettingsUpdate["notificationsSettings.local"] = otherPayload.local;
+  }
+  if (otherPayload.demarches !== undefined) {
+    notificationsSettingsUpdate["notificationsSettings.demarches"] = otherPayload.demarches;
+  }
+
+  if (currentSettings.themes === undefined) {
+    notificationsSettingsUpdate["notificationsSettings.themes"] = notificationsSettings.themes;
+  } else {
+    for (const [themeId, isEnabled] of Object.entries(payloadThemes || {})) {
+      notificationsSettingsUpdate[`notificationsSettings.themes.${themeId}`] = isEnabled;
+    }
+  }
+
+  if (currentSettings.global === undefined) {
+    notificationsSettingsUpdate["notificationsSettings.global"] = notificationsSettings.global;
+  }
+  if (currentSettings.local === undefined) {
+    notificationsSettingsUpdate["notificationsSettings.local"] = notificationsSettings.local;
+  }
+  if (currentSettings.demarches === undefined) {
+    notificationsSettingsUpdate["notificationsSettings.demarches"] =
+      notificationsSettings.demarches;
+  }
+
+  if (Object.keys(notificationsSettingsUpdate).length > 0) {
+    await AppUserModel.updateOne(
+      { uid },
+      { $set: notificationsSettingsUpdate },
+      { runValidators: true },
+    );
+  }
 
   return notificationsSettings;
 };

--- a/apps/server/src/modules/appusers/appusers.repository.ts
+++ b/apps/server/src/modules/appusers/appusers.repository.ts
@@ -31,7 +31,7 @@ export const processAppUsersByBatch = async (
 };
 
 export const getNotificationsSettings = async (uid: string) => {
-  const appUser = await AppUserModel.findOne({ uid });
+  const appUser = await AppUserModel.findOne({ uid }).lean();
   if (!appUser) {
     return null;
   }
@@ -42,7 +42,7 @@ export const updateNotificationsSettings = async (
   uid: string,
   payload: Partial<NotificationsSettings>,
 ) => {
-  const appUser = await AppUserModel.findOne({ uid });
+  const appUser = await AppUserModel.findOne({ uid }).lean();
   if (!appUser) {
     return null;
   }
@@ -52,7 +52,7 @@ export const updateNotificationsSettings = async (
 
   const { themes: payloadThemes, ...otherPayload } = payload;
 
-  appUser.notificationsSettings = {
+  const notificationsSettings: NotificationsSettings = {
     ...currentSettings,
     ...otherPayload,
     themes: {
@@ -60,8 +60,14 @@ export const updateNotificationsSettings = async (
       ...(payloadThemes || {}),
     },
   };
-  await appUser.save();
-  return appUser.notificationsSettings;
+
+  await AppUserModel.updateOne(
+    { uid },
+    { $set: { notificationsSettings } },
+    { runValidators: true },
+  );
+
+  return notificationsSettings;
 };
 
 export const updateOrCreateAppUser = async (


### PR DESCRIPTION
## Summary
- switch appuser notification settings reads to `.lean()` so merge logic works on plain objects instead of hydrated Mongoose map instances
- replace document mutation + `.save()` with `updateOne(..., { runValidators: true })` to persist merged `notificationsSettings` safely
- add regression tests for theme merge behavior and fallback defaults when `notificationsSettings` is missing

## Test plan
- [x] `pnpm test:server -- appusers.repository`
- [x] `pnpm lint:server`
- [x] `pnpm check:types:server`

## Manual testing instructions
- [ ] Open the mobile app (staging or production build) and log in with a test app-user account
- [ ] Go to Notification settings
- [ ] Toggle one top-level preference (`global`, `local`, or `demarches`) and save
- [ ] Toggle one theme preference and save
- [ ] Confirm `POST /appuser/notification_settings` returns 200 with updated values
- [ ] Reload the settings screen and verify values persisted
- [ ] Check backend-prod logs and verify there is no `Cast to Map failed` / `AppUser validation failed` on `notificationsSettings.themes`

👾 Generated with [Letta Code](https://letta.com)