### PR TITLE
fix(workspace): prevent translation page 500 on missing author ids

### DIFF
--- a/apps/client/src/components/Content/DispositifTranslate/DispositifTranslate.tsx
+++ b/apps/client/src/components/Content/DispositifTranslate/DispositifTranslate.tsx
@@ -90,7 +90,7 @@ const Dispositif = (props: Props) => {
         progress={progress}
         translators={traductions
           .map((t) => t.author)
-          .filter((auth) => auth.id.toString() !== user.userId?.toString())}
+          .filter((auth) => auth.id?.toString() !== user.userId?.toString())}
       />
       <Row className="gx-0">
         <Col xs="6" className={cn(styles.col, "bg-white")}>

--- a/apps/client/src/hooks/dispositif/useDispositifTranslateForm.ts
+++ b/apps/client/src/hooks/dispositif/useDispositifTranslateForm.ts
@@ -12,7 +12,9 @@ const getDefaultFormValues = (
   userId: Id | null,
   traductions: GetTraductionsForReviewResponse,
 ): TranslateForm => {
-  const userTrads = userId ? traductions.find((t) => t.author.id === userId.toString()) : null;
+  const userTrads = userId
+    ? traductions.find((t) => t.author.id?.toString() === userId.toString())
+    : null;
   return {
     translated: userTrads?.translated || {},
     toFinish: userTrads?.toFinish || [],

--- a/apps/client/src/hooks/dispositif/useDispositifTranslation/suggestionFunctions.ts
+++ b/apps/client/src/hooks/dispositif/useDispositifTranslation/suggestionFunctions.ts
@@ -28,7 +28,7 @@ export const transformMyTranslation = (
   return {
     validator,
     author: {
-      id: user?._id.toString() || "",
+      id: user?._id?.toString() || "",
       username: user?.username || "",
     },
     text: get(traductions.translated, section) || "",
@@ -79,5 +79,6 @@ export const getInitialTranslations = (
   userId: string,
   traductions: GetTraductionsForReviewResponse,
 ) => {
-  return traductions.filter((t) => t.author.id !== userId.toString());
+  const currentUserId = userId?.toString() || "";
+  return traductions.filter((t) => t.author.id?.toString() !== currentUserId);
 };

--- a/apps/server/src/workflows/translation/getTraductionsForReview/getTraductionsForReview.ts
+++ b/apps/server/src/workflows/translation/getTraductionsForReview/getTraductionsForReview.ts
@@ -39,6 +39,14 @@ const getTraductionsForReview = async (
   language: Languages,
   currentUser: User,
 ): Promise<GetTraductionsForReview[]> => {
+  const currentUserId = currentUser._id?.toString() || currentUser.id || "";
+  if (!currentUserId) {
+    logger.warn("[getTraductionsForReview] current user has no id", {
+      currentUserUsername: currentUser.username,
+      currentUserEmail: currentUser.email,
+    });
+  }
+
   const translations = await getTraductionsByLanguageAndDispositif(language, dispositif);
   const populatedTranslations = getPopulatedTranslations(translations);
 
@@ -52,7 +60,7 @@ const getTraductionsForReview = async (
   if (
     currentUser.isExpert() &&
     tradToReview &&
-    !populatedTranslations.find(({ userId }) => userId === currentUser.id)
+    !populatedTranslations.find(({ userId }) => userId === currentUserId)
   ) {
     return [
       {
@@ -63,7 +71,7 @@ const getTraductionsForReview = async (
           picture: toPicture(tradToReview.user.picture),
         },
         author: {
-          id: currentUser.id,
+          id: currentUserId,
           username: currentUser.username || currentUser.email,
           picture: toPicture(currentUser.picture),
         },
@@ -77,10 +85,10 @@ const getTraductionsForReview = async (
   return populatedTranslations
     .filter(
       ({ translation, userId }) =>
-        (currentUser.isExpert() && userId === currentUser.id) ||
+        (currentUser.isExpert() && userId === currentUserId) ||
         translation.type === TraductionsType.SUGGESTION,
     )
-    .sort(({ userId }) => (userId === currentUser.id ? -1 : 0))
+    .sort(({ userId }) => (userId === currentUserId ? -1 : 0))
     .map(({ translation, user, userId }) => ({
       translated: translation.translated,
       author: {

--- a/apps/server/src/workflows/translation/getTraductionsForReview/getTraductionsForReview.ts
+++ b/apps/server/src/workflows/translation/getTraductionsForReview/getTraductionsForReview.ts
@@ -1,9 +1,38 @@
 import type { GetTraductionsForReview, Languages } from "@refugies-info/api-types";
 import type { DispositifId, User } from "@refugies-info/mongo";
-import { type LeanTraductions, type Traductions, TraductionsType } from "@refugies-info/mongo";
+import { type LeanTraductions, TraductionsType } from "@refugies-info/mongo";
 import { toPicture } from "~/libs/pictureUtils";
+import logger from "~/logger";
 import { getTraductionUser } from "~/modules/traductions/traductions.business";
 import { getTraductionsByLanguageAndDispositif } from "~/modules/traductions/traductions.repository";
+
+const getPopulatedTranslations = (translations: LeanTraductions[]) =>
+  translations
+    .map((translation) => {
+      try {
+        const user = getTraductionUser(translation);
+        const userId = user._id?.toString() || user.id;
+
+        if (!userId) {
+          logger.warn("[getTraductionsForReview] skipping translation with empty user id", {
+            translationId: translation._id?.toString(),
+          });
+          return null;
+        }
+
+        return { translation, user, userId };
+      } catch (error) {
+        logger.warn("[getTraductionsForReview] skipping translation with unpopulated user", {
+          translationId: translation._id?.toString(),
+          error,
+        });
+        return null;
+      }
+    })
+    .filter(
+      (translation): translation is { translation: LeanTraductions; user: User; userId: string } =>
+        !!translation,
+    );
 
 const getTraductionsForReview = async (
   dispositif: DispositifId,
@@ -11,63 +40,57 @@ const getTraductionsForReview = async (
   currentUser: User,
 ): Promise<GetTraductionsForReview[]> => {
   const translations = await getTraductionsByLanguageAndDispositif(language, dispositif);
+  const populatedTranslations = getPopulatedTranslations(translations);
 
   // S'il y a des trads à revoir et que l'expert n'a pas de validation attitré,
   // on copie l'objet disponible et on y assigne le user courant.
   // on garde également le nom de l'expert initial dans `validator`
+  const tradToReview = populatedTranslations.find(
+    ({ translation }) => (translation.toReview || []).length > 0,
+  );
+
   if (
     currentUser.isExpert() &&
-    translations.find((t: LeanTraductions) => t.toReview.length > 0) &&
-    !translations.find(
-      (t: LeanTraductions) => getTraductionUser(t)._id.toString() === currentUser.id,
-    )
+    tradToReview &&
+    !populatedTranslations.find(({ userId }) => userId === currentUser.id)
   ) {
-    const trad = translations.find((t: LeanTraductions) => t.toReview.length > 0);
     return [
       {
-        translated: trad.translated,
+        translated: tradToReview.translation.translated,
         validator: {
-          id: getTraductionUser(trad).id,
-          username: getTraductionUser(trad).username || getTraductionUser(trad).email,
-          picture: toPicture(getTraductionUser(trad).picture),
+          id: tradToReview.userId,
+          username: tradToReview.user.username || tradToReview.user.email,
+          picture: toPicture(tradToReview.user.picture),
         },
         author: {
           id: currentUser.id,
           username: currentUser.username || currentUser.email,
           picture: toPicture(currentUser.picture),
         },
-        toReview: trad.toReview,
-        toFinish: trad.toFinish || [],
+        toReview: tradToReview.translation.toReview,
+        toFinish: tradToReview.translation.toFinish || [],
       },
     ];
   }
 
   // Sinon, on retourne toutes les suggestions + la validation de l'expert courant si applicable
-  return (
-    translations
-      // Non-experts users can only acces non-expert translations. Experts can only access his own validation
-      .filter(
-        (translation) =>
-          (currentUser.isExpert() &&
-            getTraductionUser(translation)._id.toString() === currentUser.id) ||
-          translation.type === TraductionsType.SUGGESTION,
-      )
-      // Permet d'avoir la traduction de l'utilisateur courant en première dans l'ordre d'affichage
-      .sort((translation: LeanTraductions) =>
-        getTraductionUser(translation)._id.toString() === currentUser.id ? -1 : 0,
-      )
-      // transforme en GetTraductionsForReview
-      .map((trad: LeanTraductions) => ({
-        translated: trad.translated,
-        author: {
-          id: getTraductionUser(trad).id,
-          username: getTraductionUser(trad).username || getTraductionUser(trad).email,
-          picture: toPicture(getTraductionUser(trad).picture),
-        },
-        toReview: trad.toReview,
-        toFinish: trad.toFinish || [],
-      }))
-  );
+  return populatedTranslations
+    .filter(
+      ({ translation, userId }) =>
+        (currentUser.isExpert() && userId === currentUser.id) ||
+        translation.type === TraductionsType.SUGGESTION,
+    )
+    .sort(({ userId }) => (userId === currentUser.id ? -1 : 0))
+    .map(({ translation, user, userId }) => ({
+      translated: translation.translated,
+      author: {
+        id: userId,
+        username: user.username || user.email,
+        picture: toPicture(user.picture),
+      },
+      toReview: translation.toReview,
+      toFinish: translation.toFinish || [],
+    }));
 };
 
 export default getTraductionsForReview;


### PR DESCRIPTION
## Summary
- prevent SSR crashes on translation pages by guarding `.toString()` calls against missing author/user ids in client translation hooks/components
- harden `getTraductionsForReview` server workflow by normalizing populated users via `_id?.toString() || id`
- skip and log malformed/unpopulated translation users instead of propagating undefined ids to the client

## Test plan
- [x] `pnpm -C apps/client check:types`
- [x] `pnpm -C apps/client lint`
- [x] `pnpm -C apps/server check:types`
- [x] `pnpm -C apps/server lint`
- [ ] Open `/dispositif/63be963483d62b04a6050d42/translate?language=uk` on production/staging and confirm no 500

👾 Generated with [Letta Code](https://letta.com)