### PR TITLE
fix(server): prevent validation errors from invalid suggestions

### DIFF
--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -674,7 +674,18 @@ export const deleteNeedFromDispositifs = async (needId: string) => {
 
 export const cloneDispositifInDrafts = async (id: DispositifId, newData: Partial<Dispositif>) => {
   const dispositif = await DispositifModel.findById(id).lean();
-  return DispositifDraftModel.create({ ...dispositif, ...newData });
+
+  // Filter out invalid suggestions (empty suggestion field causes validation errors)
+  // See RI-1174: legacy data may have suggestions with empty strings
+  const sanitizedDispositif = dispositif
+    ? {
+        ...dispositif,
+        suggestions:
+          dispositif.suggestions?.filter((s) => s.suggestion && s.suggestion.trim() !== "") ?? [],
+      }
+    : null;
+
+  return DispositifDraftModel.create({ ...sanitizedDispositif, ...newData });
 };
 
 export const getDispositifAbstracts = async (

--- a/migrations/1743662400000_RemoveInvalidSuggestions.ts
+++ b/migrations/1743662400000_RemoveInvalidSuggestions.ts
@@ -1,80 +1,60 @@
 import type { MigrationInterface } from "mongo-migrate-ts";
-import type { Db, Document, ObjectId } from "mongodb";
-
-// Find dispositifs with invalid suggestions (empty or whitespace-only suggestion field)
-const hasInvalidSuggestionsExpr: Document = {
-  $expr: {
-    $gt: [
-      {
-        $size: {
-          $filter: {
-            input: { $ifNull: ["$suggestions", []] },
-            as: "suggestion",
-            // Invalid: empty string or whitespace-only
-            cond: {
-              $or: [
-                { $eq: ["$$suggestion.suggestion", ""] },
-                {
-                  $eq: [
-                    {
-                      $trim: { input: "$$suggestion.suggestion" },
-                    },
-                    "",
-                  ],
-                },
-                { $eq: ["$$suggestion.suggestion", null] },
-              ],
-            },
-          },
-        },
-      },
-      0,
-    ],
-  },
-};
+import type { Db, ObjectId } from "mongodb";
 
 export class Migration1743662400000 implements MigrationInterface {
   public async up(db: Db): Promise<void> {
     const dispositifs = db.collection("dispositifs");
 
-    // Find all dispositifs with invalid suggestions
-    const docs = await dispositifs
-      .find(hasInvalidSuggestionsExpr, {
-        projection: { _id: 1, status: 1, typeContenu: 1, suggestions: 1 },
-      })
-      .toArray();
+    // Find dispositifs with invalid suggestions using $elemMatch (safer than $expr)
+    // $expr with $trim would crash on null values
+    const query = {
+      suggestions: {
+        $elemMatch: {
+          $or: [{ suggestion: null }, { suggestion: "" }, { suggestion: { $regex: /^\s+$/ } }],
+        },
+      },
+    };
 
-    if (docs.length === 0) {
-      console.log("[Migration1743662400000] No invalid suggestions found.");
-      return;
-    }
+    // Use cursor for memory efficiency
+    const cursor = dispositifs.find(query, {
+      projection: { _id: 1, suggestions: 1 },
+    });
 
-    console.log(
-      `[Migration1743662400000] Found ${docs.length} dispositif(s) with invalid suggestions.`,
-    );
-
-    // For each document, filter out invalid suggestions
+    const bulkOps: {
+      updateOne: { filter: { _id: ObjectId }; update: { $set: { suggestions: unknown[] } } };
+    }[] = [];
     let totalRemoved = 0;
-    for (const doc of docs) {
+    let docCount = 0;
+
+    // Iterate using cursor to avoid memory issues with large datasets
+    for await (const doc of cursor) {
       const validSuggestions = (doc.suggestions || []).filter(
         (s: { suggestion?: string }) => s.suggestion && s.suggestion.trim() !== "",
       );
       const removedCount = (doc.suggestions?.length || 0) - validSuggestions.length;
 
-      if (validSuggestions.length !== doc.suggestions?.length) {
-        await dispositifs.updateOne(
-          { _id: doc._id as ObjectId },
-          { $set: { suggestions: validSuggestions } },
-        );
+      if (removedCount > 0) {
+        bulkOps.push({
+          updateOne: {
+            filter: { _id: doc._id as ObjectId },
+            update: { $set: { suggestions: validSuggestions } },
+          },
+        });
         totalRemoved += removedCount;
-        console.log(
-          `[Migration1743662400000] Fixed ${doc._id}: removed ${removedCount} invalid suggestion(s)`,
-        );
+        docCount++;
       }
     }
 
+    if (bulkOps.length === 0) {
+      console.log("[Migration1743662400000] No invalid suggestions found.");
+      return;
+    }
+
+    // Use bulkWrite for efficient batch updates
+    const result = await dispositifs.bulkWrite(bulkOps);
+
     console.log(
-      `[Migration1743662400000] Removed ${totalRemoved} invalid suggestion(s) from ${docs.length} dispositif(s).`,
+      `[Migration1743662400000] Removed ${totalRemoved} invalid suggestion(s) from ${result.modifiedCount} dispositif(s).`,
     );
   }
 

--- a/migrations/1743662400000_RemoveInvalidSuggestions.ts
+++ b/migrations/1743662400000_RemoveInvalidSuggestions.ts
@@ -1,0 +1,85 @@
+import type { MigrationInterface } from "mongo-migrate-ts";
+import type { Db, Document, ObjectId } from "mongodb";
+
+// Find dispositifs with invalid suggestions (empty or whitespace-only suggestion field)
+const hasInvalidSuggestionsExpr: Document = {
+  $expr: {
+    $gt: [
+      {
+        $size: {
+          $filter: {
+            input: { $ifNull: ["$suggestions", []] },
+            as: "suggestion",
+            // Invalid: empty string or whitespace-only
+            cond: {
+              $or: [
+                { $eq: ["$$suggestion.suggestion", ""] },
+                {
+                  $eq: [
+                    {
+                      $trim: { input: "$$suggestion.suggestion" },
+                    },
+                    "",
+                  ],
+                },
+                { $eq: ["$$suggestion.suggestion", null] },
+              ],
+            },
+          },
+        },
+      },
+      0,
+    ],
+  },
+};
+
+export class Migration1743662400000 implements MigrationInterface {
+  public async up(db: Db): Promise<void> {
+    const dispositifs = db.collection("dispositifs");
+
+    // Find all dispositifs with invalid suggestions
+    const docs = await dispositifs
+      .find(hasInvalidSuggestionsExpr, {
+        projection: { _id: 1, status: 1, typeContenu: 1, suggestions: 1 },
+      })
+      .toArray();
+
+    if (docs.length === 0) {
+      console.log("[Migration1743662400000] No invalid suggestions found.");
+      return;
+    }
+
+    console.log(
+      `[Migration1743662400000] Found ${docs.length} dispositif(s) with invalid suggestions.`,
+    );
+
+    // For each document, filter out invalid suggestions
+    let totalRemoved = 0;
+    for (const doc of docs) {
+      const validSuggestions = (doc.suggestions || []).filter(
+        (s: { suggestion?: string }) => s.suggestion && s.suggestion.trim() !== "",
+      );
+      const removedCount = (doc.suggestions?.length || 0) - validSuggestions.length;
+
+      if (validSuggestions.length !== doc.suggestions?.length) {
+        await dispositifs.updateOne(
+          { _id: doc._id as ObjectId },
+          { $set: { suggestions: validSuggestions } },
+        );
+        totalRemoved += removedCount;
+        console.log(
+          `[Migration1743662400000] Fixed ${doc._id}: removed ${removedCount} invalid suggestion(s)`,
+        );
+      }
+    }
+
+    console.log(
+      `[Migration1743662400000] Removed ${totalRemoved} invalid suggestion(s) from ${docs.length} dispositif(s).`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No-op rollback: we cannot recover the removed invalid suggestions
+    console.log("[Migration1743662400000] down() is a no-op.");
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes RI-1174: Users could not save changes to dispositifs with invalid suggestions
- Root cause: `suggestions` array contained entries with empty `suggestion` field, failing Mongoose validation when cloning to draft
- Two-pronged fix: code sanitization + data migration

## Changes
1. **Code fix** in `cloneDispositifInDrafts`: Filter out invalid suggestions before creating draft
2. **Migration**: Clean up existing invalid suggestions in production database

## Test plan
- [ ] Run migration on staging to verify it finds and fixes invalid suggestions
- [ ] Deploy to staging and verify the affected dispositif (`5e189ed30742580052a332b6`) can now be saved
- [ ] Run migration on production after staging validation

👾 Generated with [Letta Code](https://letta.com)