### PR TITLE
fix: add lodash to pnpm.overrides for security

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "smol-toml@<1.6.1": "^1.6.1",
       "yaml@>=2.0.0 <2.8.3": "^2.8.3",
       "yaml@<1.10.3": "1.10.3",
-      "@hapi/content@<=6.0.0": "6.0.1"
+      "@hapi/content@<=6.0.0": "6.0.1",
+      "lodash": "^4.18.1"
     },
     "patchedDependencies": {
       "@codegouvfr/react-dsfr@1.20.2": "patches/@codegouvfr__react-dsfr@1.20.2.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,7 @@ overrides:
   yaml@>=2.0.0 <2.8.3: ^2.8.3
   yaml@<1.10.3: 1.10.3
   '@hapi/content@<=6.0.0': 6.0.1
+  lodash: ^4.18.1
 
 patchedDependencies:
   '@codegouvfr/react-dsfr@1.20.2':


### PR DESCRIPTION
## Summary

- Adds `lodash@^4.18.1` to `pnpm.overrides` to force all transitive dependencies to use the secure version
- Addresses CVE-2026-4800 (code injection via `_.template`) and CVE-2026-2950 (prototype pollution)

## Context

Gemini Code Assist flagged in PR #3696 that while lodash was updated to 4.18.1 for security fixes, it was not added to `pnpm.overrides`. This means transitive dependencies could still pin older vulnerable versions.

## Security principle

When fixing security vulnerabilities, add the package to `pnpm.overrides` to force all transitive dependencies to use the secure version. This ensures protection even when:
- Transitive deps pin older versions
- Semver ranges don't include the patch

## Test plan

- [x] `pnpm audit` returns 0 vulnerabilities ✅
- [x] `pnpm lint` passes
- [x] `pnpm check:types` passes
- [x] Lockfile shows all lodash instances at 4.18.1

👾 Generated with [Letta Code](https://letta.com)