### PR TITLE
feat: add GitLeaks pre-commit hook for secret scanning

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,21 @@
+# GitLeaks configuration for Réfugiés.info / karfur monorepo
+# https://github.com/gitleaks/gitleaks
+
+title = "Réfugiés.info GitLeaks config"
+
+[allowlist]
+paths = [
+  # Example env files (use "demo" values)
+  '''example-env-file\.env$''',
+  '''\.env\.example$''',
+  # Test files with fake secrets
+  '''\.test\.ts$''',
+  '''\.spec\.ts$''',
+  '''__tests__/''',
+  # Storybook and fixtures
+  '''\.storybook/''',
+  '''fixtures/''',
+  # Documentation
+  '''documentation/''',
+  '''README\.md$''',
+]

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,9 @@
 #!/bin/sh
+set -e
 
 # GitLeaks - scan for secrets before commit
 if command -v gitleaks >/dev/null 2>&1; then
-  gitleaks protect --staged
+  gitleaks protect
 else
   echo "⚠️  GitLeaks not installed. Install with: brew install gitleaks"
 fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,11 @@
 #!/bin/sh
+
+# GitLeaks - scan for secrets before commit
+if command -v gitleaks >/dev/null 2>&1; then
+  gitleaks protect --staged
+else
+  echo "⚠️  GitLeaks not installed. Install with: brew install gitleaks"
+fi
+
 pnpm lint-staged
 pnpm knip


### PR DESCRIPTION
## Summary
- Adds GitLeaks to the existing Husky pre-commit hook to scan for secrets before commits
- Creates `.gitleaks.toml` config with allowlist for example env files and test files
- GitLeaks runs gracefully if not installed (shows warning instead of blocking)

## Test plan
- [ ] Install GitLeaks: `brew install gitleaks`
- [ ] Verify pre-commit hook runs GitLeaks: `echo "AWS_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" > test.txt && git add test.txt && git commit -m "test"` (should be blocked)
- [ ] Verify example env files are allowed: `git add .gitleaks.toml && git commit -m "test"` (should pass)

👾 Generated with [Letta Code](https://letta.com)