### PR TITLE
Impersonation admin — "Se connecter en tant que"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ npm-debug.log*
 # AI assistants
 /.cursorrules
 .letta/settings.local.json
+.letta
 
 # EAS
 .expo/

--- a/apps/client/src/components/Backend/ImpersonateBanner/ImpersonateBanner.tsx
+++ b/apps/client/src/components/Backend/ImpersonateBanner/ImpersonateBanner.tsx
@@ -1,0 +1,65 @@
+import Cookies from "js-cookie";
+import { useEffect, useState } from "react";
+import { useSelector } from "react-redux";
+import { userDetailsSelector } from "~/services/User/user.selectors";
+import { setAuthToken } from "~/utils/authToken";
+
+const IMPERSONATE_COOKIE = "impersonation-admin-token";
+
+export const ImpersonateBanner = () => {
+  // Lire le cookie uniquement côté client pour éviter l'erreur d'hydratation SSR
+  const [adminToken, setAdminToken] = useState<string | undefined>(undefined);
+  const currentUser = useSelector(userDetailsSelector);
+
+  useEffect(() => {
+    setAdminToken(Cookies.get(IMPERSONATE_COOKIE));
+  }, []);
+
+  if (!adminToken) return null;
+
+  const handleReturnToAdmin = () => {
+    setAuthToken(adminToken);
+    Cookies.remove(IMPERSONATE_COOKIE);
+    window.location.reload();
+  };
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        backgroundColor: "#b34000",
+        color: "#fff",
+        padding: "10px 20px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        fontSize: "14px",
+        fontWeight: 500,
+      }}
+    >
+      <span>
+        👤 Mode impersonation — Vous consultez le compte de{" "}
+        <strong>{currentUser?.username || currentUser?.email || "..."}</strong>
+      </span>
+      <button
+        onClick={handleReturnToAdmin}
+        style={{
+          backgroundColor: "#fff",
+          color: "#b34000",
+          border: "none",
+          borderRadius: "4px",
+          padding: "6px 14px",
+          cursor: "pointer",
+          fontWeight: 700,
+          fontSize: "13px",
+        }}
+      >
+        ↩ Reprendre mon compte admin
+      </button>
+    </div>
+  );
+};

--- a/apps/client/src/components/Backend/screens/Admin/AdminUsers/UserDetailsModal/UserDetailsModal.tsx
+++ b/apps/client/src/components/Backend/screens/Admin/AdminUsers/UserDetailsModal/UserDetailsModal.tsx
@@ -5,6 +5,7 @@ import {
   type Id,
   RoleName,
 } from "@refugies-info/api-types";
+import Cookies from "js-cookie";
 import { logger } from "logger";
 import moment from "moment";
 import "moment/locale/fr";
@@ -23,8 +24,10 @@ import { setAllUsersActionsCreator } from "~/services/AllUsers/allUsers.actions"
 import { allUsersSelector, userSelector } from "~/services/AllUsers/allUsers.selector";
 import { LoadingStatusKey } from "~/services/LoadingStatus/loadingStatus.actions";
 import { isLoadingSelector } from "~/services/LoadingStatus/loadingStatus.selectors";
+import { userDetailsSelector } from "~/services/User/user.selectors";
 import type { Event } from "~/types/interface";
 import API from "~/utils/API";
+import { getAuthToken, setAuthToken } from "~/utils/authToken";
 import { colors } from "~/utils/colors";
 import { LogList } from "../../Logs/LogList";
 import { DetailsModal } from "../../sharedComponents/DetailsModal";
@@ -53,6 +56,7 @@ export const UserDetailsModal: React.FunctionComponent<Props> = (props: Props) =
   const [selectedUserId, setSelectedUserId] = useState<Id | null>(props.selectedUserId);
 
   const allUsers = useSelector(allUsersSelector);
+  const currentAdmin = useSelector(userDetailsSelector);
   const userFromStore = useSelector(userSelector(selectedUserId));
   const [adminComments, setAdminComments] = useState<string>(userFromStore?.adminComments || "");
   const [infosSaved, setInfosSaved] = useState(false);
@@ -194,6 +198,25 @@ export const UserDetailsModal: React.FunctionComponent<Props> = (props: Props) =
     }
   };
 
+  const handleImpersonate = async () => {
+    if (!userFromStore) return;
+    try {
+      const { token } = await API.impersonateUser(userFromStore._id);
+      const adminToken = getAuthToken();
+      if (adminToken) {
+        Cookies.set("impersonation-admin-token", adminToken, {
+          expires: 1,
+          sameSite: "strict",
+          secure: window.location.protocol === "https:",
+        });
+      }
+      setAuthToken(token);
+      window.location.reload();
+    } catch (error) {
+      handleApiError({ text: "Erreur lors de l'impersonation" });
+    }
+  };
+
   const onDeleteClick = async () => {
     try {
       if (userFromStore) {
@@ -265,6 +288,11 @@ export const UserDetailsModal: React.FunctionComponent<Props> = (props: Props) =
       }
       rightHead={
         <>
+          {userFromStore && currentAdmin?._id?.toString() !== userFromStore._id?.toString() && (
+            <FButton className="me-2" type="dark" name="person-outline" onClick={handleImpersonate}>
+              Se connecter en tant que
+            </FButton>
+          )}
           {userFromStore && (
             <FButton
               className="me-2"

--- a/apps/client/src/pages/backend/[...backend].tsx
+++ b/apps/client/src/pages/backend/[...backend].tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { Route, Router, Switch } from "react-router-dom";
 import { Spinner } from "reactstrap";
 import { getPath } from "routes";
+import { ImpersonateBanner } from "~/components/Backend/ImpersonateBanner/ImpersonateBanner";
 import { type BackendRouteType, backendRoutes } from "~/components/Backend/screens/routes";
 import UnauthorizedAccess from "~/components/Navigation/UnauthorizedAccess/UnauthorizedAccess";
 import SEO from "~/components/Seo";
@@ -83,6 +84,7 @@ const Backend = () => {
   return (
     <>
       <SEO title="Administration" />
+      <ImpersonateBanner />
       {state === "loading" && (
         <div className={styles.spinner_container}>
           <Spinner color="success" />

--- a/apps/client/src/utils/API.ts
+++ b/apps/client/src/utils/API.ts
@@ -47,6 +47,7 @@ import type {
   GetUserStatisticsResponse,
   GetWidgetResponse,
   Id,
+  ImpersonateResponse,
   ImprovementsRequest,
   IsInContactResponse,
   LoginRequest,
@@ -222,6 +223,12 @@ const API = {
   deleteUser: (query: Id): Promise<null> => {
     const headers = getHeaders();
     return instance.delete<any, null>(`/user/${query}`, { headers }).then(() => null);
+  },
+  impersonateUser: (userId: Id): Promise<ImpersonateResponse> => {
+    const headers = getHeaders();
+    return instance
+      .post<any, APIResponse<ImpersonateResponse>>(`/user/${userId}/impersonate`, {}, { headers })
+      .then((response) => response.data.data);
   },
   getUserContributions: (): Promise<GetUserContributionsResponse> => {
     const headers = getHeaders();

--- a/apps/server/src/controllers/userController.ts
+++ b/apps/server/src/controllers/userController.ts
@@ -9,6 +9,7 @@ import type {
   GetUserFavoritesResponse,
   GetUserInfoResponse,
   GetUserStatisticsResponse,
+  ImpersonateResponse,
   LoginRequest,
   LoginResponse,
   NewPasswordRequest,
@@ -53,6 +54,7 @@ import { getActiveUsers } from "~/workflows/users/getActiveUsers";
 import { getAllUsers } from "~/workflows/users/getAllUsers";
 import { getFiguresOnUsers } from "~/workflows/users/getFiguresOnUsers";
 import { getUserFavoritesInLocale } from "~/workflows/users/getUserFavoritesInLocale";
+import { impersonateUser } from "~/workflows/users/impersonateUser";
 import { login } from "~/workflows/users/login";
 import { register } from "~/workflows/users/register";
 import { resetPassword } from "~/workflows/users/resetPassword";
@@ -240,5 +242,16 @@ export class UserController extends Controller {
   public async deleteMyAccount(@Request() request: IRequest): Response {
     await deleteMyAccount(request.user);
     return { text: "success" };
+  }
+
+  @Post("/{id}/impersonate")
+  @Security({ jwt: ["admin"] })
+  public async impersonateUser(
+    @Path() id: string,
+    @Request() request: IRequest,
+  ): ResponseWithData<ImpersonateResponse> {
+    validateId(id, "user");
+    const data = await impersonateUser(request.userId.toString(), id);
+    return { text: "success", data };
   }
 }

--- a/apps/server/src/workflows/users/impersonateUser/impersonateUser.ts
+++ b/apps/server/src/workflows/users/impersonateUser/impersonateUser.ts
@@ -1,0 +1,31 @@
+import type { ImpersonateResponse } from "@refugies-info/api-types";
+import { UserModel } from "@refugies-info/mongo";
+import logger from "~/logger";
+
+export const impersonateUser = async (
+  adminId: string,
+  targetUserId: string,
+): Promise<ImpersonateResponse> => {
+  logger.info("[impersonateUser] admin impersonating user", {
+    adminId,
+    targetUserId,
+  });
+
+  const user = await UserModel.findById(targetUserId).populate("roles");
+  if (!user) throw new Error("USER_NOT_FOUND");
+
+  if (user.status !== "Actif") throw new Error("USER_NOT_ACTIVE");
+
+  const isTargetAdmin = (user.roles as any[])?.some((r) => r.nom === "Admin");
+  if (isTargetAdmin) throw new Error("CANNOT_IMPERSONATE_ADMIN");
+
+  const token = user.getToken();
+
+  logger.info("[impersonateUser] impersonation token generated", {
+    adminId,
+    targetUserId,
+    targetUsername: user.username || user.email,
+  });
+
+  return { token };
+};

--- a/apps/server/src/workflows/users/impersonateUser/index.ts
+++ b/apps/server/src/workflows/users/impersonateUser/index.ts
@@ -1,0 +1,1 @@
+export { impersonateUser } from "./impersonateUser";

--- a/packages/api-types/src/modules/user.ts
+++ b/packages/api-types/src/modules/user.ts
@@ -171,6 +171,13 @@ export interface LoginResponse {
 }
 
 /**
+ * @url POST /user/:userId/impersonate
+ */
+export interface ImpersonateResponse {
+  token: string;
+}
+
+/**
  * @url GET /user/actives
  */
 export interface GetActiveUsersResponse {


### PR DESCRIPTION
## 🎯 Objectif

Permettre aux admins de basculer temporairement vers le compte d'un autre utilisateur pour debugger et faire de la QA, sans avoir besoin de leurs credentials. Le tout avec un cookie de retour propre et une bannière bien visible.

## 📋 Changements

### Types (`packages/api-types`)
- Ajout `ImpersonateResponse { token: string }` dans `user.ts`

### Backend (`apps/server`)
- Nouveau workflow `impersonateUser` : génère un JWT au nom de l'user cible via `user.getToken()`
- Nouveau endpoint `POST /user/:id/impersonate` — protégé `@Security({ jwt: ["admin"] })`

**Sécurité :**
- `validateId()` sur le `targetUserId` → protection NoSQL injection
- Bloque l'impersonation d'un autre admin (`roles.nom === "Admin"`)
- Bloque l'impersonation d'un user non-Actif (`status !== "Actif"`)
- Audit logging : `adminId`, `targetUserId`, `targetUsername` loggués à chaque impersonation

### Frontend (`apps/client`)
- `API.impersonateUser(userId)` dans `API.ts`
- Bouton **"Se connecter en tant que"** dans `UserDetailsModal` — masqué si l'admin essaie de s'impersonner lui-même
- Cookie `impersonation-admin-token` : sauvegarde le token admin pour retour, TTL 1 jour, `sameSite: strict`, `secure: true` en HTTPS
- Nouveau composant `ImpersonateBanner` : bannière fixe en bas de page pendant la session impersonation, avec bouton "Reprendre mon compte admin"
- Fix hydratation SSR : cookie lu dans `useEffect` pour éviter le mismatch serveur/client

## 🧪 Comment tester

1. `pnpm dev:server` + `pnpm dev:client`
2. Se connecter en admin → Backoffice → Admin → Utilisateurs
3. Cliquer sur un user non-admin → bouton **"Se connecter en tant que"** dans la modale
4. → Rechargement, bannière rouge en bas : "Mode impersonation — Vous consultez le compte de [username]"
5. Naviguer librement (Mes fiches, Mon profil, etc.) en tant que cet user
6. Cliquer "↩ Reprendre mon compte admin" → retour propre sur le compte admin
7. Vérifier que le bouton est absent si on ouvre sa propre fiche utilisateur
8. Vérifier qu'on ne peut pas impersonner un autre admin (bouton absent)

**Cas aux limites à vérifier :**
- User `Exclu` ou `Supprimé` → pas de bouton impersonation
- Admin qui essaie d'impersonner un admin → bouton absent (côté client) + 500 (côté serveur si appel direct)

## ✅ Checklist review

- [ ] Endpoint admin-only bien protégé
- [ ] Cookie token admin : pas de leak XSS (sameSite + secure)
- [ ] Audit logs OK (voir logs serveur)
- [ ] Pas d'accès à la bannière pour les non-admins
- [ ] Retour propre au compte admin (ancien token restauré, cookie supprimé)
