### PR TITLE
fix(client): include administrationName in translation reconstruction for démarches

### DIFF
--- a/apps/client/src/lib/dispositif/getTranslationPageData.ts
+++ b/apps/client/src/lib/dispositif/getTranslationPageData.ts
@@ -24,6 +24,9 @@ const buildTranslationsObject = (
           why: dispositif.why || {},
           how: dispositif.how || {},
           next: dispositif.next || {},
+          ...(dispositif.administration?.name != null
+            ? { administrationName: dispositif.administration.name }
+            : {}),
         },
       },
       toReview: [],


### PR DESCRIPTION
## Summary

- **Root cause**: After an expert publishes a translation, `validateTranslation` deletes all Traduction documents for that language. On the next visit to the translation page, `buildTranslationsObject` reconstructs a fake traduction object from the published dispositif content — but it was missing `administrationName`, which démarches use for the "Avec" field.
- **Fix**: Conditionally spread `administrationName` from `dispositif.administration.name` into the reconstructed content, restoring the correct "Validé" status for the "Avec" field on démarches.

Fixes RI-1177.

## Test plan

- [x] Open a démarche that has been fully translated and published in at least one language
- [x] As an expert, navigate to the translation page for that démarche in a translated language
- [x] Verify the "Avec" field shows "Validé" instead of "À traduire"
- [x] Verify the same field on a dispositif (not démarche) is unaffected

👾 Generated with [Letta Code](https://letta.com)