### PR TITLE
fix(server): add MongoDB Performance Advisor indexes for logs, indicators, dispositifs

### DIFF
--- a/migrations/1776080086167_AddPerformanceAdvisorIndexes2.ts
+++ b/migrations/1776080086167_AddPerformanceAdvisorIndexes2.ts
@@ -1,0 +1,68 @@
+import type { MigrationInterface } from "mongo-migrate-ts";
+import type { Db } from "mongodb";
+
+/**
+ * Adds indexes recommended by MongoDB Atlas Performance Advisor (April 2026).
+ *
+ * Collections affected: logs, indicators, dispositifs
+ *
+ * These are the top suggestions from the Performance Advisor, sorted by expected impact:
+ *   1. logs: { objectId, created_at } — reduces 269.5 MB disk reads at 1.46 queries/hour
+ *   2. indicators: { dispositifId, language, userId } — 15.33 exec/hour, 133037 docs scanned per 1 returned
+ *   3. dispositifs: { mainSponsor, status } — filtering by sponsor + status
+ *   4. dispositifs: { status, typeContenu, nbVues } — sort by views within type+status
+ */
+export class AddPerformanceAdvisorIndexes21776080086167 implements MigrationInterface {
+  public async up(db: Db): Promise<void> {
+    // Index 1: logs — objectId + created_at (DESC)
+    // Query pattern: Fetch logs for a given object, sorted by creation date
+    // Impact: TOP SUGGESTION — up to 269.5 MB disk reads saved, 1314ms avg execution time
+    await db
+      .collection("logs")
+      .createIndex({ objectId: 1, created_at: -1 }, { name: "objectId_1_created_at_-1" });
+
+    // Index 2: indicators — dispositifId + language + userId
+    // Query pattern: Look up indicator for a specific dispositif/language/user combination
+    // Impact: 15.33 exec/hour, 133037 docs scanned per 1 returned (very high ratio)
+    await db
+      .collection("indicators")
+      .createIndex(
+        { dispositifId: 1, language: 1, userId: 1 },
+        { name: "dispositifId_1_language_1_userId_1" },
+      );
+
+    // Index 3: dispositifs — mainSponsor + status
+    // Query pattern: Fetch dispositifs filtered by their main sponsor and publication status
+    // Impact: 171ms avg execution time
+    await db
+      .collection("dispositifs")
+      .createIndex({ mainSponsor: 1, status: 1 }, { name: "mainSponsor_1_status_1" });
+
+    // Index 4: dispositifs — status + typeContenu + nbVues (DESC)
+    // Query pattern: List dispositifs of a given type and status, sorted by view count
+    // Impact: 502ms avg execution time
+    await db
+      .collection("dispositifs")
+      .createIndex(
+        { status: 1, typeContenu: 1, nbVues: -1 },
+        { name: "status_1_typeContenu_1_nbVues_-1" },
+      );
+  }
+
+  public async down(db: Db): Promise<void> {
+    const INDEX_NOT_FOUND_CODE = 27;
+    const drop = async (collection: string, indexName: string) => {
+      await db
+        .collection(collection)
+        .dropIndex(indexName)
+        .catch((err: any) => {
+          if (err?.code !== INDEX_NOT_FOUND_CODE) throw err;
+        });
+    };
+
+    await drop("logs", "objectId_1_created_at_-1");
+    await drop("indicators", "dispositifId_1_language_1_userId_1");
+    await drop("dispositifs", "mainSponsor_1_status_1");
+    await drop("dispositifs", "status_1_typeContenu_1_nbVues_-1");
+  }
+}

--- a/migrations/1776080086167_AddPerformanceAdvisorIndexes2.ts
+++ b/migrations/1776080086167_AddPerformanceAdvisorIndexes2.ts
@@ -51,12 +51,14 @@ export class AddPerformanceAdvisorIndexes21776080086167 implements MigrationInte
 
   public async down(db: Db): Promise<void> {
     const INDEX_NOT_FOUND_CODE = 27;
+    const NAMESPACE_NOT_FOUND_CODE = 26; // collection deleted/renamed before rollback
     const drop = async (collection: string, indexName: string) => {
       await db
         .collection(collection)
         .dropIndex(indexName)
         .catch((err: any) => {
-          if (err?.code !== INDEX_NOT_FOUND_CODE) throw err;
+          if (err?.code !== INDEX_NOT_FOUND_CODE && err?.code !== NAMESPACE_NOT_FOUND_CODE)
+            throw err;
         });
     };
 


### PR DESCRIPTION
## Summary

Adds 4 MongoDB indexes recommended by Atlas Performance Advisor (April 2026), sorted by impact:

| Collection | Index | Avg Exec Time | Docs Scanned/Returned | Impact |
|---|---|---|---|---|
| `logs` | `{ objectId: 1, created_at: -1 }` | 1314 ms | 1182686 / 78 | **TOP** — 269.5 MB disk reads saved |
| `indicators` | `{ dispositifId: 1, language: 1, userId: 1 }` | 414 ms | 133037 / 1 | 15.33 exec/hour |
| `dispositifs` | `{ mainSponsor: 1, status: 1 }` | 171 ms | 1319 / 84 | — |
| `dispositifs` | `{ status: 1, typeContenu: 1, nbVues: -1 }` | 502 ms | 1037 / 1 | — |

## Test plan

- [ ] `pnpm migrate up` on staging after merge — verify indexes are created without errors
- [ ] `pnpm migrate down` can be run for rollback (drops only the named indexes)
- [ ] Monitor Atlas Performance Advisor after deployment — suggestions should disappear

👾 Generated with [Letta Code](https://letta.com)