### PR TITLE
fix(server): cache translation statistics counter and add error handling

### DIFF
--- a/apps/server/src/modules/adminOptions/adminOptions.repository.ts
+++ b/apps/server/src/modules/adminOptions/adminOptions.repository.ts
@@ -13,7 +13,7 @@ const WORDS_TRANSLATED_KEY = "nbWordsTranslated";
 
 /** Read the pre-computed translated-words counter. Returns 0 if not yet initialised. */
 export const getWordsTranslatedCounter = async (): Promise<number> => {
-  const doc = await AdminOptionsModel.findOne({ key: WORDS_TRANSLATED_KEY }).lean();
+  const doc = await AdminOptionsModel.findOne({ key: WORDS_TRANSLATED_KEY }).cacheQuery();
   return (doc?.value as number) ?? 0;
 };
 

--- a/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
+++ b/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
@@ -60,20 +60,28 @@ const getTranslationStatistics = async ({
     }
   }
 
-  // nbActiveTranslators
+  // nbActiveTranslators — single-pass O(U×S + L) instead of O(L×U×S)
   if (noFacet || facets.includes("nbActiveTranslators")) {
     const now = Date.now();
     const activeTranslators = trads.filter(
       (user) => now - new Date(user.last_connected).getTime() <= ONE_MONTH,
     );
+
+    const languageCounts = new Map<string, number>();
+    for (const user of activeTranslators) {
+      for (const lang of user.selectedLanguages) {
+        const id = lang._id?.toString();
+        if (id) {
+          languageCounts.set(id, (languageCounts.get(id) || 0) + 1);
+        }
+      }
+    }
+
     const nbActiveTranslators = languages
       .filter((ln: any) => ln.i18nCode !== "fr")
       .map((language: any) => {
-        const languageId = language._id.toString();
-        const count = activeTranslators.filter((user) =>
-          user.selectedLanguages.map((l: any) => l._id.toString()).includes(languageId.toString()),
-        ).length;
-        return { languageId, count };
+        const languageId = language._id?.toString();
+        return { languageId, count: languageId ? languageCounts.get(languageId) || 0 : 0 };
       });
     stats.nbActiveTranslators = nbActiveTranslators;
   }

--- a/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
+++ b/apps/server/src/workflows/translation/getTranslationStatistics/getTranslationStatistics.ts
@@ -14,54 +14,71 @@ const ONE_MONTH = 30 * 24 * 60 * 60 * 1000;
 const hasRole = (user: { roles: { nom: string }[] }, roleName: string): boolean =>
   Array.isArray(user.roles) && user.roles.some((role) => role.nom === roleName);
 
-const getTranslationStatistics = ({
+const getTranslationStatistics = async ({
   facets = [],
-}: TranslationStatisticsRequest): Promise<Statistics> =>
-  Promise.all([getActiveLanguagesFromDB(), getUsersForTranslationStats()]).then(
-    async ([languages, users]) => {
-      logger.info("[getTranslationStatistics] get translations statistics");
-      const noFacet = facets.length === 0;
-      const stats: Statistics = {};
-      const trads = users.filter((user) => hasRole(user, RoleName.TRAD));
+}: TranslationStatisticsRequest): Promise<Statistics> => {
+  logger.info("[getTranslationStatistics] get translations statistics");
+  const noFacet = facets.length === 0;
+  const stats: Statistics = {};
 
-      // nbTranslators
-      if (noFacet || facets.includes("nbTranslators") || facets.includes("nbActiveTranslators")) {
-        stats.nbTranslators = trads.length;
-      }
+  // Users + languages are cached via speedgoose — failures here return partial results
+  let languages: Awaited<ReturnType<typeof getActiveLanguagesFromDB>> = [];
+  let users: Awaited<ReturnType<typeof getUsersForTranslationStats>> = [];
+  try {
+    [languages, users] = await Promise.all([
+      getActiveLanguagesFromDB(),
+      getUsersForTranslationStats(),
+    ]);
+  } catch (error: any) {
+    logger.error("[getTranslationStatistics] failed to fetch users/languages", {
+      error: error.message,
+    });
+  }
 
-      // nbRedactors
-      if (noFacet || facets.includes("nbRedactors")) {
-        const redactors = users.filter((user) => hasRole(user, RoleName.CONTRIB));
-        stats.nbRedactors = redactors.length;
-      }
+  const trads = users.filter((user) => hasRole(user, RoleName.TRAD));
 
-      // nbWordsTranslated — reads pre-computed stored counter (O(1), no full scan)
-      if (noFacet || facets.includes("nbWordsTranslated")) {
-        stats.nbWordsTranslated = await getWordsTranslatedCounter();
-      }
+  // nbTranslators
+  if (noFacet || facets.includes("nbTranslators") || facets.includes("nbActiveTranslators")) {
+    stats.nbTranslators = trads.length;
+  }
 
-      // nbActiveTranslators
-      if (noFacet || facets.includes("nbActiveTranslators")) {
-        const now = Date.now();
-        const activeTranslators = trads.filter(
-          (user) => now - new Date(user.last_connected).getTime() <= ONE_MONTH,
-        );
-        const nbActiveTranslators = languages
-          .filter((ln: any) => ln.i18nCode !== "fr")
-          .map((language: any) => {
-            const languageId = language._id.toString();
-            const count = activeTranslators.filter((user) =>
-              user.selectedLanguages
-                .map((l: any) => l._id.toString())
-                .includes(languageId.toString()),
-            ).length;
-            return { languageId, count };
-          });
-        stats.nbActiveTranslators = nbActiveTranslators;
-      }
+  // nbRedactors
+  if (noFacet || facets.includes("nbRedactors")) {
+    const redactors = users.filter((user) => hasRole(user, RoleName.CONTRIB));
+    stats.nbRedactors = redactors.length;
+  }
 
-      return stats;
-    },
-  );
+  // nbWordsTranslated — reads pre-computed stored counter (O(1), cached via speedgoose)
+  if (noFacet || facets.includes("nbWordsTranslated")) {
+    try {
+      stats.nbWordsTranslated = await getWordsTranslatedCounter();
+    } catch (error: any) {
+      logger.error("[getTranslationStatistics] failed to fetch words translated counter", {
+        error: error.message,
+      });
+      stats.nbWordsTranslated = 0;
+    }
+  }
+
+  // nbActiveTranslators
+  if (noFacet || facets.includes("nbActiveTranslators")) {
+    const now = Date.now();
+    const activeTranslators = trads.filter(
+      (user) => now - new Date(user.last_connected).getTime() <= ONE_MONTH,
+    );
+    const nbActiveTranslators = languages
+      .filter((ln: any) => ln.i18nCode !== "fr")
+      .map((language: any) => {
+        const languageId = language._id.toString();
+        const count = activeTranslators.filter((user) =>
+          user.selectedLanguages.map((l: any) => l._id.toString()).includes(languageId.toString()),
+        ).length;
+        return { languageId, count };
+      });
+    stats.nbActiveTranslators = nbActiveTranslators;
+  }
+
+  return stats;
+};
 
 export default getTranslationStatistics;


### PR DESCRIPTION
## Summary
- **Cache `getWordsTranslatedCounter()`** with speedgoose (`.cacheQuery()`) — was the only uncached DB call in the `/traduction/statistics` endpoint, hitting MongoDB directly on every request
- **Add try/catch error handling** to `getTranslationStatistics` workflow — DB failures now return partial results (`{}` / `0`) instead of propagating as 500s
- Prevents ISR revalidation stampedes (9 requests in 6 seconds) from cascading into 500 bursts

## Root cause
`getWordsTranslatedCounter()` used `.lean()` (direct DB read) while every other query in the same endpoint used `.cacheQuery()`. Any DB hiccup or timeout crashed the entire endpoint due to zero error handling.

## Test plan
- [x] `pnpm lint:server` — passes
- [x] `pnpm check:types:server` — passes (tsoa warnings are pre-existing)
- [x] `pnpm test:server` — 31 suites, 162 tests pass
- [ ] Monitor staging logs for `/traduction/statistics` 500s after deploy

Closes RI-1190

🤖 Generated with [Letta Code](https://letta.com)