### PR TITLE
fix(server): centralize Mongoose Map handling to fix autosave 500 error

### DIFF
--- a/apps/server/src/libs/formatForAlgolia.ts
+++ b/apps/server/src/libs/formatForAlgolia.ts
@@ -1,5 +1,6 @@
 import type { Dispositif, Langue, Need, NeedId, Theme, ThemeId } from "@refugies-info/mongo";
 import { get } from "lodash";
+import { mapToPlainObject } from "~/libs/mongooseMaps";
 import { getDispositifMainSponsor } from "~/modules/dispositif/dispositif.business";
 import type { AlgoliaObject } from "~/types/interface";
 
@@ -7,16 +8,11 @@ const extractValuesPerLanguage = (translations: any, path: string, keyPrefix: st
   if (!translations) return {};
   const normalizedObject: Record<string, string> = {};
 
-  if (typeof translations.entries === "function") {
-    for (const [ln, translation] of translations.entries()) {
-      const value = get(translation, path);
-      normalizedObject[`${keyPrefix}_${ln}`] = value;
-    }
-  } else {
-    for (const [ln, translation] of Object.entries(translations)) {
-      const value = get(translation, path);
-      normalizedObject[`${keyPrefix}_${ln}`] = value;
-    }
+  // Use centralized utility to handle both Map and plain object
+  const plainTranslations = mapToPlainObject(translations);
+  for (const [ln, translation] of Object.entries(plainTranslations)) {
+    const value = get(translation, path);
+    normalizedObject[`${keyPrefix}_${ln}`] = value;
   }
   return normalizedObject;
 };

--- a/apps/server/src/libs/mongooseMaps.ts
+++ b/apps/server/src/libs/mongooseMaps.ts
@@ -25,7 +25,7 @@ export const isMongooseMap = (value: unknown): boolean => {
  * @param value - The value to convert (Map or plain object)
  * @returns A plain object copy with all key-value pairs
  */
-export const mapToPlainObject = <T = unknown>(
+export const mapToPlainObject = <T = any>(
   value: Record<string, T> | Map<string, T> | undefined,
 ): Record<string, T> => {
   if (!value) return {};
@@ -48,7 +48,7 @@ export const mapToPlainObject = <T = unknown>(
  * @param key - The key to look up
  * @returns The value at the key, or undefined if not found
  */
-export const getMapValue = <T = unknown>(
+export const getMapValue = <T = any>(
   value: Record<string, T> | Map<string, T> | undefined,
   key: string,
 ): T | undefined => {

--- a/apps/server/src/libs/mongooseMaps.ts
+++ b/apps/server/src/libs/mongooseMaps.ts
@@ -8,16 +8,22 @@
 
 /**
  * Check if a value is a Mongoose Map (has entries method)
+ * Checks for both `entries` and `get` methods and excludes Arrays
+ * to avoid false positives from Arrays, Sets, and other iterables.
  */
 export const isMongooseMap = (value: unknown): boolean => {
-  return typeof (value as any)?.entries === "function";
+  return (
+    !Array.isArray(value) &&
+    typeof (value as any)?.entries === "function" &&
+    typeof (value as any)?.get === "function"
+  );
 };
 
 /**
  * Convert a Mongoose Map or plain object to a plain JavaScript object
  *
  * @param value - The value to convert (Map or plain object)
- * @returns A plain object with all key-value pairs
+ * @returns A plain object copy with all key-value pairs
  */
 export const mapToPlainObject = <T = unknown>(
   value: Record<string, T> | Map<string, T> | undefined,
@@ -28,7 +34,11 @@ export const mapToPlainObject = <T = unknown>(
     return Object.fromEntries((value as Map<string, T>).entries());
   }
 
-  return value as Record<string, T>;
+  // Always return a copy to avoid in-place mutations on the original
+  // Use .toObject() for Mongoose documents/subdocuments, otherwise spread
+  return (
+    typeof (value as any)?.toObject === "function" ? (value as any).toObject() : { ...value }
+  ) as Record<string, T>;
 };
 
 /**

--- a/apps/server/src/libs/mongooseMaps.ts
+++ b/apps/server/src/libs/mongooseMaps.ts
@@ -1,0 +1,70 @@
+/**
+ * Utility functions for handling Mongoose Map types
+ *
+ * Mongoose stores Maps as subdocuments with internal tracking properties.
+ * These utilities safely convert Maps to plain JavaScript objects and handle
+ * both Map and plain object cases uniformly.
+ */
+
+/**
+ * Check if a value is a Mongoose Map (has entries method)
+ */
+export const isMongooseMap = (value: unknown): boolean => {
+  return typeof (value as any)?.entries === "function";
+};
+
+/**
+ * Convert a Mongoose Map or plain object to a plain JavaScript object
+ *
+ * @param value - The value to convert (Map or plain object)
+ * @returns A plain object with all key-value pairs
+ */
+export const mapToPlainObject = <T = unknown>(
+  value: Record<string, T> | Map<string, T> | undefined,
+): Record<string, T> => {
+  if (!value) return {};
+
+  if (isMongooseMap(value)) {
+    return Object.fromEntries((value as Map<string, T>).entries());
+  }
+
+  return value as Record<string, T>;
+};
+
+/**
+ * Get a value from a Mongoose Map or plain object by key
+ *
+ * @param value - The Map or plain object
+ * @param key - The key to look up
+ * @returns The value at the key, or undefined if not found
+ */
+export const getMapValue = <T = unknown>(
+  value: Record<string, T> | Map<string, T> | undefined,
+  key: string,
+): T | undefined => {
+  if (!value) return undefined;
+
+  if (isMongooseMap(value)) {
+    return (value as Map<string, T>).get(key);
+  }
+
+  return (value as Record<string, T>)[key];
+};
+
+/**
+ * Get all keys from a Mongoose Map or plain object
+ *
+ * @param value - The Map or plain object
+ * @returns Array of keys
+ */
+export const getMapKeys = (
+  value: Record<string, unknown> | Map<string, unknown> | undefined,
+): string[] => {
+  if (!value) return [];
+
+  if (isMongooseMap(value)) {
+    return Array.from((value as Map<string, unknown>).keys());
+  }
+
+  return Object.keys(value);
+};

--- a/apps/server/src/modules/dispositif/dispositif.business.ts
+++ b/apps/server/src/modules/dispositif/dispositif.business.ts
@@ -3,6 +3,7 @@ import type { Dispositif, Need, Structure, Theme, User } from "@refugies-info/mo
 import { isDocument, isDocumentArray } from "@refugies-info/mongo";
 import { get, has } from "lodash";
 import { MustBePopulatedError } from "~/errors";
+import { getMapKeys, getMapValue, isMongooseMap } from "~/libs/mongooseMaps";
 
 export const getDispositifMainSponsor = (dispositif: Dispositif): Structure => {
   if (!dispositif.mainSponsor || !isDocument(dispositif.mainSponsor as any)) {
@@ -58,8 +59,9 @@ export const isDemarche = (dispositif: Dispositif): boolean => {
 
 export const isDispositifTranslatedIn = (dispositif: any, ln: Languages) => {
   if (!dispositif.translations) return false;
-  if (typeof (dispositif.translations as any).has === "function") {
-    return (dispositif.translations as any).has(ln);
+  // Use centralized utility to handle both Map and plain object
+  if (isMongooseMap(dispositif.translations)) {
+    return (dispositif.translations as Map<string, unknown>).has(ln);
   }
   return has(dispositif.translations, ln);
 };
@@ -82,11 +84,8 @@ export const getDispositifTranslation = (dispositif: any, ln: Languages, fallbac
 
   if (!targetLang) return undefined;
 
-  if (typeof (dispositif.translations as any).get === "function") {
-    return (dispositif.translations as any).get(targetLang);
-  }
-
-  return (dispositif.translations as any)[targetLang];
+  // Use centralized utility to handle both Map and plain object
+  return getMapValue(dispositif.translations, targetLang);
 };
 
 /**
@@ -107,8 +106,6 @@ export const getDispositifTranslated = (
 
 export const getAvailableLanguages = (dispositif: any): string[] => {
   if (!dispositif.translations) return [];
-  if (typeof (dispositif.translations as any).keys === "function") {
-    return Array.from((dispositif.translations as any).keys());
-  }
-  return Object.keys(dispositif.translations);
+  // Use centralized utility to handle both Map and plain object
+  return getMapKeys(dispositif.translations);
 };

--- a/apps/server/src/workflows/dispositif/updateDispositif/updateDispositif.ts
+++ b/apps/server/src/workflows/dispositif/updateDispositif/updateDispositif.ts
@@ -40,7 +40,9 @@ const buildDispositifContent = (
   // content - use helper to handle both Map and plain object access
   const frTranslation = getDispositifTranslation(oldDispositif, "fr", true);
   // Convert to plain object to avoid Map subdocument issues
-  const content = mapToPlainObject(frTranslation?.content || {});
+  const content = mapToPlainObject(frTranslation?.content || {}) as
+    | DispositifContent
+    | DemarcheContent;
   // check isString to allow empty values
   if (isString(body.titreInformatif)) content.titreInformatif = body.titreInformatif;
   if (isString(body.titreMarque)) content.titreMarque = body.titreMarque;

--- a/apps/server/src/workflows/dispositif/updateDispositif/updateDispositif.ts
+++ b/apps/server/src/workflows/dispositif/updateDispositif/updateDispositif.ts
@@ -9,6 +9,7 @@ import { type Dispositif, ObjectId, type StructureId, type User } from "@refugie
 import { isString, omit } from "lodash";
 import { checkUserIsAuthorizedToModifyDispositif } from "~/libs/checkAuthorizations";
 import { isToday } from "~/libs/isToday";
+import { mapToPlainObject } from "~/libs/mongooseMaps";
 import { countDispositifWords } from "~/libs/wordCounter";
 import logger from "~/logger";
 import {
@@ -38,7 +39,8 @@ const buildDispositifContent = (
 ): TranslationContent => {
   // content - use helper to handle both Map and plain object access
   const frTranslation = getDispositifTranslation(oldDispositif, "fr", true);
-  const content = { ...frTranslation?.content };
+  // Convert to plain object to avoid Map subdocument issues
+  const content = mapToPlainObject(frTranslation?.content || {});
   // check isString to allow empty values
   if (isString(body.titreInformatif)) content.titreInformatif = body.titreInformatif;
   if (isString(body.titreMarque)) content.titreMarque = body.titreMarque;
@@ -107,10 +109,7 @@ export const updateDispositif = async (
   const translationContent = buildDispositifContent(body, oldDispositif);
 
   // Convert translations to plain object (handles both Map and plain object)
-  const existingTranslations =
-    typeof (oldDispositif.translations as any)?.entries === "function"
-      ? Object.fromEntries((oldDispositif.translations as any).entries())
-      : oldDispositif.translations || {};
+  const existingTranslations = mapToPlainObject(oldDispositif.translations);
 
   const editedDispositif: Partial<Dispositif> = {
     lastModificationAuthor: user._id,


### PR DESCRIPTION
## Summary
- Create centralized `mongooseMaps.ts` utility with `mapToPlainObject`, `getMapValue`, `getMapKeys`, and `isMongooseMap` functions
- Refactor `updateDispositif.ts` to use centralized utilities, fixing the 500 error on `PATCH /dispositifs/{id}`
- Update `dispositif.business.ts` translation helpers to use centralized utilities
- Update `formatForAlgolia.ts` to use `mapToPlainObject`

## Root Cause
The `translations` field is stored as a Mongoose Map. When `buildDispositifContent` spread `frTranslation?.content`, it failed because Map subdocuments contain internal tracking properties that don't spread correctly. The fix ensures Maps are converted to plain objects before any manipulation.

## Test plan
- [ ] Test auto-save on the affected demarche (ID: `5dc2e40c2e9859001680b916`)
- [ ] Verify existing translation workflows still work correctly
- [ ] Check Algolia indexing after content update

Fixes: RI-1198

👾 Generated with [Letta Code](https://letta.com)