### PR TITLE
refactor(server): harden mongoose map utility helpers

### DIFF
--- a/apps/server/src/libs/mongooseMaps.ts
+++ b/apps/server/src/libs/mongooseMaps.ts
@@ -13,6 +13,7 @@
  */
 export const isMongooseMap = (value: unknown): boolean => {
   return (
+    !!value &&
     !Array.isArray(value) &&
     typeof (value as any)?.entries === "function" &&
     typeof (value as any)?.get === "function"
@@ -30,15 +31,17 @@ export const mapToPlainObject = <T = any>(
 ): Record<string, T> => {
   if (!value) return {};
 
+  // Prefer Mongoose's own conversion for documents/subdocuments.
+  if (typeof (value as any)?.toObject === "function") {
+    return (value as any).toObject({ flattenMaps: true }) as Record<string, T>;
+  }
+
   if (isMongooseMap(value)) {
     return Object.fromEntries((value as Map<string, T>).entries());
   }
 
   // Always return a copy to avoid in-place mutations on the original
-  // Use .toObject() for Mongoose documents/subdocuments, otherwise spread
-  return (
-    typeof (value as any)?.toObject === "function" ? (value as any).toObject() : { ...value }
-  ) as Record<string, T>;
+  return { ...value } as Record<string, T>;
 };
 
 /**
@@ -77,4 +80,24 @@ export const getMapKeys = (
   }
 
   return Object.keys(value);
+};
+
+/**
+ * Check if a Mongoose Map or plain object has a key
+ *
+ * @param value - The Map or plain object
+ * @param key - The key to check
+ * @returns True if the key exists
+ */
+export const hasMapKey = (
+  value: Record<string, unknown> | Map<string, unknown> | undefined,
+  key: string,
+): boolean => {
+  if (!value) return false;
+
+  if (isMongooseMap(value)) {
+    return (value as Map<string, unknown>).has(key);
+  }
+
+  return Object.hasOwn(value, key);
 };

--- a/apps/server/src/modules/dispositif/dispositif.business.ts
+++ b/apps/server/src/modules/dispositif/dispositif.business.ts
@@ -1,9 +1,9 @@
 import { ContentType, type Languages } from "@refugies-info/api-types";
 import type { Dispositif, Need, Structure, Theme, User } from "@refugies-info/mongo";
 import { isDocument, isDocumentArray } from "@refugies-info/mongo";
-import { get, has } from "lodash";
+import { get } from "lodash";
 import { MustBePopulatedError } from "~/errors";
-import { getMapKeys, getMapValue, isMongooseMap } from "~/libs/mongooseMaps";
+import { getMapKeys, getMapValue, hasMapKey } from "~/libs/mongooseMaps";
 
 export const getDispositifMainSponsor = (dispositif: Dispositif): Structure => {
   if (!dispositif.mainSponsor || !isDocument(dispositif.mainSponsor as any)) {
@@ -59,11 +59,7 @@ export const isDemarche = (dispositif: Dispositif): boolean => {
 
 export const isDispositifTranslatedIn = (dispositif: any, ln: Languages) => {
   if (!dispositif.translations) return false;
-  // Use centralized utility to handle both Map and plain object
-  if (isMongooseMap(dispositif.translations)) {
-    return (dispositif.translations as Map<string, unknown>).has(ln);
-  }
-  return has(dispositif.translations, ln);
+  return hasMapKey(dispositif.translations, ln);
 };
 
 /**


### PR DESCRIPTION
## Summary
- harden `isMongooseMap` with an explicit non-null check (`!!value`) while keeping the existing array exclusion + `entries/get` checks
- update `mapToPlainObject` to prioritize Mongoose document conversion with `toObject({ flattenMaps: true })`
- add a new `hasMapKey` helper and refactor `isDispositifTranslatedIn` to use it (single source of truth for map/object key existence)

## Why
Gemini comments on the staging release PR suggested two non-blocking hardening improvements:
1. prefer flattened conversion when a Mongoose document/subdocument exposes `toObject`
2. centralize key-existence checks similarly to `getMapValue`/`getMapKeys`

This PR implements those improvements in a focused follow-up with no behavior change intended for existing flows.

## Test plan
- [x] `pnpm --dir apps/server run lint`
- [x] `pnpm --dir apps/server run check:types`

👾 Generated with [Letta Code](https://letta.com)