### PR TITLE
fix(server): reduce May 22 production 500 regressions

### DIFF
--- a/apps/server/src/connectors/brevo/sendSMS.test.ts
+++ b/apps/server/src/connectors/brevo/sendSMS.test.ts
@@ -1,0 +1,45 @@
+const mockSendTransacSms = jest.fn();
+
+jest.mock("@getbrevo/brevo", () => ({
+  BrevoClient: jest.fn().mockImplementation(() => ({
+    transactionalSms: {
+      sendTransacSms: mockSendTransacSms,
+    },
+  })),
+  BrevoError: class BrevoError extends Error {
+    statusCode?: number;
+
+    constructor(message: string, statusCode?: number) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
+jest.mock("~/logger");
+
+describe("Brevo sendSMS", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env.BREVO_API_KEY = "brevo-api-key";
+    process.env.SMS_SENDER = "+33757902900";
+
+    mockSendTransacSms.mockReturnValue({
+      withRawResponse: jest.fn().mockResolvedValue({ rawResponse: { status: 201 } }),
+    });
+  });
+
+  it("formats the sender as an international number without a leading zero", async () => {
+    const { sendSMS } = await import("./sendSMS");
+
+    await sendSMS("Bonjour", "06 12 34 56 78");
+
+    expect(mockSendTransacSms).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: "+33612345678",
+        sender: "33757902900",
+      }),
+    );
+  });
+});

--- a/apps/server/src/connectors/brevo/sendSMS.ts
+++ b/apps/server/src/connectors/brevo/sendSMS.ts
@@ -15,13 +15,19 @@ const e164 = (phone: string): string => {
   return phone;
 };
 
+const brevoSender = (sender: string): string => {
+  if (sender.startsWith("+")) return sender.slice(1);
+  if (/^00\d+$/.test(sender)) return sender.slice(2);
+  return sender;
+};
+
 export const sendSMS = async (text: string, phone: string): Promise<SendSMSResult> => {
   try {
     const { rawResponse } = await client.transactionalSms
       .sendTransacSms({
         content: text,
         recipient: e164(phone),
-        sender: SMS_SENDER.replace("+", "00"),
+        sender: brevoSender(SMS_SENDER || ""),
         organisationPrefix: "Réfugiés.info",
         unicodeEnabled: true, // Support arabic, emojis, etc.
       })

--- a/apps/server/src/errors.test.ts
+++ b/apps/server/src/errors.test.ts
@@ -1,0 +1,46 @@
+import type { Request, Response } from "express";
+import logger from "~/logger";
+import { serverErrorHandler } from "./errors";
+
+jest.mock("~/logger", () => ({
+  error: jest.fn(),
+}));
+
+const buildResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+};
+
+describe("serverErrorHandler", () => {
+  const nodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NODE_ENV = "production";
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = nodeEnv;
+  });
+
+  it("preserves HTTP 4xx status from generic request parsing errors", () => {
+    const err = Object.assign(new Error("stream ended unexpectedly"), { statusCode: 400 });
+    const req = { url: "/" } as Request;
+    const res = buildResponse();
+    const next = jest.fn();
+
+    serverErrorHandler(err, req, res, next);
+
+    expect(logger.error).toHaveBeenCalledWith("[serverErrorHandler] Unknown error", {
+      status: 400,
+      path: "/",
+      error: err,
+    });
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ message: "stream ended unexpectedly" });
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/errors.ts
+++ b/apps/server/src/errors.ts
@@ -52,10 +52,11 @@ export class InvalidRequestError extends APIError {
 }
 
 const getErrorStatus = (err: Error): number => {
-  const status = "status" in err ? err.status : undefined;
-  if (typeof status === "number" && status >= 400 && status < 600) return status;
+  const error = err as { status?: number; statusCode?: number };
+  if (typeof error.status === "number" && error.status >= 400 && error.status < 600)
+    return error.status;
 
-  const statusCode = "statusCode" in err ? err.statusCode : undefined;
+  const statusCode = error.statusCode;
   if (typeof statusCode === "number" && statusCode >= 400 && statusCode < 600) return statusCode;
 
   return 500;

--- a/apps/server/src/errors.ts
+++ b/apps/server/src/errors.ts
@@ -31,6 +31,10 @@ export class InternalError extends APIError {
   status = 500;
 }
 
+export class ServiceUnavailableError extends APIError {
+  status = 503;
+}
+
 export class UnauthorizedError extends APIError {
   status = 401;
 }
@@ -46,6 +50,16 @@ export class NotFoundError extends APIError {
 export class InvalidRequestError extends APIError {
   status = 400;
 }
+
+const getErrorStatus = (err: Error): number => {
+  const status = "status" in err ? err.status : undefined;
+  if (typeof status === "number" && status >= 400 && status < 600) return status;
+
+  const statusCode = "statusCode" in err ? err.statusCode : undefined;
+  if (typeof statusCode === "number" && statusCode >= 400 && statusCode < 600) return statusCode;
+
+  return 500;
+};
 
 /**
  * Returns the right error code depending on the type of the error
@@ -93,12 +107,13 @@ export const serverErrorHandler: ErrorRequestHandler = (
   }
 
   if (err instanceof Error) {
+    const status = getErrorStatus(err);
     logger.error("[serverErrorHandler] Unknown error", {
-      status: 500,
+      status,
       path: req.url,
       error: err,
     });
-    res.status(500).json({
+    res.status(status).json({
       message: err.message || "Internal Server Error",
     });
     return;

--- a/apps/server/src/modules/users/__tests__/user.service.test.ts
+++ b/apps/server/src/modules/users/__tests__/user.service.test.ts
@@ -102,6 +102,19 @@ describe("registerUser", () => {
     expect(addLog).toHaveBeenCalledWith(userId, "User", "Utilisateur créé : première connexion");
   });
 
+  it("allows SSO users without a password", async () => {
+    const user = new UserModel({
+      email: "sso@example.com",
+      firstName: "Ada",
+      password: null,
+      roles: [roleId],
+      status: "Actif",
+      last_connected: new Date(1466424490000),
+    });
+
+    await expect(user.validate()).resolves.toBeUndefined();
+  });
+
   afterEach(() => {
     jest.useRealTimers();
   });

--- a/apps/server/src/modules/users/users.repository.ts
+++ b/apps/server/src/modules/users/users.repository.ts
@@ -134,7 +134,7 @@ export const removeStructureOfUserInDB = (userId: UserId, structureId: Structure
 
 export const createUser = (user: {
   firstName: string;
-  password: string;
+  password: string | null;
   roles: Types.ObjectId[];
   status: string;
   last_connected: Date;

--- a/apps/server/src/workflows/sms/contentLink/contentLink.test.ts
+++ b/apps/server/src/workflows/sms/contentLink/contentLink.test.ts
@@ -1,5 +1,5 @@
 import type { ContentLinkRequest } from "@refugies-info/api-types";
-import { InternalError, NotFoundError } from "~/errors";
+import { NotFoundError, ServiceUnavailableError } from "~/errors";
 import { getDispositifByIdWithAllFields } from "~/modules/dispositif/dispositif.repository";
 import { sendSMS } from "~/services";
 import { contentLink } from "./contentLink";
@@ -84,7 +84,7 @@ describe("contentLink", () => {
     await expect(contentLink(body)).rejects.toThrow(NotFoundError);
   });
 
-  it("should throw InternalError if SMS sending fails with non-400 status", async () => {
+  it("should throw ServiceUnavailableError if SMS sending fails with non-400 status", async () => {
     mockGetDispositif.mockResolvedValue(validDispositif);
     mockSendSMS.mockResolvedValue({ status: 401, sent: false });
 
@@ -95,7 +95,7 @@ describe("contentLink", () => {
       locale: "fr",
     };
 
-    await expect(contentLink(body)).rejects.toThrow(InternalError);
-    await expect(contentLink(body)).rejects.toThrow("[contentLink] SMS not sent. Status: 401");
+    await expect(contentLink(body)).rejects.toThrow(ServiceUnavailableError);
+    await expect(contentLink(body)).rejects.toThrow("[contentLink] SMS provider unavailable");
   });
 });

--- a/apps/server/src/workflows/sms/contentLink/contentLink.ts
+++ b/apps/server/src/workflows/sms/contentLink/contentLink.ts
@@ -1,5 +1,5 @@
 import type { ContentLinkRequest, Languages } from "@refugies-info/api-types";
-import { InternalError, InvalidRequestError, NotFoundError } from "~/errors";
+import { InvalidRequestError, NotFoundError, ServiceUnavailableError } from "~/errors";
 import { getLocaleString as t } from "~/libs/getLocaleString";
 import logger from "~/logger";
 import { getDispositifByIdWithAllFields } from "~/modules/dispositif/dispositif.repository";
@@ -29,7 +29,13 @@ export const contentLink = async (body: ContentLinkRequest): Response => {
   if (!smsSentOk.sent) {
     logger.error("[contentLink] SMS not sent", smsSentOk);
     if (smsSentOk.status === 400) throw new InvalidRequestError("[contentLink] Invalid request");
-    throw new InternalError(`[contentLink] SMS not sent. Status: ${smsSentOk.status}`);
+    throw new ServiceUnavailableError(
+      "[contentLink] SMS provider unavailable",
+      "SMS_PROVIDER_UNAVAILABLE",
+      {
+        status: smsSentOk.status,
+      },
+    );
   }
 
   return { text: "success" };

--- a/apps/server/src/workflows/sms/downloadApp/downloadApp.test.ts
+++ b/apps/server/src/workflows/sms/downloadApp/downloadApp.test.ts
@@ -1,0 +1,48 @@
+import type { DownloadAppRequest } from "@refugies-info/api-types";
+import { InvalidRequestError, ServiceUnavailableError } from "~/errors";
+import logger from "~/logger";
+import { sendSMS } from "~/services";
+import { downloadApp } from "./downloadApp";
+
+jest.mock("~/services");
+jest.mock("~/logger");
+
+const mockSendSMS = sendSMS as jest.Mock;
+
+const body: DownloadAppRequest = {
+  phone: "+33600000000",
+  locale: "fr",
+};
+
+describe("downloadApp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("sends the app download link by SMS", async () => {
+    mockSendSMS.mockResolvedValue({ status: 201, sent: true });
+
+    await expect(downloadApp(body)).resolves.toEqual({ text: "success" });
+    expect(mockSendSMS).toHaveBeenCalledWith(
+      "Voici le lien pour télécharger l'application Réfugiés.info : https://refugies.info/fr/download-app",
+      "+33600000000",
+    );
+  });
+
+  it("throws InvalidRequestError when the SMS request is invalid", async () => {
+    mockSendSMS.mockResolvedValue({ status: 400, sent: false });
+
+    await expect(downloadApp(body)).rejects.toThrow(InvalidRequestError);
+  });
+
+  it("logs and throws ServiceUnavailableError for SMS provider failures", async () => {
+    mockSendSMS.mockResolvedValue({ status: 401, sent: false });
+
+    await expect(downloadApp(body)).rejects.toThrow(ServiceUnavailableError);
+    await expect(downloadApp(body)).rejects.toThrow("[downloadApp] SMS provider unavailable");
+    expect(logger.error).toHaveBeenCalledWith("[downloadApp] SMS not sent", {
+      sent: false,
+      status: 401,
+    });
+  });
+});

--- a/apps/server/src/workflows/sms/downloadApp/downloadApp.ts
+++ b/apps/server/src/workflows/sms/downloadApp/downloadApp.ts
@@ -1,5 +1,5 @@
 import type { DownloadAppRequest } from "@refugies-info/api-types";
-import { InvalidRequestError } from "~/errors";
+import { InvalidRequestError, ServiceUnavailableError } from "~/errors";
 import { getLocaleString as t } from "~/libs/getLocaleString";
 import logger from "~/logger";
 import { sendSMS } from "~/services";
@@ -11,8 +11,15 @@ export const downloadApp = async (body: DownloadAppRequest): Response => {
   const text = `${t(body.locale, "downloadApp")} https://refugies.info/fr/download-app`;
   const smsSentOk = await sendSMS(text, body.phone);
   if (!smsSentOk.sent) {
+    logger.error("[downloadApp] SMS not sent", smsSentOk);
     if (smsSentOk.status === 400) throw new InvalidRequestError("[downloadApp] Invalid request");
-    throw new Error("[downloadApp] SMS not sent.");
+    throw new ServiceUnavailableError(
+      "[downloadApp] SMS provider unavailable",
+      "SMS_PROVIDER_UNAVAILABLE",
+      {
+        status: smsSentOk.status,
+      },
+    );
   }
 
   return { text: "success" };

--- a/packages/mongo/src/schemas/User.ts
+++ b/packages/mongo/src/schemas/User.ts
@@ -17,7 +17,7 @@ export const FavoriteZodSchema = z.object({
 // --- Mongoose-compatible schema (relaxed for zod-mongoose limitations) ---
 export const UserZodSchema = z.object({
   username: z.string().optional(),
-  password: z.string(),
+  password: z.string().nullable().optional(),
   email: z.string().email(),
   firstName: z.string().optional(),
   phone: z.string().optional(),


### PR DESCRIPTION
## Summary
- Fix Brevo SMS sender formatting so numeric senders use international format without a leading 0.
- Allow SSO-created users without passwords and preserve generic HTTP 4xx error statuses instead of reporting them as 500s.
- Return typed 503 SMS provider failures with structured logging for content-link and app-download flows.

## Test plan
- [x] pnpm --filter @refugies-info/server exec jest --runInBand --runTestsByPath src/workflows/sms/contentLink/contentLink.test.ts src/workflows/sms/downloadApp/downloadApp.test.ts src/connectors/brevo/sendSMS.test.ts src/errors.test.ts src/modules/users/__tests__/user.service.test.ts src/workflows/users/login/login.test.ts
- [x] pnpm check:types:server
- [x] pnpm lint:server
- [x] pnpm --filter @refugies-info/mongo check-types
- [x] pnpm test:server

## Ops note
- GCP log-based metrics and alert policies for backend-prod SMS failures and SSO password-validation regressions were created separately in project refugies-info.

👾 Generated with [Letta Code](https://letta.com)