### PR TITLE
fix(client): correct mission page typo

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -700,7 +700,7 @@
     "impact_title": "La bonne information au bon endroit génère un impact positif pour tout le secteur !",
     "impact_subtitle": "Fluidification du travail des administrations, facilitation du travail des professionnels de l’intégration et autonomisation des bénéficiaires",
     "impact_p1": "Sur Réfugiés.info, une information est considérée comme adaptée lorsqu’elle est fiable, à jour, claire, spécifique, traduite, écoutable, et actionnable.",
-    "impact_p2": "Une fois produite, cette information doit être ensuite diffusée auprès des usagers afin qu’ils puissent l’utiliser. Réfugiés.info est désormais un medium reconnu, fréquenté chaque mois par environ 100 000 étrangers primo-arrivants et réfugiés, ainsi que 30 000 à 40 000 professionnels.",
+    "impact_p2": "Une fois produite, cette information doit être ensuite diffusée auprès des usagers afin qu’ils puissent l’utiliser. Réfugiés.info est désormais un média reconnu, fréquenté chaque mois par environ 100 000 étrangers primo-arrivants et réfugiés, ainsi que 30 000 à 40 000 professionnels.",
     "impact_p3": "La délivrance d’une information adaptée est la <strong>première brique pour le bon fonctionnement des administrations</strong> et <strong>la bonne mise en œuvre de la politique d’intégration des étrangers</strong> en France.",
     "impact_arguments_figures_title": "En chiffres",
     "impact_arguments_title_1": "Réfugiés.info fluidifie le travail des administrations",


### PR DESCRIPTION
## Summary
- Corrects the French typo on the Mission et impact page: `medium` → `média`.
- Addresses RI-1255.

## Test plan
- [x] pnpm lint:client
- [x] pnpm check:types:client

👾 Generated with [Letta Code](https://letta.com)