### PR TITLE
fix(server): allow null firstName for SSO users

### DIFF
--- a/apps/server/src/connectors/brevo/sendSMS.test.ts
+++ b/apps/server/src/connectors/brevo/sendSMS.test.ts
@@ -19,7 +19,13 @@ jest.mock("@getbrevo/brevo", () => ({
 jest.mock("~/logger");
 
 describe("Brevo sendSMS", () => {
+  let originalBrevoApiKey: string | undefined;
+  let originalSmsSender: string | undefined;
+
   beforeEach(() => {
+    originalBrevoApiKey = process.env.BREVO_API_KEY;
+    originalSmsSender = process.env.SMS_SENDER;
+
     jest.resetModules();
     jest.clearAllMocks();
     process.env.BREVO_API_KEY = "brevo-api-key";
@@ -28,6 +34,19 @@ describe("Brevo sendSMS", () => {
     mockSendTransacSms.mockReturnValue({
       withRawResponse: jest.fn().mockResolvedValue({ rawResponse: { status: 201 } }),
     });
+  });
+
+  afterEach(() => {
+    if (originalBrevoApiKey === undefined) {
+      delete process.env.BREVO_API_KEY;
+    } else {
+      process.env.BREVO_API_KEY = originalBrevoApiKey;
+    }
+    if (originalSmsSender === undefined) {
+      delete process.env.SMS_SENDER;
+    } else {
+      process.env.SMS_SENDER = originalSmsSender;
+    }
   });
 
   it("formats the sender as an international number without a leading zero", async () => {

--- a/apps/server/src/modules/users/__tests__/user.service.test.ts
+++ b/apps/server/src/modules/users/__tests__/user.service.test.ts
@@ -98,7 +98,7 @@ describe("registerUser", () => {
       status: "Actif",
       last_connected: new Date(1466424490000),
     });
-    expect(sendWelcomeMail).toHaveBeenCalledWith("test@example.com", null, userId);
+    expect(sendWelcomeMail).toHaveBeenCalledWith("test@example.com", "", userId);
     expect(addLog).toHaveBeenCalledWith(userId, "User", "Utilisateur créé : première connexion");
   });
 

--- a/apps/server/src/modules/users/users.repository.ts
+++ b/apps/server/src/modules/users/users.repository.ts
@@ -133,7 +133,8 @@ export const removeStructureOfUserInDB = (userId: UserId, structureId: Structure
   );
 
 export const createUser = (user: {
-  firstName: string;
+  email: string;
+  firstName: string | null;
   password: string | null;
   roles: Types.ObjectId[];
   status: string;

--- a/apps/server/src/modules/users/users.service.ts
+++ b/apps/server/src/modules/users/users.service.ts
@@ -101,7 +101,7 @@ export const registerUser = async (data: RegisterUser) => {
   const user = await createUser(userToSave);
 
   if (user.email) {
-    await sendWelcomeMail(user.email, user.firstName, user._id);
+    await sendWelcomeMail(user.email, user.firstName ?? "", user._id);
   }
 
   logger.info("[Register] successfully registered a new user", {

--- a/packages/mongo/src/schemas/User.ts
+++ b/packages/mongo/src/schemas/User.ts
@@ -19,7 +19,7 @@ export const UserZodSchema = z.object({
   username: z.string().optional(),
   password: z.string().nullable().optional(),
   email: z.string().email(),
-  firstName: z.string().optional(),
+  firstName: z.string().nullable().optional(),
   phone: z.string().optional(),
   description: z.string().optional(),
   // PATCHED: Nested optional with required fields causes validation issues


### PR DESCRIPTION
## Summary

- Allow `firstName` to be `null` in the User Zod schema (`z.string().nullable().optional()`) so SSO users without a first name do not trigger validation errors
- Update `createUser` repository type to accept `firstName: string | null` and add explicit `email` field
- Add `afterEach` cleanup in `sendSMS.test.ts` to restore original environment variables, preventing test pollution

## Test plan

- [x] `pnpm check:types:server` passes
- [x] Focused `sendSMS` test suite passes
- [ ] Verify SSO login flow works for users with null firstName

👾 Generated with [Letta Code](https://letta.com)

Co-Authored-By: Letta Code <noreply@letta.com>