### PR TITLE
test(mobile): stabilize Jest setup after dependency updates

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -43,8 +43,8 @@ jobs:
       - name: Lint and Check Types
         run: pnpm lint check:types
 
-      - name: Test (except mobile for now because flaky)
-        run: turbo test --filter=!@refugies-info/mobile
+      - name: Test
+        run: turbo test
         env:
           NEXT_PUBLIC_REACT_APP_ENV: ${{ vars.NEXT_PUBLIC_REACT_APP_ENV }}
           NEXT_PUBLIC_REACT_APP_ALGOLIA_API_KEY: ${{ vars.NEXT_PUBLIC_REACT_APP_ALGOLIA_API_KEY }}

--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -9,11 +9,84 @@ require("react-native-reanimated").setUpTests();
 
 jest.useFakeTimers();
 
+(() => {
+  const { TextDecoder, TextEncoder } = require("util");
+  const { deserialize, serialize } = require("v8");
+  const { TextDecoderStream, TextEncoderStream } = require("stream/web");
+  const structuredClone = (value) => deserialize(serialize(value));
+
+  // Expo SDK 54 installs lazy WinterCG globals. Some Jest dependencies access them
+  // through Node's runtime first, where a lazy getter can resolve to undefined.
+  // Define concrete Node-compatible values for the test environment.
+  Object.defineProperty(global, "TextDecoder", {
+    configurable: true,
+    writable: true,
+    value: TextDecoder,
+  });
+  Object.defineProperty(global, "TextEncoder", {
+    configurable: true,
+    writable: true,
+    value: TextEncoder,
+  });
+  Object.defineProperty(global, "TextDecoderStream", {
+    configurable: true,
+    writable: true,
+    value: TextDecoderStream,
+  });
+  Object.defineProperty(global, "TextEncoderStream", {
+    configurable: true,
+    writable: true,
+    value: TextEncoderStream,
+  });
+  Object.defineProperty(global, "structuredClone", {
+    configurable: true,
+    writable: true,
+    value: structuredClone,
+  });
+})();
+
+jest.mock("axios", () => {
+  const axios = jest.requireActual("axios");
+
+  // Axios 1.15 can pick the fetch adapter in Jest because Expo provides fetch/streams.
+  // Force the Node adapter in mobile tests to avoid Expo virtual stream cancellation errors.
+  axios.defaults.adapter = "http";
+  if (axios.default?.defaults) {
+    axios.default.defaults.adapter = "http";
+  }
+
+  return axios;
+});
+
 // jest.mock("react-native/Libraries/EventEmitter/NativeEventEmitter.js", () => {
 //   const { EventEmitter } = require("events");
 //   return EventEmitter;
 // });
-// jest.mock("expo-speech", () => {});
+
+jest.mock("expo-av", () => {
+  const sound = {
+    playAsync: jest.fn(),
+    stopAsync: jest.fn(),
+    pauseAsync: jest.fn(),
+    setRateAsync: jest.fn(),
+    setOnPlaybackStatusUpdate: jest.fn(),
+  };
+
+  return {
+    Audio: {
+      Sound: {
+        createAsync: jest.fn().mockResolvedValue({ sound }),
+      },
+    },
+  };
+});
+
+jest.mock("expo-speech", () => ({
+  speak: jest.fn((_, options) => options?.onDone?.()),
+  stop: jest.fn(),
+  pause: jest.fn(),
+  resume: jest.fn(),
+}));
 
 jest.mock("react-native-blob-util", () => {
   return () => ({});
@@ -66,12 +139,31 @@ jest.mock("@react-native-firebase/crashlytics", () => {
 //   };
 // });
 
+jest.mock("@react-navigation/native", () => ({
+  ...jest.requireActual("@react-navigation/native"),
+  useFocusEffect: jest.fn((callback) => callback()),
+  useIsFocused: jest.fn(() => true),
+  useRoute: jest.fn(() => ({ routeName: "DummyScreen" })),
+  useNavigation: jest.fn(() => ({
+    addListener: jest.fn(() => jest.fn()),
+    dispatch: jest.fn(),
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    setOptions: jest.fn(),
+  })),
+}));
+
 jest.mock("@react-navigation/core", () => ({
   ...jest.requireActual("@react-navigation/core"),
-  useRoute: jest.fn(),
-  useNavigation: jest.fn().mockImplementation(() => ({
-    goBack: jest.fn().mockImplementation(() => () => console.log("Go back")),
-    navigate: jest.fn().mockImplementation(() => (to) => console.log("Navigation to " + to)),
+  useFocusEffect: jest.fn((callback) => callback()),
+  useIsFocused: jest.fn(() => true),
+  useRoute: jest.fn(() => ({ routeName: "DummyScreen" })),
+  useNavigation: jest.fn(() => ({
+    addListener: jest.fn(() => jest.fn()),
+    dispatch: jest.fn(),
+    goBack: jest.fn(),
+    navigate: jest.fn(),
+    setOptions: jest.fn(),
   })),
 }));
 

--- a/apps/mobile/jest.setup.js
+++ b/apps/mobile/jest.setup.js
@@ -13,7 +13,11 @@ jest.useFakeTimers();
   const { TextDecoder, TextEncoder } = require("util");
   const { deserialize, serialize } = require("v8");
   const { TextDecoderStream, TextEncoderStream } = require("stream/web");
-  const structuredClone = (value) => deserialize(serialize(value));
+  const existingStructuredClone = Object.getOwnPropertyDescriptor(global, "structuredClone")?.value;
+  const structuredClone =
+    typeof existingStructuredClone === "function"
+      ? existingStructuredClone
+      : (value) => deserialize(serialize(value));
 
   // Expo SDK 54 installs lazy WinterCG globals. Some Jest dependencies access them
   // through Node's runtime first, where a lazy getter can resolve to undefined.
@@ -141,7 +145,7 @@ jest.mock("@react-native-firebase/crashlytics", () => {
 
 jest.mock("@react-navigation/native", () => ({
   ...jest.requireActual("@react-navigation/native"),
-  useFocusEffect: jest.fn((callback) => callback()),
+  useFocusEffect: jest.fn((callback) => require("react").useEffect(callback, [])),
   useIsFocused: jest.fn(() => true),
   useRoute: jest.fn(() => ({ routeName: "DummyScreen" })),
   useNavigation: jest.fn(() => ({
@@ -155,7 +159,7 @@ jest.mock("@react-navigation/native", () => ({
 
 jest.mock("@react-navigation/core", () => ({
   ...jest.requireActual("@react-navigation/core"),
-  useFocusEffect: jest.fn((callback) => callback()),
+  useFocusEffect: jest.fn((callback) => require("react").useEffect(callback, [])),
   useIsFocused: jest.fn(() => true),
   useRoute: jest.fn(() => ({ routeName: "DummyScreen" })),
   useNavigation: jest.fn(() => ({

--- a/apps/mobile/src/components/Explorer/LocationWarning/LocationWarningModal/__snapshots__/LocationWarningModal.test.tsx.snap
+++ b/apps/mobile/src/components/Explorer/LocationWarning/LocationWarningModal/__snapshots__/LocationWarningModal.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`LocationWarningModal snapshot test suite should render without bug 1`] = `
 <Modal
   backdropColor="#F7F7F7"
-  hardwareAccelerated={false}
   statusBarTranslucent={true}
   transparent={false}
   visible={true}

--- a/apps/mobile/src/components/Notifications/NotificationsModal/__snapshots__/NotificationsModal.test.tsx.snap
+++ b/apps/mobile/src/components/Notifications/NotificationsModal/__snapshots__/NotificationsModal.test.tsx.snap
@@ -4,7 +4,6 @@ exports[`NotificationsModal snapshot test suite should render not visible 1`] = 
 
 exports[`NotificationsModal snapshot test suite should render without bug 1`] = `
 <Modal
-  hardwareAccelerated={false}
   visible={true}
 >
   <RCTScrollView

--- a/apps/mobile/src/screens/Modals/__tests__/__snapshots__/LanguageChoiceModal.test.tsx.snap
+++ b/apps/mobile/src/screens/Modals/__tests__/__snapshots__/LanguageChoiceModal.test.tsx.snap
@@ -3,10 +3,8 @@
 exports[`LanguageChoiceModal should render correctly 1`] = `
 <Modal
   animationType="fade"
-  hardwareAccelerated={false}
   onRequestClose={[MockFunction]}
   transparent={true}
-  visible={true}
 >
   <View
     style={

--- a/apps/mobile/src/screens/ProfilTab/__tests__/__snapshots__/AccessibilityScreen.test.tsx.snap
+++ b/apps/mobile/src/screens/ProfilTab/__tests__/__snapshots__/AccessibilityScreen.test.tsx.snap
@@ -545,8 +545,7 @@ exports[`Accessibility screen should render correctly 1`] = `
             ]
           }
         >
-          Sur cette page, tu trouveras les informations obligatoires concernant l’accessibilité de l’application
-           
+          Sur cette page, tu trouveras les informations obligatoires concernant l’accessibilité de l’application 
           iOS
            Réfugiés.info.
         </Text>
@@ -817,7 +816,8 @@ exports[`Accessibility screen should render correctly 1`] = `
             ]
           }
         >
-          Cette déclaration d'accessibilité s'applique à l'application mobile 
+          Cette déclaration d'accessibilité s'applique à l'application mobile
+           
           iOS
            Réfugiés.info.
         </Text>

--- a/apps/mobile/src/screens/SearchTab/__tests__/SearchResultsScreen.test.tsx
+++ b/apps/mobile/src/screens/SearchTab/__tests__/SearchResultsScreen.test.tsx
@@ -19,6 +19,25 @@ jest.mock("algoliasearch/lite", () => ({
   }),
 }));
 
+jest.mock("react-instantsearch-core", () => {
+  const React = require("react");
+
+  return {
+    Configure: () => null,
+    InstantSearch: ({ children }: { children: React.ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+    useInfiniteHits: jest.fn(() => ({
+      hits: [],
+      isLastPage: true,
+      showMore: jest.fn(),
+    })),
+    useSearchBox: jest.fn(() => ({
+      query: "",
+      refine: jest.fn(),
+    })),
+  };
+});
+
 describe("Search results screen", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/mobile/src/screens/SearchTab/__tests__/__snapshots__/SearchResultsScreen.test.tsx.snap
+++ b/apps/mobile/src/screens/SearchTab/__tests__/__snapshots__/SearchResultsScreen.test.tsx.snap
@@ -302,17 +302,17 @@ exports[`Search results screen should render correctly 1`] = `
           </RNSVGSvgView>
         </View>
         <TextInput
-          isRTL={false}
           onChangeText={[Function]}
           placeholder="Rechercher"
           placeholderTextColor="#5E5E5E"
           style={
             {
-              "flexBasis": 0,
-              "flexGrow": 1,
-              "flexShrink": 1,
-              "height": "100%",
-              "width": "100%",
+              "color": "#212121",
+              "flex": 1,
+              "fontSize": 16,
+              "height": 40,
+              "marginLeft": 8,
+              "marginRight": 0,
             }
           }
           testID="test-city-search"

--- a/apps/mobile/src/screens/__tests__/__snapshots__/ContentScreen.test.tsx.snap
+++ b/apps/mobile/src/screens/__tests__/__snapshots__/ContentScreen.test.tsx.snap
@@ -685,13 +685,7 @@ exports[`ContentScreen should render correctly 1`] = `
                   <View />
                 </Text>
                 <View>
-                  <View
-                    style={
-                      {
-                        "flexDirection": "row",
-                      }
-                    }
-                  >
+                  <View>
                     <View
                       collapsable={false}
                       style={
@@ -3124,7 +3118,6 @@ exports[`ContentScreen should render correctly 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -3143,6 +3136,8 @@ exports[`ContentScreen should render correctly 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -3251,6 +3246,8 @@ exports[`ContentScreen should render correctly 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -3283,13 +3280,7 @@ exports[`ContentScreen should render correctly 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -3533,7 +3524,6 @@ exports[`ContentScreen should render correctly 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -3552,6 +3542,8 @@ exports[`ContentScreen should render correctly 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -3660,6 +3652,8 @@ exports[`ContentScreen should render correctly 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -3692,13 +3686,7 @@ exports[`ContentScreen should render correctly 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -3942,7 +3930,6 @@ exports[`ContentScreen should render correctly 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -3961,6 +3948,8 @@ exports[`ContentScreen should render correctly 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -4069,6 +4058,8 @@ exports[`ContentScreen should render correctly 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -4101,13 +4092,7 @@ exports[`ContentScreen should render correctly 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -4409,7 +4394,6 @@ exports[`ContentScreen should render correctly 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -4428,6 +4412,8 @@ exports[`ContentScreen should render correctly 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -4536,6 +4522,8 @@ exports[`ContentScreen should render correctly 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -4568,13 +4556,7 @@ exports[`ContentScreen should render correctly 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -4968,6 +4950,8 @@ exports[`ContentScreen should render correctly 1`] = `
                   </View>
                 </View>
                 <View
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
                   style={
                     {
                       "borderBottomLeftRadius": 12,
@@ -9188,13 +9172,7 @@ exports[`ContentScreen should toggle map modal 1`] = `
                   <View />
                 </Text>
                 <View>
-                  <View
-                    style={
-                      {
-                        "flexDirection": "row",
-                      }
-                    }
-                  >
+                  <View>
                     <View
                       collapsable={false}
                       style={
@@ -11627,7 +11605,6 @@ exports[`ContentScreen should toggle map modal 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -11646,6 +11623,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -11754,6 +11733,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -11786,13 +11767,7 @@ exports[`ContentScreen should toggle map modal 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -12036,7 +12011,6 @@ exports[`ContentScreen should toggle map modal 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -12055,6 +12029,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -12163,6 +12139,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -12195,13 +12173,7 @@ exports[`ContentScreen should toggle map modal 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -12445,7 +12417,6 @@ exports[`ContentScreen should toggle map modal 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -12464,6 +12435,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -12572,6 +12545,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -12604,13 +12579,7 @@ exports[`ContentScreen should toggle map modal 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -12912,7 +12881,6 @@ exports[`ContentScreen should toggle map modal 1`] = `
                                       "fontSize": 16,
                                       "lineHeight": 20,
                                       "textAlign": "left",
-                                      "width": 630,
                                     }
                                   }
                                 >
@@ -12931,6 +12899,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                           }
                         >
                           <View
+                            accessible={false}
+                            importantForAccessibility="no"
                             isRTL={false}
                             style={
                               {
@@ -13039,6 +13009,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                       </View>
                     </View>
                     <View
+                      accessibilityElementsHidden={true}
+                      importantForAccessibility="no-hide-descendants"
                       style={
                         [
                           {
@@ -13071,13 +13043,7 @@ exports[`ContentScreen should toggle map modal 1`] = `
                             }
                           }
                         >
-                          <View
-                            style={
-                              {
-                                "flexDirection": "row",
-                              }
-                            }
-                          >
+                          <View>
                             <View
                               collapsable={false}
                               style={
@@ -13471,6 +13437,8 @@ exports[`ContentScreen should toggle map modal 1`] = `
                   </View>
                 </View>
                 <View
+                  accessibilityElementsHidden={true}
+                  importantForAccessibility="no-hide-descendants"
                   style={
                     {
                       "borderBottomLeftRadius": 12,
@@ -13603,7 +13571,6 @@ exports[`ContentScreen should toggle map modal 1`] = `
               </View>
               <Modal
                 animationType="slide"
-                hardwareAccelerated={false}
                 visible={true}
               >
                 <View

--- a/apps/mobile/src/services/redux/Contents/__tests__/contents.saga.test.ts
+++ b/apps/mobile/src/services/redux/Contents/__tests__/contents.saga.test.ts
@@ -96,6 +96,7 @@ describe("[Saga] contents", () => {
               nbVues: 1,
               sponsorUrl: null,
               avancement: 1,
+              origin: DispositifOrigin.RI,
             },
             {
               _id: "id1Fr",
@@ -106,6 +107,7 @@ describe("[Saga] contents", () => {
               nbVues: 1,
               sponsorUrl: null,
               avancement: 1,
+              origin: DispositifOrigin.RI,
             },
           ],
         })
@@ -223,6 +225,7 @@ describe("[Saga] contents", () => {
               nbVues: 1,
               nbVuesMobile: 1,
               sponsorUrl: "sponsorUrl",
+              origin: DispositifOrigin.RI,
             },
             {
               _id: "id1_ar",
@@ -237,6 +240,7 @@ describe("[Saga] contents", () => {
               nbVues: 1,
               nbVuesMobile: 1,
               sponsorUrl: "sponsorUrl",
+              origin: DispositifOrigin.RI,
             },
           ],
           dataFr: [
@@ -253,6 +257,7 @@ describe("[Saga] contents", () => {
               nbVues: 1,
               nbVuesMobile: 1,
               sponsorUrl: "sponsorUrl",
+              origin: DispositifOrigin.RI,
             },
             {
               _id: "id1_fr",
@@ -267,6 +272,7 @@ describe("[Saga] contents", () => {
               nbVues: 1,
               nbVuesMobile: 1,
               sponsorUrl: "sponsorUrl",
+              origin: DispositifOrigin.RI,
             },
           ],
         })
@@ -360,6 +366,7 @@ describe("[Saga] contents", () => {
             nbVues: 1,
             nbVuesMobile: 1,
             sponsorUrl: "sponsorUrl",
+            origin: DispositifOrigin.RI,
           },
           {
             _id: "id1_fr",
@@ -374,6 +381,7 @@ describe("[Saga] contents", () => {
             nbVues: 1,
             nbVuesMobile: 1,
             sponsorUrl: "sponsorUrl",
+            origin: DispositifOrigin.RI,
           },
         ])
         .next({ idFr: [], id1Fr: [] })


### PR DESCRIPTION
## Summary
- Add mobile Jest mocks for Expo AV/Speech and React Navigation hooks so native-module imports and `.mockReturnValue()` usages work reliably.
- Force Axios to the Node HTTP adapter in mobile Jest to avoid Expo fetch stream cancellation errors.
- Refresh stale mobile snapshots and align contents saga fixtures with typed `origin` data.

## Test plan
- [x] `pnpm --filter @refugies-info/mobile test -- src/screens/ProfilTab/__tests__/AboutScreen.test.tsx src/components/layout/Page/Page.test.tsx src/components/Explorer/LocationWarning/LocationWarningModal/LocationWarningModal.test.tsx --runInBand`
- [x] `pnpm --filter @refugies-info/mobile lint`
- [x] `pnpm --filter @refugies-info/mobile check:types`
- [x] `pnpm --filter @refugies-info/mobile test`
- [x] `pnpm test`

Note: PR #3750 was already merged into `dev`, so this follow-up targets `dev` directly.

👾 Generated with [Letta Code](https://letta.com)