### PR TITLE
feat(client): add agent duplicate search endpoint

### DIFF
--- a/apps/client/src/lib/agentDuplicateSearch.test.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.test.ts
@@ -32,10 +32,9 @@ describe("agentDuplicateSearch", () => {
   });
 
   describe("buildDuplicateSearchPipeline", () => {
-    it("filters active dispositifs and looks up sponsor with _id", () => {
+    it("filters on title and location before looking up sponsors when structure is absent", () => {
       const pipeline = buildDuplicateSearchPipeline({
         title: "Cours FLE",
-        structureName: "FTDA",
         commune: "Paris",
         departments: ["75"],
         limit: 10,
@@ -45,21 +44,78 @@ describe("agentDuplicateSearch", () => {
         $match: { status: "Actif", typeContenu: "dispositif" },
       });
       expect(pipeline[1]).toMatchObject({
+        $match: {
+          $and: [
+            {
+              $or: expect.arrayContaining([
+                {
+                  "translations.fr.content.titreInformatif": { $regex: "Cours FLE", $options: "i" },
+                },
+                { "translations.fr.content.titreMarque": { $regex: "Cours FLE", $options: "i" } },
+              ]),
+            },
+            {
+              $or: expect.arrayContaining([
+                { "metadatas.location": { $regex: "^75\\s+-", $options: "i" } },
+                { "map.city": { $regex: "Paris", $options: "i" } },
+              ]),
+            },
+          ],
+        },
+      });
+      expect(pipeline[2]).toEqual({
         $lookup: {
           from: "structures",
-          let: { sponsorId: "$mainSponsor" },
-          pipeline: [
-            {
-              $match: {
-                $expr: {
-                  $eq: ["$_id", "$$sponsorId"],
-                },
-              },
-            },
-            { $limit: 1 },
-            { $project: { nom: 1, acronyme: 1, _id: 0 } },
-          ],
+          localField: "mainSponsor",
+          foreignField: "_id",
           as: "mainSponsorInfo",
+        },
+      });
+      expect(pipeline).toContainEqual({ $limit: 40 });
+    });
+
+    it("matches sponsor fields after lookup when structure is provided", () => {
+      const pipeline = buildDuplicateSearchPipeline({
+        title: "Cours FLE",
+        structureName: "FTDA",
+        commune: "Paris",
+        departments: ["75"],
+        limit: 10,
+      });
+
+      expect(pipeline[1]).toEqual({
+        $lookup: {
+          from: "structures",
+          localField: "mainSponsor",
+          foreignField: "_id",
+          as: "mainSponsorInfo",
+        },
+      });
+      expect(pipeline[2]).toEqual({
+        $unwind: {
+          path: "$mainSponsorInfo",
+          preserveNullAndEmptyArrays: true,
+        },
+      });
+      expect(pipeline[3]).toMatchObject({
+        $match: {
+          $and: [
+            {
+              $or: expect.arrayContaining([
+                {
+                  "translations.fr.content.titreInformatif": { $regex: "Cours FLE", $options: "i" },
+                },
+                { "mainSponsorInfo.nom": { $regex: "FTDA", $options: "i" } },
+                { "mainSponsorInfo.acronyme": { $regex: "FTDA", $options: "i" } },
+              ]),
+            },
+            {
+              $or: expect.arrayContaining([
+                { "metadatas.location": { $regex: "^75\\s+-", $options: "i" } },
+                { "map.city": { $regex: "Paris", $options: "i" } },
+              ]),
+            },
+          ],
         },
       });
       expect(pipeline).toContainEqual({ $limit: 40 });

--- a/apps/client/src/lib/agentDuplicateSearch.test.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.test.ts
@@ -1,0 +1,102 @@
+import {
+  buildDuplicateSearchPipeline,
+  parseDuplicateSearchRequest,
+  scoreDuplicateCandidates,
+} from "./agentDuplicateSearch";
+
+describe("agentDuplicateSearch", () => {
+  describe("parseDuplicateSearchRequest", () => {
+    it("normalizes valid requests and caps the limit", () => {
+      expect(
+        parseDuplicateSearchRequest({
+          title: "  Cours FLE  ",
+          structureName: "  FTDA ",
+          commune: "Paris",
+          departments: ["75", "invalid"],
+          limit: 100,
+        }),
+      ).toEqual({
+        title: "Cours FLE",
+        structureName: "FTDA",
+        commune: "Paris",
+        departments: ["75", "invalid"],
+        limit: 30,
+      });
+    });
+
+    it("requires a title", () => {
+      expect(() => parseDuplicateSearchRequest({ structureName: "FTDA" })).toThrow(
+        "Field 'title' is required",
+      );
+    });
+  });
+
+  describe("buildDuplicateSearchPipeline", () => {
+    it("filters active dispositifs and looks up sponsor with _id", () => {
+      const pipeline = buildDuplicateSearchPipeline({
+        title: "Cours FLE",
+        structureName: "FTDA",
+        commune: "Paris",
+        departments: ["75"],
+        limit: 10,
+      });
+
+      expect(pipeline[0]).toEqual({
+        $match: { status: "Actif", typeContenu: "dispositif" },
+      });
+      expect(pipeline[1]).toMatchObject({
+        $lookup: {
+          from: "structures",
+          let: { sponsorId: "$mainSponsor" },
+          pipeline: [
+            {
+              $match: {
+                $expr: {
+                  $eq: ["$_id", "$$sponsorId"],
+                },
+              },
+            },
+            { $limit: 1 },
+            { $project: { nom: 1, acronyme: 1, _id: 0 } },
+          ],
+          as: "mainSponsorInfo",
+        },
+      });
+      expect(pipeline).toContainEqual({ $limit: 40 });
+    });
+  });
+
+  describe("scoreDuplicateCandidates", () => {
+    it("scores location, sponsor and content similarities", () => {
+      const [candidate] = scoreDuplicateCandidates(
+        [
+          {
+            id: "abc123",
+            titreInformatif: "Apprendre le français pour le travail",
+            titreMarque: "Cours FLE",
+            location: ["75 - Paris"],
+            city: ["Paris"],
+            mainSponsorNom: "France Terre d'Asile",
+            mainSponsorAcronyme: "FTDA",
+          },
+        ],
+        {
+          title: "Cours FLE",
+          structureName: "France Terre d'Asile",
+          commune: "Paris",
+          departments: ["75"],
+          limit: 10,
+        },
+      );
+
+      expect(candidate).toMatchObject({
+        id: "abc123",
+        url: "https://refugies.info/dispositif/abc123",
+      });
+      expect(candidate.score).toBeGreaterThanOrEqual(18);
+      expect(candidate.reasons).toEqual(
+        expect.arrayContaining(["same city", "same department/location", "similar sponsor"]),
+      );
+    });
+  });
+});

--- a/apps/client/src/lib/agentDuplicateSearch.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.ts
@@ -31,7 +31,7 @@ export interface DuplicateSearchQuery {
   limit: number;
 }
 
-type RawDuplicateCandidate = Omit<DuplicateSearchCandidate, "url" | "score" | "reasons">;
+export type RawDuplicateCandidate = Omit<DuplicateSearchCandidate, "url" | "score" | "reasons">;
 
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 30;
@@ -98,10 +98,6 @@ export const parseDuplicateSearchRequest = (body: unknown): DuplicateSearchQuery
     throw new Error("Field 'title' is required");
   }
 
-  if (!title && !description && !structureName && !commune && departments.length === 0) {
-    throw new Error("At least one search criterion is required");
-  }
-
   return {
     title,
     ...(description ? { description } : {}),
@@ -138,7 +134,7 @@ const departmentToRegex = (department: string) => {
   return escapeRegExp(trimmed);
 };
 
-const getSearchConditions = (query: DuplicateSearchQuery): Record<string, unknown>[] => {
+const getLocationSearchConditions = (query: DuplicateSearchQuery): Record<string, unknown>[] => {
   const conditions: Record<string, unknown>[] = [];
 
   for (const department of query.departments) {
@@ -151,19 +147,30 @@ const getSearchConditions = (query: DuplicateSearchQuery): Record<string, unknow
     conditions.push({ "map.city": { $regex: escapeRegExp(query.commune), $options: "i" } });
   }
 
-  if (query.structureName) {
-    conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", query.structureName));
-    conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", query.structureName));
-    for (const token of tokenize(query.structureName).slice(0, 4)) {
-      conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", token));
-      conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", token));
-    }
+  return conditions;
+};
+
+const getSponsorSearchConditions = (query: DuplicateSearchQuery): Record<string, unknown>[] => {
+  const conditions: Record<string, unknown>[] = [];
+
+  if (!query.structureName) return conditions;
+
+  conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", query.structureName));
+  conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", query.structureName));
+  for (const token of tokenize(query.structureName).slice(0, 4)) {
+    conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", token));
+    conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", token));
   }
 
-  conditions.push(
+  return conditions;
+};
+
+const getTextSearchConditions = (query: DuplicateSearchQuery): Record<string, unknown>[] => {
+  const conditions: Record<string, unknown>[] = [
     buildStringRegexCondition("translations.fr.content.titreInformatif", query.title),
-  );
-  conditions.push(buildStringRegexCondition("translations.fr.content.titreMarque", query.title));
+    buildStringRegexCondition("translations.fr.content.titreMarque", query.title),
+  ];
+
   for (const token of tokenize(query.title)) {
     conditions.push(buildStringRegexCondition("translations.fr.content.titreInformatif", token));
     conditions.push(buildStringRegexCondition("translations.fr.content.titreMarque", token));
@@ -177,32 +184,52 @@ const getSearchConditions = (query: DuplicateSearchQuery): Record<string, unknow
   return conditions;
 };
 
+const buildOrMatch = (conditions: Record<string, unknown>[]): Record<string, unknown> =>
+  conditions.length === 1 ? conditions[0] : { $or: conditions };
+
+const buildConstrainedMatchStage = (
+  signalConditions: Record<string, unknown>[],
+  locationConditions: Record<string, unknown>[],
+): PipelineStage.Match | null => {
+  if (signalConditions.length === 0) return null;
+
+  const andConditions = [buildOrMatch(signalConditions)];
+  if (locationConditions.length > 0) {
+    andConditions.push(buildOrMatch(locationConditions));
+  }
+
+  return {
+    $match: andConditions.length === 1 ? andConditions[0] : { $and: andConditions },
+  };
+};
+
 export const buildDuplicateSearchPipeline = (query: DuplicateSearchQuery): PipelineStage[] => {
-  const conditions = getSearchConditions(query);
+  const textConditions = getTextSearchConditions(query);
+  const locationConditions = getLocationSearchConditions(query);
+  const sponsorConditions = getSponsorSearchConditions(query);
+  const needsSponsorSearch = sponsorConditions.length > 0;
   const dbLimit = Math.min(query.limit * 4, MAX_DB_CANDIDATES);
 
-  return [
+  const pipeline: PipelineStage[] = [
     {
       $match: {
         status: "Actif",
         typeContenu: "dispositif",
       },
     },
+  ];
+
+  if (!needsSponsorSearch) {
+    const preLookupMatch = buildConstrainedMatchStage(textConditions, locationConditions);
+    if (preLookupMatch) pipeline.push(preLookupMatch);
+  }
+
+  pipeline.push(
     {
       $lookup: {
         from: "structures",
-        let: { sponsorId: "$mainSponsor" },
-        pipeline: [
-          {
-            $match: {
-              $expr: {
-                $eq: ["$_id", "$$sponsorId"],
-              },
-            },
-          },
-          { $limit: 1 },
-          { $project: { nom: 1, acronyme: 1, _id: 0 } },
-        ],
+        localField: "mainSponsor",
+        foreignField: "_id",
         as: "mainSponsorInfo",
       },
     },
@@ -212,7 +239,17 @@ export const buildDuplicateSearchPipeline = (query: DuplicateSearchQuery): Pipel
         preserveNullAndEmptyArrays: true,
       },
     },
-    ...(conditions.length > 0 ? [{ $match: { $or: conditions } }] : []),
+  );
+
+  if (needsSponsorSearch) {
+    const postLookupMatch = buildConstrainedMatchStage(
+      [...textConditions, ...sponsorConditions],
+      locationConditions,
+    );
+    if (postLookupMatch) pipeline.push(postLookupMatch);
+  }
+
+  pipeline.push(
     { $sort: { publishedAt: -1, updatedAt: -1 } },
     { $limit: dbLimit },
     {
@@ -235,7 +272,9 @@ export const buildDuplicateSearchPipeline = (query: DuplicateSearchQuery): Pipel
         mainSponsorAcronyme: "$mainSponsorInfo.acronyme",
       },
     },
-  ];
+  );
+
+  return pipeline;
 };
 
 const getInitials = (value: string | undefined) =>

--- a/apps/client/src/lib/agentDuplicateSearch.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.ts
@@ -1,0 +1,343 @@
+import type { PipelineStage } from "mongoose";
+
+export interface DuplicateSearchRequest {
+  title: string;
+  description?: string;
+  structureName?: string;
+  commune?: string;
+  departments?: string[];
+  limit?: number;
+}
+
+export interface DuplicateSearchCandidate {
+  id: string;
+  url: string;
+  titreInformatif?: string;
+  titreMarque?: string;
+  location?: string | string[];
+  city: string[];
+  mainSponsorNom?: string;
+  mainSponsorAcronyme?: string;
+  score: number;
+  reasons: string[];
+}
+
+export interface DuplicateSearchQuery {
+  title: string;
+  description?: string;
+  structureName?: string;
+  commune?: string;
+  departments: string[];
+  limit: number;
+}
+
+type RawDuplicateCandidate = Omit<DuplicateSearchCandidate, "url" | "score" | "reasons">;
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 30;
+const MAX_DB_CANDIDATES = 100;
+
+const STOP_WORDS = new Set([
+  "avec",
+  "dans",
+  "des",
+  "les",
+  "pour",
+  "une",
+  "aux",
+  "sur",
+  "par",
+  "sans",
+  "formation",
+  "dispositif",
+  "itineraire",
+  "langue",
+  "etrangere",
+  "francais",
+  "française",
+]);
+
+const normalizeText = (value: string | undefined | null) =>
+  (value || "")
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+
+const escapeRegExp = (value: string) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const toStringArray = (value: unknown): string[] => {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => typeof item === "string" && item.trim().length > 0);
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const parseLimit = (value: unknown): number => {
+  const limit = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(limit) || limit <= 0) return DEFAULT_LIMIT;
+  return Math.min(Math.trunc(limit), MAX_LIMIT);
+};
+
+export const parseDuplicateSearchRequest = (body: unknown): DuplicateSearchQuery => {
+  if (!isObject(body)) {
+    throw new Error("Request body must be an object");
+  }
+
+  const title = typeof body.title === "string" ? body.title.trim() : "";
+  const description = typeof body.description === "string" ? body.description.trim() : undefined;
+  const structureName =
+    typeof body.structureName === "string" ? body.structureName.trim() : undefined;
+  const commune = typeof body.commune === "string" ? body.commune.trim() : undefined;
+  const departments = toStringArray(body.departments).map((department) => department.trim());
+  const limit = parseLimit(body.limit);
+
+  if (!title) {
+    throw new Error("Field 'title' is required");
+  }
+
+  if (!title && !description && !structureName && !commune && departments.length === 0) {
+    throw new Error("At least one search criterion is required");
+  }
+
+  return {
+    title,
+    ...(description ? { description } : {}),
+    ...(structureName ? { structureName } : {}),
+    ...(commune ? { commune } : {}),
+    departments,
+    limit,
+  };
+};
+
+const tokenize = (value: string | undefined): string[] => {
+  if (!value) return [];
+
+  const originalTokens = value.match(/[\p{L}\p{N}]+/gu) || [];
+  return Array.from(
+    new Set(
+      originalTokens
+        .filter((token) => token.length >= 4 || /^[A-Z0-9]{2,}$/.test(token))
+        .map((token) => normalizeText(token))
+        .filter((token) => token.length >= 3 && !STOP_WORDS.has(token)),
+    ),
+  ).slice(0, 8);
+};
+
+const buildStringRegexCondition = (field: string, value: string): Record<string, unknown> => ({
+  [field]: { $regex: escapeRegExp(value), $options: "i" },
+});
+
+const departmentToRegex = (department: string) => {
+  const trimmed = department.trim();
+  if (/^\d{2,3}$/.test(trimmed) || /^(2A|2B)$/i.test(trimmed)) {
+    return `^${escapeRegExp(trimmed)}\\s+-`;
+  }
+  return escapeRegExp(trimmed);
+};
+
+const getSearchConditions = (query: DuplicateSearchQuery): Record<string, unknown>[] => {
+  const conditions: Record<string, unknown>[] = [];
+
+  for (const department of query.departments) {
+    conditions.push({
+      "metadatas.location": { $regex: departmentToRegex(department), $options: "i" },
+    });
+  }
+
+  if (query.commune) {
+    conditions.push({ "map.city": { $regex: escapeRegExp(query.commune), $options: "i" } });
+  }
+
+  if (query.structureName) {
+    conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", query.structureName));
+    conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", query.structureName));
+    for (const token of tokenize(query.structureName).slice(0, 4)) {
+      conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", token));
+      conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", token));
+    }
+  }
+
+  conditions.push(
+    buildStringRegexCondition("translations.fr.content.titreInformatif", query.title),
+  );
+  conditions.push(buildStringRegexCondition("translations.fr.content.titreMarque", query.title));
+  for (const token of tokenize(query.title)) {
+    conditions.push(buildStringRegexCondition("translations.fr.content.titreInformatif", token));
+    conditions.push(buildStringRegexCondition("translations.fr.content.titreMarque", token));
+  }
+
+  for (const token of tokenize(query.description).slice(0, 4)) {
+    conditions.push(buildStringRegexCondition("translations.fr.content.titreInformatif", token));
+    conditions.push(buildStringRegexCondition("translations.fr.content.titreMarque", token));
+  }
+
+  return conditions;
+};
+
+export const buildDuplicateSearchPipeline = (query: DuplicateSearchQuery): PipelineStage[] => {
+  const conditions = getSearchConditions(query);
+  const dbLimit = Math.min(query.limit * 4, MAX_DB_CANDIDATES);
+
+  return [
+    {
+      $match: {
+        status: "Actif",
+        typeContenu: "dispositif",
+      },
+    },
+    {
+      $lookup: {
+        from: "structures",
+        let: { sponsorId: "$mainSponsor" },
+        pipeline: [
+          {
+            $match: {
+              $expr: {
+                $eq: ["$_id", "$$sponsorId"],
+              },
+            },
+          },
+          { $limit: 1 },
+          { $project: { nom: 1, acronyme: 1, _id: 0 } },
+        ],
+        as: "mainSponsorInfo",
+      },
+    },
+    {
+      $unwind: {
+        path: "$mainSponsorInfo",
+        preserveNullAndEmptyArrays: true,
+      },
+    },
+    ...(conditions.length > 0 ? [{ $match: { $or: conditions } }] : []),
+    { $sort: { publishedAt: -1, updatedAt: -1 } },
+    { $limit: dbLimit },
+    {
+      $project: {
+        _id: 0,
+        id: { $toString: "$_id" },
+        titreInformatif: "$translations.fr.content.titreInformatif",
+        titreMarque: "$translations.fr.content.titreMarque",
+        location: "$metadatas.location",
+        city: {
+          $filter: {
+            input: { $ifNull: ["$map.city", []] },
+            as: "item",
+            cond: {
+              $and: [{ $ne: ["$$item", null] }, { $ne: ["$$item", ""] }],
+            },
+          },
+        },
+        mainSponsorNom: "$mainSponsorInfo.nom",
+        mainSponsorAcronyme: "$mainSponsorInfo.acronyme",
+      },
+    },
+  ];
+};
+
+const getInitials = (value: string | undefined) =>
+  (value || "")
+    .match(/[\p{L}\p{N}]+/gu)
+    ?.map((word) => word[0])
+    .join("")
+    .toLowerCase() || "";
+
+const includesEitherWay = (a: string, b: string) =>
+  a.length > 0 && b.length > 0 && (a.includes(b) || b.includes(a));
+
+const candidateLocations = (candidate: RawDuplicateCandidate) =>
+  Array.isArray(candidate.location)
+    ? candidate.location
+    : candidate.location
+      ? [candidate.location]
+      : [];
+
+export const scoreDuplicateCandidates = (
+  candidates: RawDuplicateCandidate[],
+  query: DuplicateSearchQuery,
+): DuplicateSearchCandidate[] => {
+  const titleTokens = tokenize(query.title);
+  const descriptionTokens = tokenize(query.description);
+  const normalizedTitle = normalizeText(query.title);
+  const normalizedStructure = normalizeText(query.structureName);
+  const normalizedCommune = normalizeText(query.commune);
+  const normalizedDepartments = query.departments.map(normalizeText);
+  const structureInitials = getInitials(query.structureName);
+
+  return candidates
+    .map((candidate) => {
+      let score = 0;
+      const reasons: string[] = [];
+      const candidateTitle = normalizeText(
+        [candidate.titreInformatif, candidate.titreMarque].filter(Boolean).join(" "),
+      );
+      const candidateSponsor = normalizeText(
+        [candidate.mainSponsorNom, candidate.mainSponsorAcronyme].filter(Boolean).join(" "),
+      );
+      const candidateCities = candidate.city.map(normalizeText);
+      const locations = candidateLocations(candidate).map(normalizeText);
+
+      if (
+        normalizedCommune &&
+        candidateCities.some((city) => includesEitherWay(city, normalizedCommune))
+      ) {
+        score += 5;
+        reasons.push("same city");
+      }
+
+      if (
+        normalizedDepartments.length > 0 &&
+        normalizedDepartments.some((department) =>
+          locations.some(
+            (location) =>
+              includesEitherWay(location, department) || location.startsWith(`${department} `),
+          ),
+        )
+      ) {
+        score += 4;
+        reasons.push("same department/location");
+      }
+
+      if (normalizedStructure && includesEitherWay(candidateSponsor, normalizedStructure)) {
+        score += 5;
+        reasons.push("similar sponsor");
+      } else if (
+        structureInitials.length >= 2 &&
+        normalizeText(candidate.mainSponsorAcronyme).includes(structureInitials)
+      ) {
+        score += 4;
+        reasons.push("sponsor acronym match");
+      }
+
+      if (includesEitherWay(candidateTitle, normalizedTitle)) {
+        score += 4;
+        reasons.push("similar title");
+      } else {
+        const overlap = titleTokens.filter((token) => candidateTitle.includes(token)).length;
+        if (overlap > 0) {
+          score += Math.min(overlap, 3);
+          reasons.push("shared title keywords");
+        }
+      }
+
+      const descriptionOverlap = descriptionTokens.filter((token) =>
+        candidateTitle.includes(token),
+      ).length;
+      if (descriptionOverlap > 0) {
+        score += Math.min(descriptionOverlap, 2);
+        reasons.push("shared description keywords");
+      }
+
+      return {
+        ...candidate,
+        url: `https://refugies.info/dispositif/${candidate.id}`,
+        score,
+        reasons,
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, query.limit);
+};

--- a/apps/client/src/pages/api/agent/dispositifs/duplicates.ts
+++ b/apps/client/src/pages/api/agent/dispositifs/duplicates.ts
@@ -3,6 +3,7 @@ import {
   buildDuplicateSearchPipeline,
   type DuplicateSearchCandidate,
   parseDuplicateSearchRequest,
+  type RawDuplicateCandidate,
   scoreDuplicateCandidates,
 } from "~/lib/agentDuplicateSearch";
 import dbConnect from "~/lib/db";
@@ -37,7 +38,7 @@ const handler = async (
   try {
     const conn = await dbConnect();
     const Dispositif = getDispositifModel(conn);
-    const rawCandidates = await executeCachedPipeline(
+    const rawCandidates = await executeCachedPipeline<RawDuplicateCandidate>(
       Dispositif.aggregate(buildDuplicateSearchPipeline(query)),
     );
 

--- a/apps/client/src/pages/api/agent/dispositifs/duplicates.ts
+++ b/apps/client/src/pages/api/agent/dispositifs/duplicates.ts
@@ -1,0 +1,54 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import {
+  buildDuplicateSearchPipeline,
+  type DuplicateSearchCandidate,
+  parseDuplicateSearchRequest,
+  scoreDuplicateCandidates,
+} from "~/lib/agentDuplicateSearch";
+import dbConnect from "~/lib/db";
+import { executeCachedPipeline, getDispositifModel } from "~/lib/search-helpers";
+import { validateWebhookSecret } from "~/lib/webhookUtils";
+
+type DuplicateSearchResponse = {
+  query: ReturnType<typeof parseDuplicateSearchRequest>;
+  candidates: DuplicateSearchCandidate[];
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse<DuplicateSearchResponse | { message: string }>,
+) => {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method Not Allowed" });
+  }
+
+  if (!validateWebhookSecret(req)) {
+    return res.status(401).json({ message: "Accès refusé : Secret invalide ou manquant" });
+  }
+
+  let query: ReturnType<typeof parseDuplicateSearchRequest>;
+  try {
+    query = parseDuplicateSearchRequest(req.body);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Invalid payload";
+    return res.status(400).json({ message });
+  }
+
+  try {
+    const conn = await dbConnect();
+    const Dispositif = getDispositifModel(conn);
+    const rawCandidates = await executeCachedPipeline(
+      Dispositif.aggregate(buildDuplicateSearchPipeline(query)),
+    );
+
+    return res.status(200).json({
+      query,
+      candidates: scoreDuplicateCandidates(rawCandidates, query),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Internal Server Error";
+    return res.status(500).json({ message });
+  }
+};
+
+export default handler;


### PR DESCRIPTION
## Summary
- Add a protected frontend API endpoint for agent duplicate candidate search backed by fresh MongoDB data
- Return the fields Agathe currently expects from `dispositifs.yaml`, plus candidate URLs, scores, and match reasons
- Cover request parsing, aggregation shape, and scoring logic with focused client tests

## Test plan
- [x] `pnpm --filter @refugies-info/client test -- agentDuplicateSearch`
- [x] `pnpm --filter @refugies-info/client check:types`
- [x] `pnpm --filter @refugies-info/client lint`

👾 Generated with [Letta Code](https://letta.com)