### PR TITLE
fix(client): improve duplicate candidate ranking

### DIFF
--- a/apps/client/src/lib/agentDuplicateSearch.test.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.test.ts
@@ -129,6 +129,48 @@ describe("agentDuplicateSearch", () => {
       });
       expect(pipeline).toContainEqual({ $limit: 40 });
     });
+
+    it("keeps normalized sponsor fallback for accented names", () => {
+      const pipeline = buildDuplicateSearchPipeline({
+        title: "Atelier cuisine",
+        structureName: "Café",
+        departments: [],
+        limit: 10,
+      });
+
+      const serializedPipeline = JSON.stringify(pipeline);
+      expect(serializedPipeline).toContain('"regex":"Café"');
+      expect(serializedPipeline).toContain('"regex":"cafe"');
+    });
+
+    it("does not duplicate single-word title score expressions", () => {
+      const pipeline = buildDuplicateSearchPipeline({
+        title: "FLE",
+        departments: [],
+        limit: 10,
+      });
+      const addFieldsStage = pipeline.find((stage) => "$addFields" in stage);
+
+      const serializedScore = JSON.stringify(addFieldsStage);
+      expect(serializedScore).toContain('"regex":"FLE"');
+      expect(serializedScore).not.toContain('"regex":"fle"');
+    });
+
+    it("includes sponsor and location signals in the pre-limit score", () => {
+      const pipeline = buildDuplicateSearchPipeline({
+        title: "Cours FLE",
+        structureName: "FTDA",
+        commune: "Paris",
+        departments: ["75"],
+        limit: 10,
+      });
+      const addFieldsStage = pipeline.find((stage) => "$addFields" in stage);
+
+      const serializedScore = JSON.stringify(addFieldsStage);
+      expect(serializedScore).toContain("$mainSponsorInfo.nom");
+      expect(serializedScore).toContain("$map.city");
+      expect(serializedScore).toContain("$metadatas.location");
+    });
   });
 
   describe("scoreDuplicateCandidates", () => {

--- a/apps/client/src/lib/agentDuplicateSearch.test.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.test.ts
@@ -71,6 +71,9 @@ describe("agentDuplicateSearch", () => {
           as: "mainSponsorInfo",
         },
       });
+      expect(pipeline).toContainEqual({
+        $sort: { duplicateSearchScore: -1, publishedAt: -1, updatedAt: -1 },
+      });
       expect(pipeline).toContainEqual({ $limit: 40 });
     });
 
@@ -118,11 +121,67 @@ describe("agentDuplicateSearch", () => {
           ],
         },
       });
+      expect(pipeline).toContainEqual({
+        $addFields: { duplicateSearchScore: expect.any(Object) },
+      });
+      expect(pipeline).toContainEqual({
+        $sort: { duplicateSearchScore: -1, publishedAt: -1, updatedAt: -1 },
+      });
       expect(pipeline).toContainEqual({ $limit: 40 });
     });
   });
 
   describe("scoreDuplicateCandidates", () => {
+    it("does not match numeric department codes by substring", () => {
+      const [candidate] = scoreDuplicateCandidates(
+        [
+          {
+            id: "marseille",
+            titreInformatif: "Cours FLE",
+            titreMarque: "Français",
+            location: ["13 - Bouches-du-Rhône"],
+            city: ["Marseille"],
+            mainSponsorNom: "France Terre d'Asile",
+            mainSponsorAcronyme: "FTDA",
+          },
+        ],
+        {
+          title: "Cours FLE",
+          structureName: "France Terre d'Asile",
+          commune: "",
+          departments: ["3"],
+          limit: 10,
+        },
+      );
+
+      expect(candidate.reasons).not.toContain("same department/location");
+    });
+
+    it("matches one-digit department codes against zero-padded locations", () => {
+      const [candidate] = scoreDuplicateCandidates(
+        [
+          {
+            id: "allier",
+            titreInformatif: "Cours FLE",
+            titreMarque: "Français",
+            location: ["03 - Allier"],
+            city: ["Vichy"],
+            mainSponsorNom: "France Terre d'Asile",
+            mainSponsorAcronyme: "FTDA",
+          },
+        ],
+        {
+          title: "Cours FLE",
+          structureName: "France Terre d'Asile",
+          commune: "",
+          departments: ["3"],
+          limit: 10,
+        },
+      );
+
+      expect(candidate.reasons).toContain("same department/location");
+    });
+
     it("scores location, sponsor and content similarities", () => {
       const [candidate] = scoreDuplicateCandidates(
         [

--- a/apps/client/src/lib/agentDuplicateSearch.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.ts
@@ -155,9 +155,11 @@ const getSponsorSearchConditions = (query: DuplicateSearchQuery): Record<string,
 
   if (!query.structureName) return conditions;
 
+  const normalizedSponsor = normalizeText(query.structureName);
   conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", query.structureName));
   conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", query.structureName));
   for (const token of tokenize(query.structureName).slice(0, 4)) {
+    if (token === normalizedSponsor) continue;
     conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", token));
     conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", token));
   }
@@ -201,6 +203,63 @@ const buildConstrainedMatchStage = (
   return {
     $match: andConditions.length === 1 ? andConditions[0] : { $and: andConditions },
   };
+};
+
+const buildRegexScoreExpression = (
+  fieldExpression: string,
+  value: string,
+  score: number,
+): Record<string, unknown> => ({
+  $cond: [
+    {
+      $regexMatch: {
+        input: { $ifNull: [fieldExpression, ""] },
+        regex: escapeRegExp(value),
+        options: "i",
+      },
+    },
+    score,
+    0,
+  ],
+});
+
+const buildDuplicateSearchScoreExpression = (
+  query: DuplicateSearchQuery,
+): Record<string, unknown> => {
+  const expressions: Record<string, unknown>[] = [
+    buildRegexScoreExpression("$translations.fr.content.titreInformatif", query.title, 6),
+    buildRegexScoreExpression("$translations.fr.content.titreMarque", query.title, 6),
+  ];
+
+  for (const token of tokenize(query.title)) {
+    expressions.push(
+      buildRegexScoreExpression("$translations.fr.content.titreInformatif", token, 2),
+    );
+    expressions.push(buildRegexScoreExpression("$translations.fr.content.titreMarque", token, 2));
+  }
+
+  for (const token of tokenize(query.description).slice(0, 4)) {
+    expressions.push(
+      buildRegexScoreExpression("$translations.fr.content.titreInformatif", token, 1),
+    );
+    expressions.push(buildRegexScoreExpression("$translations.fr.content.titreMarque", token, 1));
+  }
+
+  if (query.structureName) {
+    const normalizedSponsor = normalizeText(query.structureName);
+    expressions.push(buildRegexScoreExpression("$mainSponsorInfo.nom", query.structureName, 5));
+    expressions.push(
+      buildRegexScoreExpression("$mainSponsorInfo.acronyme", query.structureName, 5),
+    );
+
+    for (const token of tokenize(query.structureName).slice(0, 4)) {
+      if (token === normalizedSponsor) continue;
+      expressions.push(buildRegexScoreExpression("$mainSponsorInfo.nom", token, 1));
+      expressions.push(buildRegexScoreExpression("$mainSponsorInfo.acronyme", token, 1));
+    }
+  }
+
+  return { $add: expressions };
 };
 
 export const buildDuplicateSearchPipeline = (query: DuplicateSearchQuery): PipelineStage[] => {
@@ -250,7 +309,8 @@ export const buildDuplicateSearchPipeline = (query: DuplicateSearchQuery): Pipel
   }
 
   pipeline.push(
-    { $sort: { publishedAt: -1, updatedAt: -1 } },
+    { $addFields: { duplicateSearchScore: buildDuplicateSearchScoreExpression(query) } },
+    { $sort: { duplicateSearchScore: -1, publishedAt: -1, updatedAt: -1 } },
     { $limit: dbLimit },
     {
       $project: {
@@ -286,6 +346,24 @@ const getInitials = (value: string | undefined) =>
 
 const includesEitherWay = (a: string, b: string) =>
   a.length > 0 && b.length > 0 && (a.includes(b) || b.includes(a));
+
+const isDepartmentCode = (department: string) =>
+  /^\d+$/.test(department) || /^(2a|2b)$/.test(department);
+
+const departmentCodeVariants = (department: string) =>
+  /^\d$/.test(department) ? [department, `0${department}`] : [department];
+
+const locationMatchesDepartment = (location: string, department: string) => {
+  if (!department) return false;
+
+  if (isDepartmentCode(department)) {
+    return departmentCodeVariants(department).some(
+      (code) => location === code || location.startsWith(`${code} `),
+    );
+  }
+
+  return includesEitherWay(location, department);
+};
 
 const candidateLocations = (candidate: RawDuplicateCandidate) =>
   Array.isArray(candidate.location)
@@ -330,10 +408,7 @@ export const scoreDuplicateCandidates = (
       if (
         normalizedDepartments.length > 0 &&
         normalizedDepartments.some((department) =>
-          locations.some(
-            (location) =>
-              includesEitherWay(location, department) || location.startsWith(`${department} `),
-          ),
+          locations.some((location) => locationMatchesDepartment(location, department)),
         )
       ) {
         score += 4;

--- a/apps/client/src/lib/agentDuplicateSearch.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.ts
@@ -244,6 +244,7 @@ const joinFieldValues = (fieldExpression: string): Record<string, unknown> => ({
 const buildDuplicateSearchScoreExpression = (
   query: DuplicateSearchQuery,
 ): Record<string, unknown> => {
+  const normalizedTitle = normalizeText(query.title);
   const rawTitleRegex = query.title.toLowerCase();
   const expressions: Record<string, unknown>[] = [
     buildRegexScoreExpression("$translations.fr.content.titreInformatif", query.title, 4),
@@ -251,7 +252,7 @@ const buildDuplicateSearchScoreExpression = (
   ];
 
   for (const token of tokenize(query.title)) {
-    if (token === rawTitleRegex) continue;
+    if (token === normalizedTitle && token === rawTitleRegex) continue;
     expressions.push(
       buildRegexScoreExpression("$translations.fr.content.titreInformatif", token, 1),
     );

--- a/apps/client/src/lib/agentDuplicateSearch.ts
+++ b/apps/client/src/lib/agentDuplicateSearch.ts
@@ -155,11 +155,11 @@ const getSponsorSearchConditions = (query: DuplicateSearchQuery): Record<string,
 
   if (!query.structureName) return conditions;
 
-  const normalizedSponsor = normalizeText(query.structureName);
+  const rawSponsorRegex = query.structureName.toLowerCase();
   conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", query.structureName));
   conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", query.structureName));
   for (const token of tokenize(query.structureName).slice(0, 4)) {
-    if (token === normalizedSponsor) continue;
+    if (token === rawSponsorRegex) continue;
     conditions.push(buildStringRegexCondition("mainSponsorInfo.nom", token));
     conditions.push(buildStringRegexCondition("mainSponsorInfo.acronyme", token));
   }
@@ -206,15 +206,19 @@ const buildConstrainedMatchStage = (
 };
 
 const buildRegexScoreExpression = (
-  fieldExpression: string,
+  fieldExpression: string | Record<string, unknown>,
   value: string,
   score: number,
+  escapeValue = true,
 ): Record<string, unknown> => ({
   $cond: [
     {
       $regexMatch: {
-        input: { $ifNull: [fieldExpression, ""] },
-        regex: escapeRegExp(value),
+        input:
+          typeof fieldExpression === "string"
+            ? { $ifNull: [fieldExpression, ""] }
+            : fieldExpression,
+        regex: escapeValue ? escapeRegExp(value) : value,
         options: "i",
       },
     },
@@ -223,19 +227,35 @@ const buildRegexScoreExpression = (
   ],
 });
 
+const joinFieldValues = (fieldExpression: string): Record<string, unknown> => ({
+  $cond: [
+    { $isArray: fieldExpression },
+    {
+      $reduce: {
+        input: { $ifNull: [fieldExpression, []] },
+        initialValue: "",
+        in: { $concat: ["$$value", " ", "$$this"] },
+      },
+    },
+    { $ifNull: [fieldExpression, ""] },
+  ],
+});
+
 const buildDuplicateSearchScoreExpression = (
   query: DuplicateSearchQuery,
 ): Record<string, unknown> => {
+  const rawTitleRegex = query.title.toLowerCase();
   const expressions: Record<string, unknown>[] = [
-    buildRegexScoreExpression("$translations.fr.content.titreInformatif", query.title, 6),
-    buildRegexScoreExpression("$translations.fr.content.titreMarque", query.title, 6),
+    buildRegexScoreExpression("$translations.fr.content.titreInformatif", query.title, 4),
+    buildRegexScoreExpression("$translations.fr.content.titreMarque", query.title, 4),
   ];
 
   for (const token of tokenize(query.title)) {
+    if (token === rawTitleRegex) continue;
     expressions.push(
-      buildRegexScoreExpression("$translations.fr.content.titreInformatif", token, 2),
+      buildRegexScoreExpression("$translations.fr.content.titreInformatif", token, 1),
     );
-    expressions.push(buildRegexScoreExpression("$translations.fr.content.titreMarque", token, 2));
+    expressions.push(buildRegexScoreExpression("$translations.fr.content.titreMarque", token, 1));
   }
 
   for (const token of tokenize(query.description).slice(0, 4)) {
@@ -245,17 +265,32 @@ const buildDuplicateSearchScoreExpression = (
     expressions.push(buildRegexScoreExpression("$translations.fr.content.titreMarque", token, 1));
   }
 
-  if (query.structureName) {
-    const normalizedSponsor = normalizeText(query.structureName);
-    expressions.push(buildRegexScoreExpression("$mainSponsorInfo.nom", query.structureName, 5));
+  if (query.commune) {
+    expressions.push(buildRegexScoreExpression(joinFieldValues("$map.city"), query.commune, 5));
+  }
+
+  for (const department of query.departments) {
     expressions.push(
-      buildRegexScoreExpression("$mainSponsorInfo.acronyme", query.structureName, 5),
+      buildRegexScoreExpression(
+        joinFieldValues("$metadatas.location"),
+        departmentToRegex(department),
+        4,
+        false,
+      ),
+    );
+  }
+
+  if (query.structureName) {
+    const rawSponsorRegex = query.structureName.toLowerCase();
+    expressions.push(buildRegexScoreExpression("$mainSponsorInfo.nom", query.structureName, 7));
+    expressions.push(
+      buildRegexScoreExpression("$mainSponsorInfo.acronyme", query.structureName, 7),
     );
 
     for (const token of tokenize(query.structureName).slice(0, 4)) {
-      if (token === normalizedSponsor) continue;
-      expressions.push(buildRegexScoreExpression("$mainSponsorInfo.nom", token, 1));
-      expressions.push(buildRegexScoreExpression("$mainSponsorInfo.acronyme", token, 1));
+      if (token === rawSponsorRegex) continue;
+      expressions.push(buildRegexScoreExpression("$mainSponsorInfo.nom", token, 2));
+      expressions.push(buildRegexScoreExpression("$mainSponsorInfo.acronyme", token, 2));
     }
   }
 


### PR DESCRIPTION
## Summary
- prevent numeric department-code substring false positives in duplicate scoring
- rank MongoDB candidates by coarse title/sponsor duplicate signal before applying the database cap
- avoid redundant sponsor regex conditions and add regression coverage

## Test plan
- [x] `pnpm --filter @refugies-info/client test -- agentDuplicateSearch`
- [x] `pnpm --filter @refugies-info/client check:types`
- [x] `pnpm --filter @refugies-info/client lint`

👾 Generated with [Letta Code](https://letta.com)