### PR TITLE
Fix: autosave KO sur fiche OFPRA avec avis anonymes legacy

### DIFF
--- a/apps/server/src/libs/cleanupAvis.ts
+++ b/apps/server/src/libs/cleanupAvis.ts
@@ -1,7 +1,8 @@
 import type { Avis } from "@refugies-info/mongo";
 
-export const cleanupAvis = (avis: Avis) => {
-  if (avis.userId == null) delete avis.userId;
-  if (avis.anonymousUserId == null) delete avis.anonymousUserId;
-  return avis;
+export const cleanupAvis = (avis: Avis): Avis => {
+  const cleaned = { ...avis };
+  if (cleaned.userId == null) delete cleaned.userId;
+  if (cleaned.anonymousUserId == null) delete cleaned.anonymousUserId;
+  return cleaned;
 };

--- a/apps/server/src/libs/cleanupAvis.ts
+++ b/apps/server/src/libs/cleanupAvis.ts
@@ -1,7 +1,7 @@
 import type { Avis } from "@refugies-info/mongo";
 
 export const cleanupAvis = (avis: Avis) => {
-  if (avis.userId === undefined) delete avis.userId;
-  if (avis.anonymousUserId === undefined) delete avis.anonymousUserId;
+  if (avis.userId == null) delete avis.userId;
+  if (avis.anonymousUserId == null) delete avis.anonymousUserId;
   return avis;
 };

--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -689,12 +689,14 @@ export const cloneDispositifInDrafts = async (id: DispositifId, newData: Partial
 
   // Sanitize legacy data that causes Mongoose validation errors on create()
   // See RI-1174: suggestions with empty strings, RI-1192: null entries in participants
+  // and legacy anonymous feedbacks with userId: null.
   const sanitizedDispositif = dispositif
     ? {
         ...dispositif,
         suggestions:
           dispositif.suggestions?.filter((s) => s.suggestion && s.suggestion.trim() !== "") ?? [],
         participants: dispositif.participants?.filter((p) => p != null) ?? [],
+        avis: dispositif.avis?.map((avis) => cleanupAvis({ ...avis } as Avis)) ?? [],
       }
     : null;
 

--- a/apps/server/src/modules/dispositif/dispositif.repository.ts
+++ b/apps/server/src/modules/dispositif/dispositif.repository.ts
@@ -696,7 +696,7 @@ export const cloneDispositifInDrafts = async (id: DispositifId, newData: Partial
         suggestions:
           dispositif.suggestions?.filter((s) => s.suggestion && s.suggestion.trim() !== "") ?? [],
         participants: dispositif.participants?.filter((p) => p != null) ?? [],
-        avis: dispositif.avis?.map((avis) => cleanupAvis({ ...avis } as Avis)) ?? [],
+        avis: dispositif.avis?.map((avis) => cleanupAvis(avis as Avis)) ?? [],
       }
     : null;
 

--- a/migrations/1780387153155_RemoveNullAvisUserIds.ts
+++ b/migrations/1780387153155_RemoveNullAvisUserIds.ts
@@ -20,18 +20,23 @@ export class Migration1780387153155 implements MigrationInterface {
       const collection = db.collection(collectionName);
       const query = { avis: { $elemMatch: { userId: { $type: "null" } } } };
 
-      const matchedCount = await collection.countDocuments(query);
       const result = await collection.updateMany(
         query,
-        { $unset: { "avis.$[avis].userId": "" } },
-        { arrayFilters: [{ "avis.userId": { $type: "null" } }] },
+        { $unset: { "avis.$[elem].userId": "" } },
+        { arrayFilters: [{ "elem.userId": { $type: "null" } }] },
       );
 
-      totalMatched += matchedCount;
+      totalMatched += result.matchedCount;
       totalModified += result.modifiedCount;
 
       console.log(
-        `[Migration1780387153155] ${collectionName}: removed null avis.userId from ${result.modifiedCount}/${matchedCount} document(s)`,
+        "[Migration1780387153155] " +
+          collectionName +
+          ": removed null avis.userId from " +
+          result.modifiedCount +
+          "/" +
+          result.matchedCount +
+          " document(s)",
       );
     }
 

--- a/migrations/1780387153155_RemoveNullAvisUserIds.ts
+++ b/migrations/1780387153155_RemoveNullAvisUserIds.ts
@@ -1,0 +1,47 @@
+import type { MigrationInterface } from "mongo-migrate-ts";
+import type { Db } from "mongodb";
+
+/**
+ * Migration: remove explicit null userId fields from avis subdocuments.
+ *
+ * Anonymous feedbacks should store anonymousUserId and omit userId entirely.
+ * Legacy documents may contain `avis[].userId: null`, which is invalid with
+ * the Zod/Mongoose schema (`userId` is optional, not nullable) and can break
+ * autosave when an active dispositif is cloned into dispositifs_draft.
+ */
+export class Migration1780387153155 implements MigrationInterface {
+  public async up(db: Db): Promise<void> {
+    const collectionsToClean = ["dispositifs", "dispositifs_draft"];
+
+    let totalMatched = 0;
+    let totalModified = 0;
+
+    for (const collectionName of collectionsToClean) {
+      const collection = db.collection(collectionName);
+      const query = { avis: { $elemMatch: { userId: { $type: "null" } } } };
+
+      const matchedCount = await collection.countDocuments(query);
+      const result = await collection.updateMany(
+        query,
+        { $unset: { "avis.$[avis].userId": "" } },
+        { arrayFilters: [{ "avis.userId": { $type: "null" } }] },
+      );
+
+      totalMatched += matchedCount;
+      totalModified += result.modifiedCount;
+
+      console.log(
+        `[Migration1780387153155] ${collectionName}: removed null avis.userId from ${result.modifiedCount}/${matchedCount} document(s)`,
+      );
+    }
+
+    console.log(
+      `[Migration1780387153155] Total: cleaned ${totalModified}/${totalMatched} document(s)`,
+    );
+  }
+
+  public async down(): Promise<void> {
+    // No-op: cannot recover which anonymous feedbacks originally had userId: null.
+    console.log("[Migration1780387153155] down() is a no-op.");
+  }
+}


### PR DESCRIPTION
## 🎯 Contexte
Certaines fiches actives historiques peuvent contenir des avis anonymes stockés avec :

```json
  "userId": null
```

Or depuis la migration Zod/Mongoose, le schéma AvisZodSchema définit userId comme optionnel, mais non nullable :
userId: zId("User").optional()

Donc userId peut être absent ou être un ObjectId valide, mais pas null.

Lors de l’autosave d’une fiche publiée, le serveur peut cloner la fiche active vers dispositifs_draft via cloneDispositifInDrafts().
Ce clone recrée un document complet avec le schéma strict, ce qui peut faire échouer l’autosave si des sous-documents avis contiennent encore userId: null.

✅ Ce que fait cette PR

1. Nettoyage des avis avant écriture
cleanupAvis() supprime maintenant les champs userId et anonymousUserId quand ils valent null ou undefined.

Avant :
if (avis.userId === undefined) delete avis.userId;

Après :
if (avis.userId == null) delete avis.userId;

Cela normalise correctement les avis anonymes : pas de userId: null, le champ est simplement absent.

2. Protection du clone actif → draft
Dans cloneDispositifInDrafts(), on sanitise désormais aussi les avis, en plus des protections déjà existantes sur :

  - suggestions invalides ;
  - participants contenant des null.

Ajout :
avis: dispositif.avis?.map((avis) => cleanupAvis({ ...avis } as Avis)) ?? [],

Objectif : éviter qu’une donnée legacy encore présente sur une fiche active casse la création du draft.

3. Migration de nettoyage DB

Nouvelle migration :
migrations/1780387153155_RemoveNullAvisUserIds.ts

Elle supprime les champs avis[].userId lorsqu’ils valent explicitement null, dans :
  - dispositifs
  - dispositifs_draft
Les avis ne sont pas supprimés. Les anonymousUserId sont conservés.

🧠 Pourquoi ne pas rendre le schéma nullable ?

On aurait pu accepter userId: null dans le schéma, mais ce serait moins propre.

Le modèle attendu est :

  - avis connecté → userId
  - avis anonyme → anonymousUserId
  - pas d’utilisateur connecté → pas de champ userId

Donc userId: null est une donnée legacy à normaliser, pas un état métier à officialiser.

Comment tester

1. Prendre une fiche active contenant des avis avec userId: null, par exemple la fiche OFPRA concernée.
2. Modifier un champ éditorial mineur.
3. Vérifier que l’autosave ne renvoie plus d’erreur.
4. Vérifier que le draft est bien créé / mis à jour.
5. Après migration, vérifier qu’il ne reste plus d’avis avec userId: null :
db.dispositifs.countDocuments({
    avis: { $elemMatch: { userId: { $type: "null" } } }
})

db.dispositifs_draft.countDocuments({
    avis: { $elemMatch: { userId: { $type: "null" } } }
})

Les deux doivent retourner 0.