### PR TITLE
Fix z-index search badge

### DIFF
--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -87,7 +87,7 @@ const DispositifCard = (props: Props) => {
     >
       <Badge
         small
-        className={cn(badge.className, "absolute top-2 left-2 z-20")}
+        className={cn(badge.className, "absolute top-2 left-2 z-10")}
         aria-label={isRCO ? "Contenu généré par intelligence artificielle" : undefined}
       >
         {isOnline && <i className="ri-at-line me-1" aria-hidden="true"></i>}


### PR DESCRIPTION
Lowered the z-index of the badge on DispositifCard from z-20 to z-10 to fix an unintended overlap with other UI elements in the search results.