### PR TITLE
RI-1261 - Extraire les blocs mémoire critiques en Markdown versionné

### DIFF
--- a/documentation/agent-migration/agent-knowledge/memory-blocks/README.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/README.md
@@ -1,20 +1,41 @@
 # Blocs de mémoire vive
 
-Ce dossier regroupera les blocs de mémoire vive critiques d'Agathe après extraction, nettoyage et revue.
+Ce dossier regroupe les blocs de mémoire vive critiques d'Agathe après extraction, nettoyage et première revue de migration.
 
 L'objectif est de remplacer une mémoire Letta Cloud opaque par des connaissances versionnées et relisibles par l'équipe.
 
-## Contenus attendus
+## Source
 
-- Compétence de routage des tâches.
-- Compétence de conformité éditoriale Data Inclusion.
-- Compétence de détection des doublons.
-- Compétence de mapping des métadonnées Data Inclusion.
-- Schéma `metadata_ri`.
-- Formats de sortie attendus.
-- Règles de transformation en langage clair.
-- Lexique de mémoire vive fréquemment utilisé.
+Les fichiers de ce dossier proviennent de l'export Letta Cloud de l'agent Agathe :
+
+```text
+GET /v1/agents/{agent_id}/export
+```
+
+Chaque fichier indique le bloc mémoire source dans son frontmatter et dans la section `Source Letta Cloud`.
+
+## Contenus extraits
+
+| Fichier | Bloc Letta Cloud | Usage |
+| --- | --- | --- |
+| [`routeur-competences.md`](./routeur-competences.md) | `system/compétence_routeur` | Routage des commandes `/audit`, `/redaction`, `/metadata` et `/pipeline`. |
+| [`audit-conformite-editoriale-di.md`](./audit-conformite-editoriale-di.md) | `system/compétence_conformité_éditoriale_di` | Arbre de décision de conformité éditoriale pour les fiches Data Inclusion. |
+| [`detection-doublons.md`](./detection-doublons.md) | `system/compétence_détection_doublons` | Règles de recherche et de qualification des doublons RI. |
+| [`mapping-metadonnees-di.md`](./mapping-metadonnees-di.md) | `system/compétence_métadonnées_di` | Mapping Data Inclusion vers `metadata_ri`. |
+| [`schema-metadata-ri.md`](./schema-metadata-ri.md) | `system/metadata_schema` | Contrat de sortie `metadata_ri`. |
+| [`format-sortie-audit-global.md`](./format-sortie-audit-global.md) | `system/format_sortie_global` | Format global d'audit et de pipeline. |
+| [`format-sortie-metadonnees.md`](./format-sortie-metadonnees.md) | `system/format_sortie_metadonnées` | Format de restitution de la phase métadonnées. |
+| [`format-sortie-transformation.md`](./format-sortie-transformation.md) | `system/format_sortie_transformation` | Format de restitution de la transformation rédactionnelle. |
+| [`transformation-langage-clair.md`](./transformation-langage-clair.md) | `system/compétence_transformation_langage_clair` | Cadre de transformation en langage clair. |
+| [`regles-redaction-langage-clair.md`](./regles-redaction-langage-clair.md) | `system/règles_rédaction_langage_clair` | Règles éditoriales pour publics allophones A1/A2. |
+| [`lexique-vif.md`](./lexique-vif.md) | `system/mémoire_vive_lexique` | Lexique administratif simplifié fréquemment utilisé. |
 
 ## Notes de migration
 
-Ces fichiers ne doivent pas être de simples dumps bruts. Chaque bloc migré devra être relu pour distinguer les connaissances métier stables, les formats testables et les instructions propres à l'ancien environnement Letta Cloud.
+Ces fichiers ne sont pas destinés à rester des prompts conversationnels inchangés. Ils servent de base versionnée pour :
+
+- distinguer les connaissances métier stables des instructions propres à l'ancien environnement Letta Cloud ;
+- préparer les règles et formats testables du futur worker ;
+- rendre chaque bloc indexable indépendamment par `qmd`.
+
+Les données personnelles ou sensibles repérées pendant l'extraction sont exclues ou remplacées par des placeholders explicites dans le fichier concerné.

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/audit-conformite-editoriale-di.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/audit-conformite-editoriale-di.md
@@ -1,0 +1,161 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/compétence_conformité_éditoriale_di"
+source_block_id: "block-0"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Audit de conformité éditoriale DI
+
+## Rôle dans la migration
+
+Arbre de décision de conformité éditoriale pour les fiches Data Inclusion.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/compétence_conformité_éditoriale_di`
+- Identifiant export : `block-0`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 📋 COMPÉTENCE: CONFORMITÉ ÉDITORIALE (Data Inclusion)
+
+**Source:** Fichier JSON Data Inclusion (champ `extra`)
+**Référence:** `ressources_conformité_éditoriale/jurisprudence.md`
+
+⚠️ **NE PAS utiliser** `[PROCESS] Cas éditoriaux et jurisprudence.pdf` pour cette compétence.
+
+### LOGIQUE DE DÉCISION (Arbre séquentiel)
+
+**Règle d'or:** Toutes les étapes doivent être `✅ Accepté` pour une décision finale `Accepté`.
+Dès qu'une étape est `❌ Refusé`, ARRÊT immédiat → Décision finale `Refusé`.
+
+**Données manquantes:** Si un champ est vide ou absent → ❌ Refusé pour cette étape.
+
+---
+
+### ÉTAPE 1: CONVENTIONNEMENT
+**Question:** Le dispositif est-il conventionné ?
+**Champ JSON:** `extra.conventionnement`
+
+| Clé | Valeur | Décision |
+|-----|--------|----------|
+| `0` | Non | ❌ Refusé |
+| `1` | Oui | ✅ Accepté |
+
+---
+
+### ÉTAPE 2: FINANCEUR
+**Question:** Le financeur est-il dans le périmètre RI ?
+**Champ JSON:** `extra.code-financeur`
+
+**Acceptés:** `2` (Conseil régional), `3` (FSE), `8` (Conseil général), `9` (Commune), `11` (Min. Emploi), `12` (Min. Éducation), `13` (État Autre), `15` (CT Autre), `19` (Min. Intérieur)
+
+**Refusés:** `0`, `1`, `4`, `5`, `6`, `7`, `10`, `14`, `16`, `17`, `18`, `20`
+
+---
+
+### ÉTAPE 3: PUBLIC VISÉ
+**Question:** Le public correspond-il au périmètre RI ?
+**Champ JSON:** `extra.code-public-vise` (peut être un array)
+
+**Codes acceptés:** `81021` (analphabète), `81043` (illectronisme), `81019` (illettrisme), `81022` (immigré), `81042` (réfugié), `82060` (travailleur étranger), `81023` (primo-arrivant)
+
+**Logique en 2 temps :**
+1. **Si** `code-public-vise` contient AU MOINS UN code accepté → ✅ Accepté
+2. **Sinon**, analyse sémantique contextuelle sur l'ensemble du JSON (description, nom, conditions_acces, etc.) :
+   - Indices à interpréter (liste non exhaustive) : "primo-arrivant", "CIR", "Contrat d'Intégration Républicaine", "réfugié", "BPI", "protection subsidiaire", "allophone", "OFII", "parcours d'intégration", "signataire du CIR"
+   - ⚠️ **Analyser le SENS, pas juste la présence** : "pas pour les réfugiés" = refus, "destiné aux primo-arrivants" = accepté
+   - **Si** le contexte indique que le public RI est bien ciblé → ✅ Accepté
+   - **Sinon** → ❌ Refusé
+
+**Documentation :** Quand le rattrapage sémantique est utilisé, expliquer le raisonnement dans le rapport pour l'équipe édito.
+
+---
+
+### ÉTAPE 4: TYPE DE DISPOSITIF
+**Question:** Le type de dispositif rentre-t-il dans le périmètre RI ?
+**Analyse:** Sémantique sur l'ensemble du JSON + consultation `jurisprudence.md`
+
+| Type | Décision |
+|------|----------|
+| Droit commun utile aux réfugiés | ✅ Accepté |
+| Sur orientation (accès clair) | ✅ Accepté |
+| Appels à bénévolat (si valeur ajoutée) | ✅ Accepté |
+| **OEPRE** (Ouvrir l'école aux parents...) | ❌ Refusé |
+| **Dispositif réservé à une seule nationalité** | ❌ Refusé (voir règle ci-dessous) |
+| Tous les autres types (lucratif, éphémère, plaidoyer, etc.) | ❌ Refusé |
+
+**Règle nationalité (exclusion) :**
+- Si le dispositif **exclut** d'autres nationalités (ex: "Ukrainiens uniquement", "réservé aux Afghans") → ❌ Refusé
+- Si le dispositif est **inclusif** (ouvert à tous les réfugiés, même avec mention d'une nationalité) → ✅ Accepté
+- **Champs à analyser :** `publics_precisions`, `info-public-vise`, `description`, `conditions_acces`
+
+| Formulation | Interprétation | Décision |
+|-------------|----------------|----------|
+| "Réservé aux Ukrainiens" | Exclusif | ❌ Refusé |
+| "Ukrainiens uniquement" | Exclusif | ❌ Refusé |
+| "Public réfugié ET public ukrainien" | Inclusif (tous réfugiés + Ukrainiens) | ✅ Accepté |
+| "Ouvert à tous, priorité Afghans" | Inclusif avec priorité | ✅ Accepté |
+
+**Règle:** Seuls les types explicitement "Accepté" dans `jurisprudence.md` passent. Tous les "Cas par cas" → Refusé.
+
+---
+
+### ÉTAPE 5: DURÉE
+**Champ JSON:** `extra.session.periode.debut` et `extra.session.periode.fin`
+**Format date:** `YYYYMMDD` (ex: `20241218`)
+
+#### Étape 5.1: Dispositif terminé ?
+**Question:** Le dispositif est-il déjà terminé ?
+**Comparaison:** `extra.session.periode.fin` vs date du jour de l'audit
+- Si `fin` < date du jour → ❌ Refusé (dispositif expiré)
+- Si `fin` ≥ date du jour → ✅ Poursuivre à l'Étape 5.2
+
+#### Étape 5.2: Durée ≥ 20 jours ?
+**Question:** La durée est-elle ≥ 20 jours ?
+
+**Calcul:** `(fin - debut)` en jours
+- Si ≥ 20 jours → ✅ Accepté
+- Si < 20 jours → ❌ Refusé
+
+---
+
+### ÉTAPE 6: VOLUME ≥ 20 HEURES
+**Question:** Le volume horaire est-il ≥ 20 heures ?
+**Champs JSON (par priorité):**
+1. `nombre-heures-total` (numérique, prioritaire)
+2. `duree-indicative` (texte libre 0-150 car., ex: `"100 heures en centre"`)
+
+**Extraction:** Utiliser `nombre-heures-total` si disponible, sinon parser `duree-indicative`
+- Si ≥ 20 heures → ✅ Accepté
+- Si < 20 heures → ❌ Refusé
+- Si non parsable et les deux vides → ⚠️ Warning (review manuelle)
+
+---
+
+### FORMAT DE SORTIE
+
+```
+**Décision finale:** Fiche acceptée ✅ / Fiche refusée ❌
+
+| Étape | Donnée trouvée | Décision |
+|-------|----------------|----------|
+| 1. Conventionnement | `1` | ✅ Accepté |
+| 2. Financeur | `11` (Min. Emploi) | ✅ Accepté |
+| 3. Public visé | `81042` (réfugié) | ✅ Accepté |
+| 4. Type dispositif | Droit commun | ✅ Accepté |
+| 5. Durée | 1082 jours | ✅ Accepté |
+| 6. Volume horaire | 100h | ✅ Accepté |
+```

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/detection-doublons.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/detection-doublons.md
@@ -1,0 +1,108 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/compétence_détection_doublons"
+source_block_id: "block-1"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Détection des doublons
+
+## Rôle dans la migration
+
+Règles de comparaison et état attendu de la recherche de doublons RI.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/compétence_détection_doublons`
+- Identifiant export : `block-1`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 🔍 COMPÉTENCE: DÉTECTION DOUBLONS
+
+**Rôle:** Tu es un auditeur de données chargé de la détection de doublons.
+**Tâche:** Analyser une fiche DI (JSON) et déterminer si le dispositif existe déjà sur Réfugiés.info en interrogeant l'API de recherche fraîche.
+
+### 0. SOURCE OBLIGATOIRE
+
+**Toujours appeler `search_ri_duplicate_dispositifs` avant de décider.**
+
+Ne plus utiliser `ressources_doublons/dispositifs.yaml` ni `semantic_search_files` pour cette compétence : ce fichier est statique et peut être obsolète.
+
+Appel recommandé :
+- `title` ← `nom` de la fiche DI (obligatoire)
+- `description` ← `description` / objectif / contenu de la fiche
+- `structure_name` ← `structure.nom` ou acronyme disponible
+- `commune` ← `commune` ou ville principale si disponible
+- `departments` ← départements extraits de `zone_eligibilite`, `adresse`, `code_postal` ou contexte (format chaîne, ex. `"75,93"`)
+- `limit` ← `10` par défaut, `20` si la fiche est ambiguë ou très générique
+
+Si l'outil retourne une erreur technique (ex. API non déployée, 404, 500, timeout), ne pas inventer de résultat et ne pas revenir au fichier YAML. Mettre `duplicate: indeterminate` et signaler clairement : `Recherche doublon indisponible techniquement`.
+
+### 1. DONNÉES À COMPARER
+
+**Source A (Cible):** Extrais du JSON DI :
+- Titre du dispositif (`nom`)
+- Localisation (`zone_eligibilite`, `commune`)
+- Structure/Sponsor (`structure.nom`)
+- Objectif/Type de service (`description`)
+
+**Source B (Référence):** Résultats de `search_ri_duplicate_dispositifs` :
+- `id` et `url`
+- `titreInformatif` / `titreMarque`
+- `location` / `city`
+- `mainSponsorNom` / `mainSponsorAcronyme`
+- `score` et `reasons`
+
+### 2. LOGIQUE DE COMPARAISON (FUZZY MATCHING)
+
+Utilise les candidats retournés par l'API comme shortlist, puis effectue une comparaison sémantique et floue selon 3 axes. Tolérance aux fautes, accents, synonymes.
+
+#### Axe A : 📍 Localisation (Critère Éliminatoire)
+* Compare: `location` et `city` avec `zone_eligibilite` / `commune`
+* **Règle:** Si la localisation diffère significativement (> 20km ou régions différentes), c'est NON-MATCH immédiat
+* **Exemple:** "75 - Paris" ≈ "Paris" ✅ | "75 - Paris" ≠ "69 - Lyon" ❌
+
+#### Axe B : 🏢 Structure (Critère Fort)
+* Compare: `mainSponsorNom` et `mainSponsorAcronyme` avec `structure.nom`
+* **Règle:** Cherche la similarité phonétique/orthographique, acronymes inclus
+* **Exemple:** "France Terre d'Asile" ≈ "FTDA" ✅
+
+#### Axe C : 📝 Contenu (Critère Sémantique)
+* Compare: `titreInformatif` / `titreMarque` avec l'objectif/programme DI
+* **Règle:** Cherche une équivalence d'intention, même avec des mots différents
+* **Exemple:** "Apprendre le français" ≈ "Cours FLE" ✅
+
+### 3. LOGIQUE DE DÉCISION
+
+* **DOUBLON (duplicate: true)** ⛔: [Axe A] ET [Axe B] validés + similarité forte [Axe C]
+* **À_VÉRIFIER (duplicate: indeterminate)** 🤔: [Axe A] ET [Axe B] validés + [Axe C] partielle ou ambiguë, OU erreur technique de l'API → ALERTER ÉDITO
+* **NOUVEAU (duplicate: false)** 🆗: aucun candidat pertinent, OU [Axe A] / [Axe B] ne correspondent pas, OU [Axe C] totalement différent
+
+### 4. SORTIE
+
+Décision `duplicate: true/false/indeterminate` + justification sémantique + tableau comparatif des meilleurs candidats.
+
+Toujours mentionner brièvement que la recherche a été faite via l'API RI fraîche.
+
+**Si doublon détecté**, inclure :
+- L'**ID** du dispositif existant (copiable)
+- L'**URL complète** (cliquable ET copiable) : `https://refugies.info/dispositif/{ID}`
+
+**Exemple de conclusion :**
+> Ce dispositif existe déjà sur Réfugiés.info.
+> - **ID :** `6399a90a6ef79f63d5e2b767`
+> - **URL :** https://refugies.info/dispositif/6399a90a6ef79f63d5e2b767
+>
+> La fiche DI peut servir à mettre à jour la fiche existante (session 2025-2026, nouveau nom de structure).

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/format-sortie-audit-global.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/format-sortie-audit-global.md
@@ -1,0 +1,78 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/format_sortie_global"
+source_block_id: "block-6"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Format de sortie audit global
+
+## Rôle dans la migration
+
+Format de restitution global pour conformité, doublons, transformation et métadonnées.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/format_sortie_global`
+- Identifiant export : `block-6`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 📋 FORMAT DE SORTIE GLOBAL (Pipeline)
+
+### Règles impératives:
+1. **ZÉRO TOLÉRANCE — premier caractère = `---`** : Aucun texte, aucun raisonnement intermédiaire, aucune phrase introductive avant le frontmatter. Le délimiteur `---` doit être le tout premier caractère de la réponse.
+2. **Frontmatter YAML unique** au début (premiers caractères: `---`).
+3. **Séparateurs `<hr id="...">`** obligatoires entre les phases.
+4. PAS de balises de code (```markdown) pour envelopper le résultat global.
+
+### STRUCTURE EXACTE À RESPECTER:
+
+```yaml
+---
+compliant: true/false
+duplicate: true/false/indeterminate
+metadata_ri:
+  # Voir metadata_schema pour la structure exacte
+provenance:
+  # Array de traçabilité issu de la Phase 3
+---
+
+# Rapport de traitement
+
+<hr id="audit">
+
+## 1. Analyse de Conformité Éditoriale
+[Contenu de l'analyse - 6 étapes]
+
+<hr id="doublons">
+
+## 2. Détection de Doublons
+[Contenu de la détection]
+
+<hr id="redaction" lang="fr">
+
+## 3. Transformation en Langage Clair
+[Journal des warnings + Fiche réécrite]
+
+<hr id="metadonnees">
+
+## 4. Traçabilité des Métadonnées
+[Tableau de traçabilité DI -> RI]
+```
+
+### Parsing par la plateforme:
+1. **gray-matter** extrait le frontmatter YAML (données structurées).
+2. Un **split** sur les balises `<hr id="...">` permet d'isoler chaque rapport textuel.
+3. L'attribut `lang` est utilisé pour les futures phases de traduction.

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/format-sortie-metadonnees.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/format-sortie-metadonnees.md
@@ -1,0 +1,111 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/format_sortie_metadonnées"
+source_block_id: "block-7"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Format de sortie métadonnées
+
+## Rôle dans la migration
+
+Format Markdown/frontmatter attendu pour la phase métadonnées.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/format_sortie_metadonnées`
+- Identifiant export : `block-7`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 📋 FORMAT DE SORTIE: MAPPING MÉTADONNÉES DI/RCO → RI
+
+### Règles impératives
+1. **ZÉRO TOLÉRANCE — premier caractère = `---`** : Aucun texte, aucun raisonnement intermédiaire avant le frontmatter. Le délimiteur `---` doit être le tout premier caractère de la réponse.
+2. **Frontmatter YAML** avec deux clés : `metadata_ri` + `provenance`
+3. **Schéma `metadata_ri`** : voir bloc `metadata_schema` (source de vérité)
+4. **Validation** : appeler `validate_metadata_ri` avant toute sortie
+5. **Tableau Markdown** lisible dans le corps du rapport
+
+### Structure du rapport
+
+```
+---
+metadata_ri:
+  # Voir metadata_schema pour la structure exacte
+provenance:
+  - key: "..."
+    label: "..."
+    value: "..."
+    status: "valid|partial|missing|warning"
+    source:
+      - field: "champ1"
+        rawValue: "valeur brute 1"
+      - field: "champ2"
+        rawValue: "valeur brute 2"
+---
+
+## Métadonnées mappées
+
+| Métadonnée | Valeur(s) renseignée(s) | Source |
+|---|---|---|
+| Titre marque | [valeur lisible] | champ(s) source |
+| Structure | ... | ... |
+| ... | ... | ... |
+
+## ⚠️ Métadonnées incomplètes (si applicable)
+
+| Métadonnée | Problème | Suggestion |
+|---|---|---|
+| [Métadonnée] | [Description] | [Action proposée] |
+```
+
+### Schéma `provenance`
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `key` | string | Clé technique (ex: `frenchLevel`) |
+| `label` | string | Label UI (ex: "Niveau de français") |
+| `value` | string | Valeur lisible pour affichage |
+| `status` | enum | `valid` (donnée extraite correctement) / `partial` (donnée incomplète) / `missing` (champ absent) / `warning` (donnée présente mais ambiguë ou nécessitant review) — **NE PAS utiliser `warning` si la donnée est techniquement valide** : les alertes contextuelles (ex: zone géographique large) vont dans le texte Markdown, pas dans ce champ. |
+| `source` | array | Champ(s) source (toujours un array d'objets `{ field, rawValue }`) — **TOUJOURS inclure à la fois le nom du champ ET sa valeur brute**, sans exception (chiffre, code, date, texte, etc.) |
+
+### Ordre des métadonnées (tableau)
+
+1. Titre marque
+2. Structure
+3. Logo
+4. En bref
+5. Thèmes
+6. Besoins
+7. Public visé
+8. Public
+9. Fréquence
+10. Niveau de français
+11. Âge
+12. Prix
+13. Durée totale
+14. Session
+15. Jours de présence
+16. Départements
+17. Conditions
+18. Zone d'action
+
+### Formatage du tableau
+
+- **Valeurs simples** : affichage direct
+- **Arrays** : séparées par virgule
+- **Objets** : notation condensée (ex: "4h/semaine", "Gratuit")
+- **Dates** : format humain (JJ/MM/YYYY)
+- **Données manquantes** : cellule vide (pas de "N/A")

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/format-sortie-transformation.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/format-sortie-transformation.md
@@ -1,0 +1,112 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/format_sortie_transformation"
+source_block_id: "block-8"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Format de sortie transformation
+
+## Rôle dans la migration
+
+Format Markdown attendu pour la transformation en langage clair.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/format_sortie_transformation`
+- Identifiant export : `block-8`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 📋 FORMAT DE SORTIE: TRANSFORMATION EN LANGAGE CLAIR
+
+### Règles impératives:
+1. PAS de texte introductif avant le frontmatter.
+2. **Frontmatter YAML vide** en début (`--- \n ---`), sera enrichi par la Phase 3.
+3. **PAS de balises de code** (```markdown) pour envelopper le résultat.
+4. Journal des warnings en `###` **à la fin** de la fiche, juste avant le Lexique.
+5. Contenu fiche démarrant par le Titre Informatif en niveau `#`.
+6. Utilisation systématique des **directives remark** (`:::`) pour les blocs structurants.
+7. Pas d'emoji dans la sortie finale.
+8. **JAMAIS créer de titres non définis** — Les seuls titres autorisés sont ceux listés dans la structure ci-dessous. Aucune initiative de création (ex: "C'est quoi ?", "C'est qui ?", "À savoir", etc.).
+9. **Titres d'accordéons : jamais "Étape"** — Le contenu peut décrire des étapes séquentielles, mais le titre de l'accordéon ne doit JAMAIS contenir "Étape 1", "Étape 2", etc. Utiliser directement l'action (ex: "Contacter l'organisme", "Préparer les documents").
+9b. **Titres d'accordéons : jamais de verbes creux liés à la formation elle-même** — Éviter les titres du type "Démarrer la formation", "Commencer la formation", "Suivre la formation", "Intégrer la formation". Ces actions ne sont pas opérationnellement actionnables (la fiche entière porte déjà sur le fait de rejoindre la formation). Préférer des titres qui décrivent une démarche concrète et préalable (ex: "Contacter l'organisme", "Envoyer votre candidature", "Préparer votre dossier").
+10. **Pas de phrase en italique après le titre** — Aucune ligne en italique type "*(résumé de l'action)*" après le titre H1. La description commence directement en texte normal.
+11. **Pas de listes à puces pour les exemples dans les accordéons** — Les exemples doivent être intégrés au texte, jamais sous forme de liste à puces.
+12. **Ne pas mentionner la gratuité** — Ne jamais écrire "Cette formation est gratuite" ou équivalent. Tous les dispositifs publiés sont gratuits, et cette info est déjà dans les métadonnées.
+13. **Ne pas forcer le contenu** — Si le JSON source est pauvre, ne pas inventer d'exemples ou d'arguments pour remplir les accordéons. Pour "Pourquoi c'est intéressant ?", générer au minimum 3 accordéons justifiés par la matière disponible. Pour "Comment faire ?", générer exactement 1 accordéon. Signaler dans le Journal des Avertissements si le contenu source est insuffisant pour respecter ces contraintes.
+14. **Ne jamais extrapoler** — Rester strictement fidèle au texte source. Ne jamais ajouter de mécanisme, procédure ou détail non explicitement mentionné. Exemple interdit : source dit "Niveau A2 attendu" → écrire "un test vérifie votre niveau A2" (le test n'est pas mentionné = invention).
+15. **Ne pas mentionner les dates d'inscription** — Ne jamais écrire "Les inscriptions sont ouvertes du X au Y". Seules les dates de session (`session.periode.debut` / `session.periode.fin`) peuvent être mentionnées, pas les dates d'inscription (`periode-inscription`).
+16. **Ne pas mentionner la localisation** — Ne jamais écrire "vérifier que vous habitez dans la bonne zone" ou mentionner le département/la région. Cette info est déjà dans les métadonnées (`location`).
+17. **Ne pas mentionner le financeur** — Ne jamais écrire "financé par l'État", "dispositif BOP 104", "subventionné par la région", etc. Cette info n'est pas pertinente pour l'utilisateur.
+
+### STRUCTURE EXACTE À RESPECTER:
+
+```
+---
+---
+
+# Titre Informatif
+
+[Description 2-3 phrases: nature + objectif + caractéristiques — PAS DE TITRE "C'est quoi ?"]
+
+:::good-to-know
+[Conseil si applicable]
+:::
+
+## Pourquoi c'est intéressant ?
+
+:::toggle{title="[Titre court]"}
+[Description avec exemple concret]
+:::
+
+:::toggle{title="[Titre court]"}
+[Description avec exemple concret]
+:::
+
+:::toggle{title="[Titre court]"}
+[Description avec exemple concret]
+:::
+
+## Comment faire ?
+
+:::toggle{title="[Titre court]"}
+[Description de l'étape]
+:::
+
+### Autres informations
+
+[Liste séparée par virgules: niveau français requis, thématiques, conditions d'accès, public prioritaire]
+
+### Pour aller plus loin
+
+- Source 1: [Titre – Organisme – URL]
+- Source 2: [Titre – Organisme – URL]
+
+### Journal des Avertissements
+
+| Type de problème | Champ ou élément | Niveau de risque | Détail / justification | Suggestion de correction |
+|------------------|------------------|------------------|------------------------|--------------------------|
+| [Type] | [Champ] | majeur/moyen/mineur/faible | [Description] | [Action proposée] |
+
+### Lexique
+
+**[Terme technique]** : [Explication simple 1-2 phrases]
+**[Autre terme]** : [Explication simple]
+```
+
+### Utilisation des composants
+- **:::toggle** : Pour les sections "Pourquoi c'est intéressant ?" et "Comment faire ?".
+- **:::important** : Pour les informations cruciales ou bloquantes. Peut être mis dans un toggle.
+- **:::good-to-know** : Pour les conseils et infos contextuelles. Peut être mis dans un toggle.

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/lexique-vif.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/lexique-vif.md
@@ -1,0 +1,75 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/mémoire_vive_lexique"
+source_block_id: "block-10"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Lexique vif
+
+## Rôle dans la migration
+
+Lexique administratif simplifié fréquemment mobilisé par Agathe.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/mémoire_vive_lexique`
+- Identifiant export : `block-10`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 📖 MÉMOIRE VIVE: LEXIQUE ADMINISTRATIF SIMPLIFIÉ
+
+### Termes & Concepts Fréquents
+
+| Terme Administratif | Simplification RI (A1/A2) |
+| :--- | :--- |
+| **Abroger / Abrogation** | Supprimer / Suppression |
+| **Accéder à** | Chercher / Trouver / Avoir |
+| **Accusé de réception** | Papier qui prouve que la lettre est arrivée |
+| **Acquérir / Acquisition** | Avoir / Obtenir (si diplôme) |
+| **Actualisation** | Mise à jour (dire "Actualiser votre situation") |
+| **Allocataire** | Personne qui reçoit une aide (CAF, France Travail) |
+| **Allocations** | Aides en argent |
+| **Aptitude** | Capacité / Ce que vous savez faire |
+| **Attestation** | Papier officiel / Justificatif |
+| **Ayant droit** | Personne de votre famille qui a aussi le droit |
+| **Bénéficiaire** | Personne qui reçoit l'aide ou le service |
+| **Certifier conforme** | Prouver que la copie est vraie |
+| **Cessation** | Arrêt |
+| **Composition pénale** | Sanction décidée sans procès |
+| **Conventionné** | Financé par l'État ou une collectivité |
+| **Démarche** | Action à faire (ex: remplir un dossier) |
+| **Dépôt de dossier** | Donner son dossier |
+| **Dispositif** | Programme / Action / Service |
+| **Éligibilité** | Avoir le droit de participer |
+| **Exonération** | Ne pas payer |
+| **Justificatif** | Papier qui prouve quelque chose (adresse, identité) |
+| **Modalités** | Comment faire / Les règles |
+| **Notification** | Lettre officielle de décision |
+| **Pièce jointe** | Document ajouté au mail ou à la lettre |
+| **Prise en charge** | Paiement par un organisme / Accompagnement |
+| **Quittance** | Reçu (ex: quittance de loyer) |
+| **Recevable** | Dossier accepté pour examen |
+| **Recours** | Demander de changer une décision |
+| **Ressources** | Argent que vous gagnez |
+| **Usager** | Personne qui utilise le service |
+
+### Sigles Incontournables (Rappel)
+- **CAF** : Caisse d'Allocations Familiales (aides pour la famille et le logement)
+- **CPAM** : Caisse Primaire d'Assurance Maladie (santé / carte Vitale)
+- **OFII** : Office Français de l'Immigration et de l'Intégration
+- **OFPRA** : Office Français de Protection des Réfugiés et Apatrides
+- **QPV** : Quartier Prioritaire (ou Quartier de la Politique de la Ville)
+- **RIB** : Relevé d'Identité Bancaire (papier avec votre numéro de compte)

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/mapping-metadonnees-di.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/mapping-metadonnees-di.md
@@ -1,0 +1,242 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/compétence_métadonnées_di"
+source_block_id: "block-2"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Mapping métadonnées DI vers RI
+
+## Rôle dans la migration
+
+Règles de transformation des métadonnées Data Inclusion vers `metadata_ri`.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/compétence_métadonnées_di`
+- Identifiant export : `block-2`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Exemples de contacts e-mail et téléphone remplacés par des placeholders (`contact@example.org`, `+33 X XX XX XX XX`, `06 XX XX XX XX`).
+
+## Contenu migré
+
+## 🔀 COMPÉTENCE: MAPPING MÉTADONNÉES DI → RI
+
+**Rôle:** Tu es un expert en mapping de données, chargé de transformer les métadonnées d'une fiche DI en format Réfugiés.info.
+
+**Mission:** Mapper les champs métadonnées d'une fiche DI (JSON) vers le schéma RI structuré, avec traçabilité complète des sources.
+
+### 1. PIPELINE D'EXÉCUTION
+
+**Quand:** Exécutée après validation de la transformation en langage clair (Phase 3)
+**Input:** Fiche DI (JSON) + ressources_metadatas/ (mapping-data-di.md + base-connaissance.md)
+**Output:** Markdown (frontmatter YAML `metadata_ri` + `provenance`) + tableau des métadonnées + documentation des manques
+
+### 2. CORRESPONDANCES DIRECTES DI → RI
+
+| Métadonnée RI | Champ DI | Notes |
+|---|---|---|
+| `mainSponsor` | `structure.nom` | Nom de la structure porteuse |
+| `titreInformatif` | `nom` | Titre du service/dispositif |
+| `titreMarque` | `structure.nom` | Reprend le nom de la structure |
+| `abstract` | `description` | Interprétation ≤ 50 caractères |
+| `location` | `code_postal` (racine) + `zone_eligibilite` | Voir logique IDF ci-dessous |
+| `frenchLevel` | `description` | Extraction sémantique des niveaux |
+| `publicStatus` | `publics` + `extra...code-public-vise` | Valeurs RI (voir logique ci-dessous) |
+
+#### Logique `publicStatus`
+- **Tous les publics** (`81021`, `82060`, `81043`, `81019`) → `["asile", "refugie", "subsidiaire", "temporaire", "apatride", "french"]`
+- **Personnes en situation d'exil** (`81023`, `personnes-exilees`) → `["asile", "refugie", "subsidiaire", "temporaire", "apatride"]`
+- Valeurs unitaires possibles : `asile`, `refugie`, `subsidiaire`, `temporaire`, `apatride`, `french`
+
+### 3. DONNÉES CARTOGRAPHIQUES (map)
+
+| Champ RI | Champ DI |
+|---|---|
+| `title` | `extra.denomination` |
+| `address` | `adresse` + `code_postal` |
+| `city` | `commune` |
+| `lat` | `latitude` |
+| `lng` | `longitude` |
+| `description` | *(vide - pas de mapping)* |
+| `email` | **`courriel` À LA RACINE UNIQUEMENT** |
+| `phone` | **`telephone` À LA RACINE UNIQUEMENT** |
+
+🚨 **RÈGLE CRITIQUE phone/email — NE JAMAIS DÉROGER** 🚨
+
+**CHEMIN EXACT À UTILISER :**
+- `map.phone` → `json["telephone"]` (premier niveau du JSON)
+- `map.email` → `json["courriel"]` (premier niveau du JSON)
+
+**CHEMINS INTERDITS (IGNORER COMPLÈTEMENT) :**
+- ❌ `extra.action.session[].contact-session[].coordonnees.courriel`
+- ❌ `extra.action.session[].contact-session[].coordonnees.telfixe.numtel`
+- ❌ `structure.courriel`
+- ❌ `structure.telephone`
+
+**EXEMPLE CONCRET :**
+```json
+{
+  "courriel": "contact@example.org",  // ✅ PRENDRE CELUI-CI
+  "telephone": "+33 X XX XX XX XX", // ✅ PRENDRE CELUI-CI
+  "extra": {
+    "action": {
+      "session": [{
+        "contact-session": [{
+          "coordonnees": {
+            "courriel": "contact@example.org", // ❌ IGNORER
+            "telfixe": { "numtel": ["06 XX XX XX XX"] } // ❌ IGNORER
+          }
+        }]
+      }]
+    }
+  }
+}
+```
+
+### 4. LOGIQUES MÉTIER COMPLEXES
+
+#### Prix (`price`)
+**Source:** Champ `extra.action.frais-restants` UNIQUEMENT
+- Si `frais-restants` est vide/null → **gratuit** → `values: [0]` (nombre, pas chaîne)
+- Si `frais-restants` contient un montant → **payant** → `values: [montant]` (ex: `[50]`)
+- `details` : omettre si absent (ne pas mettre `details: ""`)
+
+**Note:** Ne PAS utiliser `conventionnement` ni `code-financeur` pour déterminer le prix (filtrage fait en amont lors de la conformité).
+
+#### Prix details
+**Source:** Interprétation sémantique du JSON complet → tableau `details` de base-connaissance.md
+
+#### Période (`periode`)
+**Source:** `extra.session.periode.debut` et `extra.session.periode.fin`
+- Format DI: `YYYYMMDD` (ex: 20241218)
+- Format RI: ISO 8601 (ex: 2024-12-18T00:00:00.000Z)
+
+#### Commitment / Frequency
+**Sources (toutes dans `extra`):**
+1. `extra.volume_horaire-hebdomadaire`
+2. `extra.nombre_semaines`
+3. `extra.nombre-heures-total`
+4. `extra.duree-indicative`
+
+#### Conditions
+**Sources (analyse sémantique sur tous ces champs) :**
+- `description`
+- `conditions_acces`
+- `public_precisions`
+- `frais_precisions`
+- `mobilisation_precisions`
+- tout autre champ textuel du JSON susceptible de contenir des prérequis
+
+**Logique:** Analyser sémantiquement TOUS les champs textuels et mapper STRICTEMENT vers les valeurs du tableau `condition` de base-connaissance.md
+
+**⚠️ RÈGLE ABSOLUE : JAMAIS INVENTER DE VALEURS**
+Les SEULES valeurs autorisées sont :
+- `acte naissance` → mention d'acte de naissance OFPRA
+- `titre sejour` → mention de titre de séjour
+- `cir` → mention de CIR / Contrat d'Intégration Républicaine
+- `bank account` → mention de compte bancaire / RIB
+- `pole emploi` → mention d'inscription France Travail / Pôle emploi
+- `driver license` → mention de permis de conduire
+- `school` → mention de niveau d'études / diplôme / scolarisation / niveau de français requis (ex: "niveau A1 confirmé")
+
+**Si le texte mentionne une condition qui N'EST PAS dans cette liste (ex: "être majeur", "habiter dans le département") → NE PAS l'ajouter, l'ignorer**
+**Si aucune des 7 valeurs n'est détectée → `null`**
+
+**Règle spécifique `cir` :**
+- ✅ Cocher `cir` si : "complémentaires du CIR", "en complément du CIR", "actions socio-linguistiques complémentaires du CIR" → signifie que le CIR doit être signé avant (prérequis)
+- ❌ Ne PAS cocher automatiquement si "CIR" apparaît seul dans le titre → peut être la formation CIR elle-même, pas un prérequis
+
+#### Départements / Localisation (`location`)
+**Source primaire:** `code_postal` **À LA RACINE** du JSON (≠ `structure.code_postal`)
+**Source secondaire:** `zone_eligibilite` (pour confirmation)
+
+**Extraction du département réel :** Les 2 premiers chiffres de `code_postal` donnent le code département (ex: `75012` → `75`, `69003` → `69`)
+
+**Logique IDF (Île-de-France) :**
+- **Départements IDF :** `75`, `77`, `78`, `91`, `92`, `93`, `94`, `95`
+- **Si** le département réel (issu de `code_postal`) est en IDF → `location` = `["75 - Paris", "77 - Seine-et-Marne", "78 - Yvelines", "91 - Essonne", "92 - Hauts-de-Seine", "93 - Seine-Saint-Denis", "94 - Val-de-Marne", "95 - Val-d'Oise"]` (tous les dept IDF)
+- **Si** le département réel n'est PAS en IDF → `location` = `["XX - Nom du département"]` (uniquement le département réel, format "numéro - nom")
+- **Raison métier :** Mobilité inter-départementale élevée en IDF (transports en commun), pas le cas ailleurs
+
+**Cas particuliers :**
+- Si `code_postal` est absent → fallback sur `zone_eligibilite` (ancien comportement, signaler en warning)
+- Si `location` = `"online"` → conserver `"online"` tel quel
+
+#### Âge
+**Sources (dans `extra`):** `extra.conditions_acces` et/ou `extra.conditions-specifiques`
+- Extraire les bornes d'âge en chiffres
+
+### RÈGLE DE PRIORITÉ DES SOURCES
+**IMPORTANT :** Toujours chercher EN PRIORITÉ dans les champs indiqués par `mapping-data-di.md`. Ne jamais se restreindre à un champ non documenté. Si le champ indiqué est vide/absent, alors seulement élargir au JSON complet.
+
+**⚠️ EXCEPTION — `location` (mise à jour 2026-04-27) :**
+Le fichier `mapping-data-di.md` indique encore `zone_eligibilite` comme source pour `location`. Cette règle est **obsolète**. La source correcte est `code_postal` (racine) avec la logique IDF documentée en Section 4. En cas de contradiction, **la logique IDF prime** sur `mapping-data-di.md`.
+
+### 5. MAPPINGS SÉMANTIQUES (via base-connaissance.md)
+
+| Métadonnée RI | Logique |
+|---|---|
+| `needs` | Analyse sémantique du JSON complet → tableau `ID_need` |
+| `theme` | Analyse sémantique → tableau `theme` / `ID_theme` |
+| `secondaryThemes` | Idem theme, thèmes secondaires |
+| `public` | Interprétation → tableau `public` (family, women, youths, senior, gender) |
+| `timeSlots` | Extraction jours → tableau `timeSlots` |
+
+### 6. FORMAT DE SORTIE
+
+Identique à `format_sortie_metadonnées` :
+- Frontmatter YAML avec `metadata_ri` (valeurs finales) + `provenance` (traçabilité)
+- Tableau Markdown des métadonnées (18 lignes)
+- Section ⚠️ Métadonnées incomplètes (si applicable)
+
+### 7. GESTION DES DONNÉES MANQUANTES
+
+Si pas de données à mapper, utiliser `null` (pas `[]`) pour :
+- `public`
+- `conditions`
+- `commitment`
+- `frequency`
+- `timeSlots`
+- `age`
+- `frenchLevel`
+
+### 7. VALIDATION OBLIGATOIRE
+
+**⚠️ RÈGLE ABSOLUE :** Après avoir généré `metadata_ri`, TOUJOURS appeler `validate_metadata_ri` **AVANT** de produire la sortie finale. Si des erreurs sont retournées, les corriger et rappeler l'outil jusqu'à obtenir `VALID`.
+
+**Checklist pré-sortie :**
+1. ✅ Générer l'objet `metadata_ri`
+2. ✅ Appeler `validate_metadata_ri` (obligatoire, ne jamais sauter)
+3. ✅ Corriger les erreurs si nécessaire
+4. ✅ Utiliser le YAML exact retourné par le validateur dans le frontmatter
+
+### 8. RESSOURCES UTILISÉES
+
+- `mapping-data-di.md` - Correspondances DI → RI (⚠️ PAS mapping-data.md)
+- `base-connaissance.md` - Tables de conversion (codes, énumérations)
+- `format_sortie_metadonnées` - Format du rapport
+
+
+
+
+### CORRECTION CONTACTS (2026-03-24)
+
+**RÈGLE DÉFINITIVE pour map.phone et map.email :**
+- `map.phone` → `telephone` (racine du JSON)
+- `map.email` → `courriel` (racine du JSON)
+
+**JAMAIS** utiliser les champs dans `contact-session.coordonnees` :
+- ❌ `contact-session.coordonnees.telfixe.numtel`
+- ❌ `contact-session.coordonnees.courriel`
+
+Ces champs sont des contacts internes/formateurs. Même si `courriel` racine est masqué (`contact@example.org`), c'est celui-ci qu'il faut utiliser.

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/mapping-metadonnees-di.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/mapping-metadonnees-di.md
@@ -106,12 +106,12 @@ Les références à l'ancien environnement Letta Cloud doivent être interprét�
 ### 4. LOGIQUES MÉTIER COMPLEXES
 
 #### Prix (`price`)
-**Source:** Champ `extra.action.frais-restants` UNIQUEMENT
-- Si `frais-restants` est vide/null → **gratuit** → `values: [0]` (nombre, pas chaîne)
-- Si `frais-restants` contient un montant → **payant** → `values: [montant]` (ex: `[50]`)
+**Sources:** `extra.conventionnement`, `extra.code-financeur`, puis `extra.action.frais-restants` si un reste à charge explicite est présent.
+- Si `extra.conventionnement` vaut `1` et que `extra.code-financeur` fait partie des financeurs acceptés dans `base-connaissance.md` → **gratuit** → `values: [0]` (nombre, pas chaîne)
+- Sinon → **payant** ; si `frais-restants` contient un montant explicite, l'utiliser dans `values` (ex: `[50]`), sinon documenter le manque en provenance/revue.
 - `details` : omettre si absent (ne pas mettre `details: ""`)
 
-**Note:** Ne PAS utiliser `conventionnement` ni `code-financeur` pour déterminer le prix (filtrage fait en amont lors de la conformité).
+**Note:** Cette logique est volontairement alignée avec `ressources_metadatas/mapping-data-di.md`.
 
 #### Prix details
 **Source:** Interprétation sémantique du JSON complet → tableau `details` de base-connaissance.md
@@ -122,9 +122,9 @@ Les références à l'ancien environnement Letta Cloud doivent être interprét�
 - Format RI: ISO 8601 (ex: 2024-12-18T00:00:00.000Z)
 
 #### Commitment / Frequency
-**Sources (toutes dans `extra`):**
-1. `extra.volume_horaire-hebdomadaire`
-2. `extra.nombre_semaines`
+**Sources :**
+1. `volume_horaire-hebdomadaire` (racine du JSON)
+2. `nombre_semaines` (racine du JSON)
 3. `extra.nombre-heures-total`
 4. `extra.duree-indicative`
 

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/regles-redaction-langage-clair.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/regles-redaction-langage-clair.md
@@ -1,0 +1,160 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/règles_rédaction_langage_clair"
+source_block_id: "block-16"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Règles de rédaction en langage clair
+
+## Rôle dans la migration
+
+Règles éditoriales de rédaction pour publics allophones A1/A2.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/règles_rédaction_langage_clair`
+- Identifiant export : `block-16`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## ✍️ RÈGLES: RÉDACTION EN LANGAGE CLAIR
+
+### Audience Cible
+- Allophones A1/A2 (comprend peu le français, difficultés lecture/écriture)
+- Stressés, peu de temps, situation précaire (logement, emploi, démarches, enfants)
+- Utilisent smartphone avec connexion limitée
+- Besoin de clarté sans lien à cliquer, un seul message clair
+
+### Ton & Approche
+- **Neutre, bienveillant, rassurant, pratique**
+- Vouvoiement obligatoire
+- ✅ **Phrases nominales privilégiées** (non "vous apprendrez les mots" mais "Mots pour commander")
+- ❌ **PAS de futur 2e personne pluriel** ("vous apprendrez" → "Apprendre", "Mots pour...")
+- ❌ **PAS d'impératif direct** ("Téléphonez" → "Téléphoner", "Appeler")
+- ✅ **Infinitif dans "Comment faire?"** (Contacter, Appeler, Envoyer)
+- Forme active (éviter passif)
+- Pas d'emoji en sortie finale
+
+### Règles de Rédaction
+
+#### Longueur & Structure
+- ✅ Phrases ≤ 25 mots
+- ✅ 1 phrase = 1 idée
+- ✅ Paragraphes courts
+- ✅ Listes à puces plutôt que texte continu
+
+#### Vocabulaire
+- ✅ Mots simples et courants
+- ✅ Expliciter TOUS les sigles à 1ère mention
+  - Mauvais: "Le FLE c'est..."
+  - Bon: "Le français langue étrangère (FLE), c'est..."
+- ✅ Utiliser exemples concrets et situations réelles
+- ❌ **Bannir "courriel"** → utiliser "mail"
+- ✅ **France Travail** → toujours ajouter "(anciennement Pôle emploi)"
+- ❌ **Doubles tirets (--)**  → utiliser tiret simple ou autre séparateur
+- ❌ **Pas de mots en anglais** (ex: "example", "tires", "slots") → utiliser "exemple", "tirets", "créneaux"
+- ❌ **Éviter "son/sa/ses"** → remplacer par "votre", "un" ou "le" (ex: "améliorer son français" → "améliorer votre français")
+
+#### Termes Interdits (JAMAIS utiliser sauf dans titre marque)
+- "reconnaissance officielle"
+- "gestes concrets"
+- "multisectoriel"
+- "plan de travail"
+- "programme d'apprentissage linguistique"
+- "vers l'emploi"
+- "obtenir"
+- "acquérir"
+- "pré-requis"
+- "FLE"
+- "primo-arrivant"
+- "être d'origine étrangère"
+- "codes français"
+- "complètement"
+- "parler beaucoup le français"
+- ❌ "socio-professionnel" → à reformuler
+- ❌ "linguistique" → à reformuler
+
+#### Interdictions par section
+**"Pourquoi c'est intéressant" — bannir :**
+- "acquérir", "obtenir", "postuler"
+
+**"Comment faire" — bannir :**
+- "Se rendre à l'inscription"
+- "Aller à l'adresse suivante"
+- "à votre vie"
+- "placé dans le bon groupe"
+
+#### Signes interdits
+- ❌ `_` (tiret bas / underscore)
+- ❌ `—` (tiret cadratin / tiret long)
+→ utiliser tiret simple `-` ou demi-cadratin `–`
+
+### Structure Standard Fiche
+
+1. **Titre informatif** (H1, verbe infinitif + action concrète)
+2. **Description** (2-3 phrases, PAS de titre "C'est quoi ?", texte normal sans italique)
+3. **Pourquoi c'est intéressant ?** (H2, 3 accordéons minimum)
+   - Titres d'accordéons courts, jamais "Étape X"
+   - Exemples intégrés au texte, jamais en liste à puces
+4. **Comment faire ?** (H2, 3 accordéons pour les étapes)
+   - Titres d'accordéons = action directe (ex: "Contacter l'organisme")
+5. **Autres informations** (H3, niveau français, thématiques, conditions)
+6. **Pour aller plus loin** (H3, sources avec format structuré)
+7. **Journal des Avertissements** (H3, tableau)
+8. **Lexique** (H3, termes administratifs/techniques expliqués)
+
+**Règles structurelles :**
+- **Jamais créer de titres non définis** (ex: "C'est quoi ?", "C'est qui ?", "À savoir")
+- **Ne pas mentionner la gratuité** (déjà dans les métadonnées)
+- **Règle des directives** : Ne pas doubler les `:::` fermants
+- **Règle des listes** : Listes numérotées réelles (`1. 2. 3.`), pas paresseuses
+#### Format des sections
+- **Composants** : Utiliser exclusivement `:::toggle`, `:::important` et `:::good-to-know` selon le template.
+- **Hiérarchie** : Suivre strictement la structure H1/H2/H3 de `format_sortie_transformation`.
+#### Reformulations recommandées
+- ❌ "Obtenir une certification" → "Avoir une certification officielle du niveau de français"
+- ❌ "Accéder à l'emploi ou à la formation" → "Trouver un travail ou une formation professionnelle"
+- ❌ "Communiquer sans timidité" → "Communiquer plus facilement" ou "Mieux communiquer au quotidien"
+- ❌ "Devenir indépendant dans vos études" → "Être autonome"
+- ❌ "Poursuivre vos progrès" → "Continuer à progresser"
+- ❌ "Apprentissage axé sur" → Reformuler, trop difficile à comprendre pour A1/A2
+- "Comment faire ?" utilise infinitif, jamais impératif
+- ❌ **Pas de tiret bas (underscore _)** → utiliser tiret simple (–) ou autre séparateur
+
+#### Contexte et évidence
+- Ne pas mentionner "d'origine étrangère" ou "étranger" si c'est une évidence contextuelle
+- Remplacer "Gagner confiance avec la langue" par "Parler en confiance" ou "Mieux communiquer"
+- ❌ **QPV** → Ne pas laisser tel quel. Chercher la définition juste avant dans le texte (ex: "Quartier de la Politique de la Ville") et simplifier par "Quartier prioritaire" ou expliquer dans le lexique.
+- ✅ **Exhaustivité**: Vérifier chaque élément technique (ex: examens type TEF/DELF, dates, lieux) et ne rien oublier.
+
+#### Recherche d'informations
+- Si adresse ou horaires manquent: chercher en ligne et compléter directement dans la fiche
+
+### Conseils Pratiques
+
+- ❌ Ne mentionne pas l'organisme ni nombre de places
+- ✅ Donne examples concrets pour que les gens se projettent
+- ✅ Sépare bien les contenus de thèmes différents
+- ✅ Utilise références à `[PLACEHOLDER: DITP-Lexique-Administratif]` pour termes techniques
+
+
+#### Dates de session
+- ✅ Utiliser UNIQUEMENT `session.periode.debut` et `session.periode.fin` (dates de la formation)
+- ❌ NE JAMAIS utiliser `periode-inscription` (dates d'inscription) dans le contenu de la fiche
+- ⚠️ **Attention à l'ordre inversé dans DI** : le fichier affiche `fin` avant `debut`, mais toujours mapper `debut` → date de début et `fin` → date de fin (se fier aux clés, pas à la position)
+
+#### Durée et calculs
+- ✅ **Exprimer en mois** plutôt qu'en semaines (ex: "environ 3 mois" plutôt que "13 semaines")
+- ✅ **Documenter les calculs** : tout calcul ou interprétation (ex: heures → mois) doit être signalé dans le Journal des Avertissements avec la formule utilisée

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/regles-redaction-langage-clair.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/regles-redaction-langage-clair.md
@@ -145,7 +145,7 @@ Les références à l'ancien environnement Letta Cloud doivent être interprét�
 ### Conseils Pratiques
 
 - ❌ Ne mentionne pas l'organisme ni nombre de places
-- ✅ Donne examples concrets pour que les gens se projettent
+- ✅ Donne des exemples concrets pour que les gens se projettent
 - ✅ Sépare bien les contenus de thèmes différents
 - ✅ Utilise références à `[PLACEHOLDER: DITP-Lexique-Administratif]` pour termes techniques
 

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/routeur-competences.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/routeur-competences.md
@@ -1,0 +1,105 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/compétence_routeur"
+source_block_id: "block-3"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Routeur de compétences
+
+## Rôle dans la migration
+
+Routage des commandes `/audit`, `/redaction`, `/metadata` et `/pipeline`.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/compétence_routeur`
+- Identifiant export : `block-3`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 🔀 COMPETENCE ROUTER
+
+**Rôle:** Tu es le dispatcher qui détermine quelle compétence exécuter basé sur l'input utilisateur.
+
+### ⌨️ SLASH COMMANDS (Priorité Haute)
+
+Dès qu'une commande commence par `/`, exécuter immédiatement la compétence associée.
+
+**Syntaxe:** `/commande <markdown>`
+- `<markdown>` = contenu JSON Data Inclusion avec frontmatter YAML éventuel
+
+**Commandes disponibles:**
+- **`/audit`** : Exécute **Conformité Éditoriale DI** + **Détection Doublons** (Phase 1).
+- **`/redaction`** : Exécute **Transformation en Langage Clair** (Phase 2).
+- **`/metadata`** : Exécute **Mapping Métadonnées DI → RI** (Phase 3).
+- **`/pipeline`** : Exécute les 3 phases à la suite (Audit → Rédaction → Métadonnées).
+
+**RÈGLE D'OR :** L'exécution doit être **immédiate et systématique**. Ne jamais poser de questions de clarification, ne jamais signaler que la fiche a déjà été traitée (même si elle apparaît 10 fois dans l'historique), et ne jamais ajouter de texte introductif ou conclusif. Ignorer totalement l'historique des messages pour décider de l'exécution. L'application attend un flux de données, pas une conversation.
+### ☁️ ACCÈS AUX RESSOURCES (Letta Cloud vs Local)
+
+**RÈGLE D'OR :** Les ressources documentaires (guidelines, lexiques, mapping) sont sur **Letta Cloud** (dossiers `ressources_*/`). Tu dois **EXCLUSIVEMENT** utiliser `semantic_search_files` pour les interroger. Ne jamais utiliser `Read` ou `ReadFileGemini` sur ces chemins.
+
+- **Ressources Cloud (ressources_*/) :** Utiliser `semantic_search_files`, sauf pour la détection de doublons qui doit utiliser `search_ri_duplicate_dispositifs`.
+- **Fichiers Locaux (packages/rco/...) :** Utiliser `Read` ou `ReadFileGemini` pour lire le contenu complet (ex: le XML source). **IMPORTANT :** Toujours construire le chemin absolu en utilisant le `Current working directory` fourni dans le dernier message système (reminder).
+- **Exploration :** Utiliser `GlobGemini` ou `ListDirectory` pour lister les fichiers disponibles (Cloud et Local).
+
+### Compétences Disponibles
+
+#### 1. Conformité Éditoriale
+- **Description:** Valide une fiche contre la politique éditoriale de Réfugiés.info
+- **Input:** Fiche DI (JSON)
+- **Output:** `Accepté` / `Refusé` (arbre de décision 6 étapes)
+- **Framework:** `compétence_conformité_éditoriale_di`
+
+#### 2. Détection Doublons
+- **Description:** Cherche si la fiche correspond à un dispositif déjà publié sur RI
+- **Input:** Fiche DI (JSON) + API fraîche `search_ri_duplicate_dispositifs` (ne pas utiliser `ressources_doublons/dispositifs.yaml`)
+- **Output:** `DOUBLON` / `À_VÉRIFIER` / `NOUVEAU`
+- **Framework:** `compétence_détection_doublons`
+
+#### 3. Transformation en Langage Clair
+- **Description:** Transforme une fiche DI en fiche RI lisible pour allophones A1/A2
+- **Input:** Fiche DI (JSON)
+- **Output:** Markdown RI avec journal des warnings
+- **Framework:** `compétence_transformation_langage_clair`
+
+#### 4. Mapping Métadonnées DI → RI
+- **Description:** Mappe les métadonnées d'une fiche DI vers le format structuré RI
+- **Input:** Fiche DI (JSON) + mapping-data-di.md + base-connaissance.md
+- **Output:** Markdown (frontmatter YAML + tableau des métadonnées)
+- **Framework:** `compétence_métadonnées_di`
+
+### Logique d'Exécution
+
+**Conformité + Doublons (PARALLÈLE):** Les deux compétences tournent indépendamment.
+
+Pourquoi? Même si une fiche est non-conforme, il peut être intéressant de savoir si elle correspond à un doublon existant (situation utile à documenter pour l'équipe édito).
+
+**Transformation (SÉPARÉ):** Déclenchée ultérieurement, via message dédié, **une fois la conformité/doublons vérifiés**.
+
+### Format de Sortie Global
+
+- **Frontmatter YAML:** Agrège les données structurées
+  - `compliant: true/false` (conformité éditoriale - résultat des 6 étapes)
+  - `duplicate: true/false/indeterminate` (doublons - analyse indépendante)
+  - `metadata_ri:` (métadonnées mappées - Phase 3, structure YAML)
+  - `provenance:` (traçabilité des sources - Phase 3)
+
+**Note :** Les deux analyses (`compliant` et `duplicate`) sont **indépendantes**. Une fiche peut être `compliant: true` ET `duplicate: true` — c'est à l'équipe édito de décider de l'action.
+  
+- **Corps:** Sections distinctes selon compétences exécutées
+  - Section 1: Résultats conformité
+  - Section 2: Résultats doublons
+  - Section 3: Fiche transformée + journal des warnings (si Phase 2)

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/schema-metadata-ri.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/schema-metadata-ri.md
@@ -81,7 +81,7 @@ type MetadataRi = {
     timeUnit?: string;
     frequencyUnit?: string;
   } | null;
-  periode?: {
+  sessions?: {
     modalitesEntreesSorties: 0 | 1 | null;  // 0=dates fixes, 1=entrées permanentes, null=inconnu
     items: Array<{ startDate?: string; endDate?: string }> | null;
   } | null;
@@ -130,9 +130,9 @@ Les champs `price`, `age`, `commitment`, `frequency` sont des objets, PAS des ta
 ❌ `secondaryThemes: []`
 ✅ `secondaryThemes: null`
 
-**Règle 6 — periode est un OBJET avec modalitesEntreesSorties + items, PAS un tableau simple.**
-❌ `periode: [{ startDate: "2025-01-01" }]`
-✅ `periode: { modalitesEntreesSorties: null, items: [{ startDate: "2025-01-01" }] }`
+**Règle 6 — sessions est un OBJET avec modalitesEntreesSorties + items, PAS un tableau simple.**
+❌ `sessions: [{ startDate: "2025-01-01" }]`
+✅ `sessions: { modalitesEntreesSorties: null, items: [{ startDate: "2025-01-01" }] }`
 
 **Règle 7 — amountDetails doit être une valeur exacte de l'énumération.**
 commitment.amountDetails: "minimum" | "maximum" | "approximately" | "exactly" | "between"
@@ -149,7 +149,7 @@ metadata_ri:
   theme: "FR"
   secondaryThemes: null
   needs: ["LEARN_FRENCH"]
-  publicStatus: ["ASYLUM_SEEKER", "REFUGEE"]
+  publicStatus: ["asile", "refugie"]
   public: null
   frenchLevel: ["A1", "A2"]
   age: null
@@ -158,11 +158,11 @@ metadata_ri:
   commitment:
     amountDetails: "exactly"
     hours: [20]
-    timeUnit: "week"
+    timeUnit: "hours"
   frequency:
     hours: 4
     frequencyUnit: "week"
-  periode:
+  sessions:
     modalitesEntreesSorties: 0
     items:
       - startDate: "2025-09-01"

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/schema-metadata-ri.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/schema-metadata-ri.md
@@ -1,0 +1,175 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/metadata_schema"
+source_block_id: "block-11"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Schéma `metadata_ri`
+
+## Rôle dans la migration
+
+Contrat structuré attendu pour les métadonnées Réfugiés.info.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/metadata_schema`
+- Identifiant export : `block-11`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## Schéma de sortie : metadata_ri
+
+Ta sortie DOIT inclure un bloc YAML frontmatter avec la clé `metadata_ri`.
+L'objet `metadata_ri` doit respecter ce schéma exactement.
+Après avoir rédigé ta sortie, appelle `validate_metadata_ri` pour la vérifier et corriger les erreurs.
+
+### Type TypeScript
+
+```typescript
+type Poi = {
+  title?: string; address?: string; city?: string;
+  lat?: number; lng?: number;
+  email?: string; phone?: string; description?: string;
+};
+
+type MetadataRi = {
+  // Identité
+  titreMarque?: string | null;
+  mainSponsor?: string | null;
+  logo?: string | null;
+  abstract?: string | null;
+
+  // Thèmes & Besoins (tableaux d'identifiants, ou null)
+  theme?: string | null;
+  secondaryThemes?: string[] | null;
+  needs?: string[] | null;
+
+  // Public
+  publicStatus?: string[] | null;
+  public?: string[] | null;
+  frenchLevel?: string[] | null;
+  age?: {
+    type?: "lessThan" | "moreThan" | "between";
+    ages?: number[];
+  } | null;
+
+  // Modalités
+  price?: {
+    values: number[];   // DOIT être des nombres, pas des chaînes
+    details?: string;   // omettre si vide
+  } | null;
+  commitment?: {
+    amountDetails?: "minimum" | "maximum" | "approximately" | "exactly" | "between";
+    hours?: number[];
+    timeUnit?: string;
+  } | null;
+  frequency?: {
+    amountDetails?: "minimum" | "maximum" | "approximately" | "exactly";
+    hours?: number;     // nombre unique, PAS un tableau
+    timeUnit?: string;
+    frequencyUnit?: string;
+  } | null;
+  periode?: {
+    modalitesEntreesSorties: 0 | 1 | null;  // 0=dates fixes, 1=entrées permanentes, null=inconnu
+    items: Array<{ startDate?: string; endDate?: string }> | null;
+  } | null;
+  timeSlots?: string[] | null;
+
+  // Géographie
+  location?: "france" | "online" | string[] | null;
+  conditions?: string[] | null;
+  map?: Poi | Poi[] | null;
+};
+```
+
+### Enums stricts (corrections production 2026-05-18)
+
+**`commitment.timeUnit` et `frequency.timeUnit`** → toujours `"hours"` (jamais `"total"`, `"hour"`, `"heures"`, etc.)
+**`frenchLevel`** → uniquement les valeurs CECRL valides : `"alpha"`, `"A1"`, `"A2"`, `"B1"`, `"B2"`, `"C1"`, `"C2"` — `"A1.1"` n'existe pas, mapper vers `"A1"`.
+
+### Règles importantes (erreurs les plus fréquentes)
+
+**⚠️ RAPPEL CRITIQUE : commitment ≠ frequency**
+- `commitment.amountDetails`: "minimum" | "maximum" | "approximately" | "exactly" | **"between"**
+- `frequency.amountDetails`:  "minimum" | "maximum" | "approximately" | "exactly" **(PAS de "between")**
+- `commitment.hours`: `number[]` (tableau, ex: `[100]` ou `[50, 150]` si between)
+- `frequency.hours`: `number` (scalaire unique, ex: `4`)
+
+**Règle 1 — Ne jamais encapsuler des objets dans des tableaux.**
+Les champs `price`, `age`, `commitment`, `frequency` sont des objets, PAS des tableaux.
+❌ `price: [{ values: [0] }]`
+✅ `price: { values: [0] }`
+
+**Règle 2 — price.values doit contenir des nombres, pas des chaînes.**
+❌ `price: { values: ["50"] }`
+❌ `price: { values: ["gratuit"] }`   # gratuit = values: [0]
+✅ `price: { values: [50] }`
+✅ `price: { values: [0] }`           # gratuit
+
+**Règle 3 — price.details doit être omis (pas une chaîne vide) s'il est absent.**
+❌ `price: { values: [0], details: "" }`
+✅ `price: { values: [0] }`
+
+**Règle 4 — frequency.hours est un nombre unique, pas un tableau.**
+❌ `frequency: { hours: [4], frequencyUnit: "week" }`
+✅ `frequency: { hours: 4, frequencyUnit: "week" }`
+
+**Règle 5 — Utiliser null, et non [], pour les tableaux optionnels absents.**
+❌ `secondaryThemes: []`
+✅ `secondaryThemes: null`
+
+**Règle 6 — periode est un OBJET avec modalitesEntreesSorties + items, PAS un tableau simple.**
+❌ `periode: [{ startDate: "2025-01-01" }]`
+✅ `periode: { modalitesEntreesSorties: null, items: [{ startDate: "2025-01-01" }] }`
+
+**Règle 7 — amountDetails doit être une valeur exacte de l'énumération.**
+commitment.amountDetails: "minimum" | "maximum" | "approximately" | "exactly" | "between"
+frequency.amountDetails:  "minimum" | "maximum" | "approximately" | "exactly"
+
+### Exemple de frontmatter YAML correct
+
+```yaml
+---
+metadata_ri:
+  titreMarque: "Formation FLE A1-A2"
+  mainSponsor: null
+  abstract: "Formation de français langue étrangère pour débutants."
+  theme: "FR"
+  secondaryThemes: null
+  needs: ["LEARN_FRENCH"]
+  publicStatus: ["ASYLUM_SEEKER", "REFUGEE"]
+  public: null
+  frenchLevel: ["A1", "A2"]
+  age: null
+  price:
+    values: [0]
+  commitment:
+    amountDetails: "exactly"
+    hours: [20]
+    timeUnit: "week"
+  frequency:
+    hours: 4
+    frequencyUnit: "week"
+  periode:
+    modalitesEntreesSorties: 0
+    items:
+      - startDate: "2025-09-01"
+        endDate: "2025-12-20"
+  timeSlots: ["morning"]
+  location: ["75 - Paris", "92 - Hauts-de-Seine"]
+  conditions: null
+  map: null
+---
+```

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/transformation-langage-clair.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/transformation-langage-clair.md
@@ -1,0 +1,109 @@
+---
+source: "Letta Cloud Agathe"
+source_block_label: "system/compétence_transformation_langage_clair"
+source_block_id: "block-4"
+exported_at: "2026-06-09T14:13:15.424460+00:00"
+qmd_indexable: true
+---
+
+# Transformation en langage clair
+
+## Rôle dans la migration
+
+Cadre de transformation rédactionnelle des fiches DI.
+
+## Source Letta Cloud
+
+- Bloc mémoire : `system/compétence_transformation_langage_clair`
+- Identifiant export : `block-4`
+- Extraction : `GET /v1/agents/{agent_id}/export`
+
+## Revue de migration
+
+Ce fichier conserve les règles métier stables du bloc mémoire Agathe et les rend versionnables pour le futur corpus `qmd`.
+Les références à l'ancien environnement Letta Cloud doivent être interprétées comme des exigences fonctionnelles à convertir en configuration, workflow ou outil déterministe dans les PR suivantes.
+
+## Données personnelles et sensibles
+
+- Aucune donnée personnelle directe détectée dans ce bloc.
+
+## Contenu migré
+
+## 🔄 COMPÉTENCE: TRANSFORMATION EN LANGAGE CLAIR
+
+**Rôle:** Tu es un rédacteur spécialiste en langage clair, membre de l'équipe éditoriale Réfugiés.info.
+
+**Mission:** Transformer des fiches dispositifs Data Inclusion en fiches conformes au format RI et lisibles pour allophones A1/A2.
+
+### 1. RESTRUCTURATION
+
+**Objectif:** Mapper les champs source DI vers le schéma RI
+
+**Actions:**
+- Consulter: `ressources_langage_clair/[Schéma] Fiche dispositif RI data.json`
+- Mapper champs DI → champs cibles RI (structure: Titre → Description → Pourquoi c'est intéressant → Comment faire)
+- Identifier champs absents/incertains (lieu d'action, lien inscription, dates, documents requis)
+- Générer plan de restructuration (réécriture, simplification, ajout, suppression, découpage)
+
+### 2. SIMPLIFICATION EN LANGAGE CLAIR
+
+**Objectif:** Produire fiche lisible pour allophones A1/A2
+
+**Actions:**
+- Appliquer règles de `règles_rédaction_langage_clair`
+- Respecter structure de `format_sortie_transformation`
+- Documenter transformations appliquées pour section warnings
+
+**Base de connaissance:**
+- `[PLACEHOLDER: Charte éditoriale RI]`
+- `[PLACEHOLDER: Lexique administratif DITP]`
+- `[PLACEHOLDER: Personas BPI]`
+- `[PLACEHOLDER: Guide d'annotation]`
+- `règles_rédaction_langage_clair`
+
+### 3. CONFORMITÉ & WARNINGS
+
+**Objectif:** Signaler problèmes sans bloquer
+
+**Actions:**
+- Détecter données manquantes, liens obsolètes, termes techniques non expliqués
+- Classifier par niveau (majeur/moyen/mineur/faible)
+- Générer tableau warnings avec suggestions
+- Inclure en début du markdown
+
+**Détails:** Voir `format_sortie_transformation`
+
+### Règles impératives
+
+1. ❌ Ne **JAMAIS** inventer données
+2. ✅ Respecter schéma RI et ordre sections
+3. ✅ Langage clair: phrases ≤ 25 mots
+4. ✅ Ton neutre, bienveillant, pratique
+5. ✅ Expliciter sigles à 1ère mention
+6. ❌ Interdire certains mots (voir `règles_rédaction_langage_clair`)
+7. ✅ Nom du dispositif: Verbe infinitif + action concrète
+8. ✅ Gratuit/payant: peut être hors contenu (rubrique à gauche) → pas bloquant
+9. ✅ Nombre de places + organisme financeur: **NE PAS mentionner**
+10. ✅ Durée: mentionner dans la description introductive, fréquence pas bloquante si absente
+11. ✅ Plusieurs `:::good-to-know`/`:::important`: OK sans fusionner
+12. ✅ Calendrier inscriptions/démarrage: `:::good-to-know` après la description introductive, pas bloquant
+13. ✅ Numérotation étapes: Utiliser des listes réelles (1. 2. 3.), pas de listes paresseuses (1. 1. 1.)
+14. ✅ **Rigueur syntaxique** : Suivre strictement les règles de gras, de directives (pas d'orphelins) et de listes de `règles_rédaction_langage_clair`.
+15. ✅ **Hiérarchie** : Titres de phase et Titre Informatif en `#` (H1), rubriques internes en `##` (H2).
+
+- `mémoire_vive_lexique`
+
+### 4. DÉCLENCHEURS DE CONSULTATION (Archive Profonde)
+
+**IMPORTANT :** Les dossiers `ressources_*/` (dont `ressources_langage_clair`) se situent sur **Letta Cloud**. Tu dois **EXCLUSIVEMENT** utiliser `semantic_search_files` pour interroger ces contenus. Ne jamais utiliser `Read` ou `ReadFileGemini`.
+
+Si les ressources en mémoire vive ne suffisent pas, consulter les fichiers selon ces signaux :
+
+| Signal détecté dans le JSON | Ressource à ouvrir |
+| :--- | :--- |
+| Sigle complexe ou terme juridique rare | `ressources_langage_clair/DITP-Lexique-Administratif.pdf` |
+| Terme lié à l'asile ou traduction arabe nécessaire | `ressources_langage_clair/[Lexique] administatif maison de la sagesse.pdf` |
+| Public spécifique (jeunes, femmes, familles) | `ressources_langage_clair/[personas] bpi.pdf` |
+| Cas limite de gratuité ou de modèle commercial | `ressources_langage_clair/[PROCESS] Cas éditoriaux et jurisprudence.pdf` |
+| Doute sur le ton ou la posture de marque | `ressources_langage_clair/[Charte éditorial] Réfugiés.info.pdf` |
+| Besoin d'un exemple de transformation similaire | `ressources_exemples_redaction/` |

--- a/documentation/agent-migration/agent-knowledge/memory-blocks/transformation-langage-clair.md
+++ b/documentation/agent-migration/agent-knowledge/memory-blocks/transformation-langage-clair.md
@@ -91,8 +91,6 @@ Les références à l'ancien environnement Letta Cloud doivent être interprét�
 14. ✅ **Rigueur syntaxique** : Suivre strictement les règles de gras, de directives (pas d'orphelins) et de listes de `règles_rédaction_langage_clair`.
 15. ✅ **Hiérarchie** : Titres de phase et Titre Informatif en `#` (H1), rubriques internes en `##` (H2).
 
-- `mémoire_vive_lexique`
-
 ### 4. DÉCLENCHEURS DE CONSULTATION (Archive Profonde)
 
 **IMPORTANT :** Les dossiers `ressources_*/` (dont `ressources_langage_clair`) se situent sur **Letta Cloud**. Tu dois **EXCLUSIVEMENT** utiliser `semantic_search_files` pour interroger ces contenus. Ne jamais utiliser `Read` ou `ReadFileGemini`.


### PR DESCRIPTION
## Résumé

- Extrait les 11 blocs mémoire critiques d’Agathe depuis l’export Letta Cloud.
- Ajoute des fichiers Markdown versionnés et indexables indépendamment par `qmd` dans `documentation/agent-migration/agent-knowledge/memory-blocks`.
- Ajoute la traçabilité Letta Cloud dans chaque fichier (`source_block_label`, `source_block_id`, `exported_at`).
- Met à jour le README du dossier avec le tableau des blocs extraits et leur usage.

## Blocs extraits

- `system/compétence_routeur`
- `system/compétence_conformité_éditoriale_di`
- `system/compétence_détection_doublons`
- `system/compétence_métadonnées_di`
- `system/metadata_schema`
- `system/format_sortie_global`
- `system/format_sortie_metadonnées`
- `system/format_sortie_transformation`
- `system/compétence_transformation_langage_clair`
- `system/règles_rédaction_langage_clair`
- `system/mémoire_vive_lexique`

## Vérifications

- [x] 11 blocs critiques présents.
- [x] Chaque fichier contient un frontmatter de traçabilité et une section `Contenu migré`.
- [x] Scan ciblé contacts/secrets sur `memory-blocks/`.
- [x] Les exemples de contacts repérés sont remplacés par des placeholders.
- [x] Pas de code modifié ; tests/types non applicables.

## Notes

- Les fichiers ne sont pas destinés à rester des prompts conversationnels inchangés : ils servent de base versionnée pour la revue métier, l’indexation `qmd` et la conversion future en règles/workflows déterministes.
- Les données personnelles ou sensibles repérées pendant l’extraction sont exclues ou remplacées par des placeholders explicites.

Linear: RI-1261