### PR TITLE
RI-1262 - Configurer qmd pour indexer le corpus agent-knowledge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ npm-debug.log*
 
 # AI assistants
 /.cursorrules
+.qmd/
 .letta/settings.local.json
 .letta
 

--- a/documentation/agent-migration/agent-knowledge/README.md
+++ b/documentation/agent-migration/agent-knowledge/README.md
@@ -27,9 +27,68 @@ Les contenus exportés depuis Letta Cloud sont ajoutés progressivement via le s
 
 ## Indexation qmd
 
-Les documents de ce dossier ont vocation à être indexés par `qmd` afin d'être utilisés par l'agent Letta Code SDK.
+Les documents de ce dossier ont vocation à être indexés par `qmd` afin d'être utilisés par l'agent Letta Code SDK. `qmd` est un moteur local de recherche documentaire Markdown : l'index est construit sur le poste de développement et n'est pas commité.
 
-La configuration d'indexation et les scripts associés seront ajoutés dans des PR ultérieures. Les fichiers de ce corpus doivent donc rester structurés, traçables et faciles à convertir en entrée `qmd`.
+### Installation locale
+
+Installer `qmd` sur le poste de développement :
+
+```bash
+npm install -g @tobilu/qmd
+qmd status
+```
+
+Le dépôt cible Node `24.14.0` via Volta. En cas d'erreur native `better-sqlite3` ou `node-llama-cpp`, vérifier que la version Node active correspond bien à celle du dépôt, puis réinstaller `qmd`.
+
+### Construire l'index
+
+```bash
+pnpm agent-knowledge:qmd:index
+```
+
+Par défaut, le script configure :
+
+- index qmd : `refugies-info-agent-knowledge` ;
+- collection qmd : `agent-knowledge` ;
+- corpus source : `documentation/agent-migration/agent-knowledge`.
+
+Variables de surcharge :
+
+```bash
+QMD_BIN=/chemin/vers/qmd \
+QMD_INDEX=refugies-info-agent-knowledge \
+QMD_COLLECTION=agent-knowledge \
+AGENT_KNOWLEDGE_CORPUS_DIR=documentation/agent-migration/agent-knowledge \
+pnpm agent-knowledge:qmd:index
+```
+
+### Smoke test de recherche
+
+```bash
+pnpm agent-knowledge:qmd:smoke
+```
+
+Le smoke test reconstruit/met à jour l'index, exécute une recherche lexicale ciblant les champs de session du schéma de métadonnées, puis vérifie que le fichier `memory-blocks/schema-metadata-ri.md` ressort dans les résultats.
+
+Variables utiles pour tester une autre requête :
+
+```bash
+QMD_SMOKE_QUERY="conformité éditoriale" \
+QMD_SMOKE_EXPECTED_RESULT="memory-blocks/audit-conformite-editoriale-di.md" \
+pnpm agent-knowledge:qmd:smoke
+```
+
+### Artefacts générés
+
+Les artefacts `qmd` ne doivent pas être commités :
+
+- l'index global qmd est stocké dans le cache utilisateur (`~/.cache/qmd/index.sqlite` sur macOS/Linux) ;
+- un éventuel index local `.qmd/` est ignoré par `.gitignore` ;
+- les embeddings générés par `qmd embed` restent locaux.
+
+Cette PR configure l'indexation lexicale et le smoke test local. La génération d'embeddings (`qmd embed`) reste volontairement manuelle, car elle dépend des modèles et des dépendances natives disponibles sur le poste.
+
+Pour un déploiement futur de l'agent Letta Code sur GCP, l'index `qmd` devra être traité comme un artefact applicatif : soit construit à l'image/deploy time, soit restauré depuis un volume ou cache persistant compatible avec la version du corpus. Il ne faut pas supposer qu'un conteneur éphémère conservera l'index entre deux déploiements.
 
 ## Export Letta Cloud
 

--- a/documentation/agent-migration/agent-knowledge/README.md
+++ b/documentation/agent-migration/agent-knowledge/README.md
@@ -50,7 +50,8 @@ Par défaut, le script configure :
 
 - index qmd : `refugies-info-agent-knowledge` ;
 - collection qmd : `agent-knowledge` ;
-- corpus source : `documentation/agent-migration/agent-knowledge`.
+- corpus source : `documentation/agent-migration/agent-knowledge` ;
+- masque qmd : `**/*.{md,json,csv}` afin d'inclure les ressources Markdown, JSON et CSV du corpus.
 
 Variables de surcharge :
 
@@ -58,6 +59,7 @@ Variables de surcharge :
 QMD_BIN=/chemin/vers/qmd \
 QMD_INDEX=refugies-info-agent-knowledge \
 QMD_COLLECTION=agent-knowledge \
+QMD_MASK='**/*.{md,json,csv}' \
 AGENT_KNOWLEDGE_CORPUS_DIR=documentation/agent-migration/agent-knowledge \
 pnpm agent-knowledge:qmd:index
 ```

--- a/package.json
+++ b/package.json
@@ -168,7 +168,9 @@
     "storybook:publish": "pnpm --filter @refugies-info/storybook storybook:publish",
     "knip": "knip",
     "update-dependencies": "pnpm update -i --filter . --filter api-types --filter ui --filter server --filter client --filter mobile --filter storybook --filter mongo",
-    "agent-knowledge:export": "tsx scripts/export-letta-agent-knowledge.ts"
+    "agent-knowledge:export": "tsx scripts/export-letta-agent-knowledge.ts",
+    "agent-knowledge:qmd:index": "bash scripts/index-agent-knowledge-qmd.sh",
+    "agent-knowledge:qmd:smoke": "bash scripts/smoke-test-agent-knowledge-qmd.sh"
   },
   "engines": {
     "node": "24.14.0"

--- a/scripts/index-agent-knowledge-qmd.sh
+++ b/scripts/index-agent-knowledge-qmd.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CORPUS_DIR="${AGENT_KNOWLEDGE_CORPUS_DIR:-$ROOT_DIR/documentation/agent-migration/agent-knowledge}"
+QMD_BIN="${QMD_BIN:-qmd}"
+QMD_INDEX="${QMD_INDEX:-refugies-info-agent-knowledge}"
+QMD_COLLECTION="${QMD_COLLECTION:-agent-knowledge}"
+
+if ! command -v "$QMD_BIN" >/dev/null 2>&1; then
+  cat >&2 <<EOF
+qmd est introuvable.
+
+Installez-le localement, par exemple :
+  npm install -g @tobilu/qmd
+
+Ou relancez avec QMD_BIN si le binaire porte un autre nom :
+  QMD_BIN=/chemin/vers/qmd pnpm agent-knowledge:qmd:index
+EOF
+  exit 1
+fi
+
+if [[ ! -d "$CORPUS_DIR" ]]; then
+  echo "Corpus introuvable : $CORPUS_DIR" >&2
+  exit 1
+fi
+
+echo "Index qmd            : $QMD_INDEX"
+echo "Collection qmd       : $QMD_COLLECTION"
+echo "Corpus agent-knowledge: $CORPUS_DIR"
+
+if "$QMD_BIN" --index "$QMD_INDEX" collection show "$QMD_COLLECTION" >/dev/null 2>&1; then
+  echo "Collection existante : suppression avant réindexation du worktree courant."
+  "$QMD_BIN" --index "$QMD_INDEX" collection remove "$QMD_COLLECTION"
+fi
+
+echo "Création de la collection."
+"$QMD_BIN" --index "$QMD_INDEX" collection add "$CORPUS_DIR" --name "$QMD_COLLECTION"
+
+echo "Indexation qmd terminée."

--- a/scripts/index-agent-knowledge-qmd.sh
+++ b/scripts/index-agent-knowledge-qmd.sh
@@ -7,6 +7,7 @@ CORPUS_DIR="${AGENT_KNOWLEDGE_CORPUS_DIR:-$ROOT_DIR/documentation/agent-migratio
 QMD_BIN="${QMD_BIN:-qmd}"
 QMD_INDEX="${QMD_INDEX:-refugies-info-agent-knowledge}"
 QMD_COLLECTION="${QMD_COLLECTION:-agent-knowledge}"
+QMD_MASK="${QMD_MASK:-**/*.{md,json,csv}}"
 
 if ! command -v "$QMD_BIN" >/dev/null 2>&1; then
   cat >&2 <<EOF
@@ -29,6 +30,7 @@ fi
 echo "Index qmd            : $QMD_INDEX"
 echo "Collection qmd       : $QMD_COLLECTION"
 echo "Corpus agent-knowledge: $CORPUS_DIR"
+echo "Masque qmd           : $QMD_MASK"
 
 if "$QMD_BIN" --index "$QMD_INDEX" collection show "$QMD_COLLECTION" >/dev/null 2>&1; then
   echo "Collection existante : suppression avant réindexation du worktree courant."
@@ -36,6 +38,6 @@ if "$QMD_BIN" --index "$QMD_INDEX" collection show "$QMD_COLLECTION" >/dev/null 
 fi
 
 echo "Création de la collection."
-"$QMD_BIN" --index "$QMD_INDEX" collection add "$CORPUS_DIR" --name "$QMD_COLLECTION"
+"$QMD_BIN" --index "$QMD_INDEX" collection add "$CORPUS_DIR" --name "$QMD_COLLECTION" --mask "$QMD_MASK"
 
 echo "Indexation qmd terminée."

--- a/scripts/smoke-test-agent-knowledge-qmd.sh
+++ b/scripts/smoke-test-agent-knowledge-qmd.sh
@@ -13,23 +13,11 @@ EXPECTED_URI="qmd://$QMD_COLLECTION/$EXPECTED_RESULT"
 "$ROOT_DIR/scripts/index-agent-knowledge-qmd.sh"
 
 echo "Recherche smoke test : $SMOKE_QUERY"
-
-SEARCH_OUTPUT=""
-for attempt in 1 2 3 4 5; do
-  SEARCH_OUTPUT="$(
-    "$QMD_BIN" --index "$QMD_INDEX" search "$SMOKE_QUERY" \
-      --collection "$QMD_COLLECTION" \
-      -n 10
-  )"
-
-  if grep -Fq "$EXPECTED_URI" <<<"$SEARCH_OUTPUT"; then
-    break
-  fi
-
-  if [[ "$attempt" != "5" ]]; then
-    sleep 1
-  fi
-done
+SEARCH_OUTPUT="$(
+  "$QMD_BIN" --index "$QMD_INDEX" search "$SMOKE_QUERY" \
+    --collection "$QMD_COLLECTION" \
+    -n 10
+)"
 
 printf '%s\n' "$SEARCH_OUTPUT"
 

--- a/scripts/smoke-test-agent-knowledge-qmd.sh
+++ b/scripts/smoke-test-agent-knowledge-qmd.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QMD_BIN="${QMD_BIN:-qmd}"
+QMD_INDEX="${QMD_INDEX:-refugies-info-agent-knowledge}"
+QMD_COLLECTION="${QMD_COLLECTION:-agent-knowledge}"
+SMOKE_QUERY="${QMD_SMOKE_QUERY:-modalitesEntreesSorties}"
+EXPECTED_RESULT="${QMD_SMOKE_EXPECTED_RESULT:-memory-blocks/schema-metadata-ri.md}"
+EXPECTED_URI="qmd://$QMD_COLLECTION/$EXPECTED_RESULT"
+
+"$ROOT_DIR/scripts/index-agent-knowledge-qmd.sh"
+
+echo "Recherche smoke test : $SMOKE_QUERY"
+
+SEARCH_OUTPUT=""
+for attempt in 1 2 3 4 5; do
+  SEARCH_OUTPUT="$(
+    "$QMD_BIN" --index "$QMD_INDEX" search "$SMOKE_QUERY" \
+      --collection "$QMD_COLLECTION" \
+      -n 10
+  )"
+
+  if grep -Fq "$EXPECTED_URI" <<<"$SEARCH_OUTPUT"; then
+    break
+  fi
+
+  if [[ "$attempt" != "5" ]]; then
+    sleep 1
+  fi
+done
+
+printf '%s\n' "$SEARCH_OUTPUT"
+
+if ! grep -Fq "$EXPECTED_URI" <<<"$SEARCH_OUTPUT"; then
+  cat >&2 <<EOF
+Smoke test qmd échoué.
+
+Résultat attendu : $EXPECTED_URI
+Requête          : $SMOKE_QUERY
+Index            : $QMD_INDEX
+Collection       : $QMD_COLLECTION
+EOF
+  exit 1
+fi
+
+echo "Smoke test qmd réussi."


### PR DESCRIPTION
## Résumé

- ajoute un script d’indexation qmd du corpus `documentation/agent-migration/agent-knowledge`
- ajoute un smoke test de recherche qmd sur le bloc `schema-metadata-ri.md`
- documente l’installation, l’usage, les variables de surcharge et les artefacts générés
- ignore les index locaux `.qmd/`
- documente le point de vigilance GCP : l’index qmd devra être reconstruit au déploiement ou restauré depuis un artefact/cache persistant

## Vérification

- `PATH="$HOME/.proto/shims:$HOME/.proto/bin:$PATH" bash -n scripts/index-agent-knowledge-qmd.sh scripts/smoke-test-agent-knowledge-qmd.sh`
- `PATH="$HOME/.proto/shims:$HOME/.proto/bin:$PATH" node -e 'JSON.parse(require("fs").readFileSync("package.json", "utf8")); console.log("package.json ok")'`
- `PATH="$HOME/.proto/shims:$HOME/.proto/bin:$PATH" pnpm agent-knowledge:qmd:smoke`
- `pnpm dlx @biomejs/biome@2.3.7 check package.json --write`
- `git diff --check`

Note : les commandes qmd ont été lancées avec les shims Proto en premier dans le PATH afin d’utiliser le Node repo-pinné (`24.14.0`) plutôt que le Node Homebrew local (`25.x`).