### PR TITLE
RI-1336 - Nettoyer les noms de fichiers exportés du corpus agent-knowledge

### DIFF
--- a/documentation/agent-migration/agent-knowledge/README.md
+++ b/documentation/agent-migration/agent-knowledge/README.md
@@ -16,14 +16,35 @@ Les contenus exportés depuis Letta Cloud sont ajoutés progressivement via le s
 
 > Le dossier `metadatas/` conserve le nom utilisé dans les ressources exportées depuis Letta Cloud, malgré l’anglicisme, afin de préserver la traçabilité avec la source.
 
-| Dossier | Usage |
-| --- | --- |
-| `langage-clair/` | Références de langage clair, chartes, lexiques et guides de transformation rédactionnelle. |
-| `exemples-redaction/` | Exemples de fiches initiales et finales utilisés pour guider les transformations. |
-| `metadatas/` | Mapping, schémas et références de métadonnées Réfugiés.info. |
-| `conformite-editoriale/` | Règles, jurisprudence et référentiels de conformité éditoriale. |
-| `memory-blocks/` | Blocs de mémoire vive critiques d'Agathe, après extraction et revue. |
-| `archival/` | Mémoire archivée utile après tri : décisions, jurisprudence et historique produit. |
+| Dossier                  | Usage                                                                                      |
+| ------------------------ | ------------------------------------------------------------------------------------------ |
+| `langage-clair/`         | Références de langage clair, chartes, lexiques et guides de transformation rédactionnelle. |
+| `exemples-redaction/`    | Exemples de fiches initiales et finales utilisés pour guider les transformations.          |
+| `metadatas/`             | Mapping, schémas et références de métadonnées Réfugiés.info.                               |
+| `conformite-editoriale/` | Règles, jurisprudence et référentiels de conformité éditoriale.                            |
+| `memory-blocks/`         | Blocs de mémoire vive critiques d'Agathe, après extraction et revue.                       |
+| `archival/`              | Mémoire archivée utile après tri : décisions, jurisprudence et historique produit.         |
+
+## Convention de nommage
+
+Les chemins source exportés depuis Letta Cloud sont conservés à l'identique dans les métadonnées de provenance :
+
+- frontmatter `original_file_name` et `source_path` ;
+- manifeste `_export-manifest.json` (`fileName`, `logicalPath`, `originalFileName`).
+
+Les chemins cible versionnés dans le dépôt peuvent corriger une coquille évidente quand le nom propre sera utilisé par les skills, `qmd` ou la documentation de migration. Dans ce cas, la ressource doit documenter :
+
+- `previous_target_path` ;
+- `target_path_normalization_reason` ;
+- la correspondance dans `_export-manifest.json`.
+
+Normalisations appliquées :
+
+| Ancien chemin cible                                                       | Chemin cible versionné                                                     | Raison                                                          |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `langage-clair/[Charte éditorial] Réfugiés.info.md`                       | `langage-clair/[Charte éditoriale] Réfugiés.info.md`                       | Correction de la coquille « éditorial » → « éditoriale ».       |
+| `langage-clair/[Lexique] administatif maison de la sagesse.md`            | `langage-clair/[Lexique] administratif maison de la sagesse.md`            | Correction de la coquille « administatif » → « administratif ». |
+| `langage-clair/[guide dannotation] agent transformateur refugies-info.md` | `langage-clair/[Guide d'annotation] agent transformateur refugies-info.md` | Correction du libellé « dannotation » → « d'annotation ».       |
 
 ## Indexation qmd
 

--- a/documentation/agent-migration/agent-knowledge/_export-manifest.json
+++ b/documentation/agent-migration/agent-knowledge/_export-manifest.json
@@ -4,13 +4,13 @@
   "generatedAt": "2026-06-08T15:50:31.834Z",
   "generatedFiles": [
     "metadatas/mapping-data.md",
-    "langage-clair/[PROCESS] Cas éditoriaux et jurisprudence.md",
+    "langage-clair/[PROCESS] Cas éditoriaux et jurisprudence.md",
     "langage-clair/[Guide d'annotation] agent transformateur refugies-info.md",
     "langage-clair/DITP-Lexique-Administratif.md",
     "langage-clair/[Charte éditoriale] Réfugiés.info.md",
     "langage-clair/[Lexique] administratif maison de la sagesse.md",
     "langage-clair/[personas] bpi.md",
-    "langage-clair/[Schéma] Fiche dispositif RI data.json",
+    "langage-clair/[Schéma] Fiche dispositif RI data.json",
     "metadatas/dispositif-letta.json",
     "metadatas/base-connaissance.md",
     "metadatas/mapping-data-di.md",
@@ -44,7 +44,7 @@
       "processingStatus": "completed",
       "sourceId": "source-0",
       "sourceName": "ressources_langage_clair",
-      "targetPath": "langage-clair/[PROCESS] Cas éditoriaux et jurisprudence.md",
+      "targetPath": "langage-clair/[PROCESS] Cas éditoriaux et jurisprudence.md",
       "totalChunks": 48,
       "weakExtractionReasons": []
     },
@@ -94,7 +94,7 @@
       "targetPath": "langage-clair/[Charte éditoriale] Réfugiés.info.md",
       "totalChunks": 12,
       "weakExtractionReasons": [],
-      "previousTargetPath": "langage-clair/[Charte éditorial] Réfugiés.info.md",
+      "previousTargetPath": "langage-clair/[Charte éditorial] Réfugiés.info.md",
       "targetPathNormalizationReason": "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance"
     },
     {
@@ -140,7 +140,7 @@
       "processingStatus": "completed",
       "sourceId": "source-0",
       "sourceName": "ressources_langage_clair",
-      "targetPath": "langage-clair/[Schéma] Fiche dispositif RI data.json",
+      "targetPath": "langage-clair/[Schéma] Fiche dispositif RI data.json",
       "totalChunks": 48,
       "weakExtractionReasons": []
     },
@@ -256,7 +256,7 @@
       "processingStatus": "completed",
       "sourceId": "source-1",
       "sourceName": "ressources_exemples_redaction",
-      "targetPath": "exemples-redaction/Version finale - Solenciel - Réfugiés.info - février 2025.md",
+      "targetPath": "exemples-redaction/Version finale - Solenciel - Réfugiés.info - février 2025.md",
       "totalChunks": 1,
       "weakExtractionReasons": ["PDF avec un seul chunk indexé, extraction à relire"],
       "exclusionReason": "source retirée du corpus cible après revue qualité"
@@ -272,7 +272,7 @@
       "processingStatus": "completed",
       "sourceId": "source-1",
       "sourceName": "ressources_exemples_redaction",
-      "targetPath": "exemples-redaction/Version finale - Alliance française Aix MArseille - Réfugiés.info - sept 2025.md",
+      "targetPath": "exemples-redaction/Version finale - Alliance française Aix MArseille - Réfugiés.info - sept 2025.md",
       "totalChunks": 1,
       "weakExtractionReasons": ["PDF avec un seul chunk indexé, extraction à relire"],
       "exclusionReason": "source retirée du corpus cible après revue qualité"
@@ -288,7 +288,7 @@
       "processingStatus": "completed",
       "sourceId": "source-1",
       "sourceName": "ressources_exemples_redaction",
-      "targetPath": "exemples-redaction/Version finale - ADFIC Formation de français - Réfugiés.info - juin 2024.md",
+      "targetPath": "exemples-redaction/Version finale - ADFIC Formation de français - Réfugiés.info - juin 2024.md",
       "totalChunks": 1,
       "weakExtractionReasons": ["PDF avec un seul chunk indexé, extraction à relire"],
       "exclusionReason": "source retirée du corpus cible après revue qualité"
@@ -304,7 +304,7 @@
       "processingStatus": "completed",
       "sourceId": "source-1",
       "sourceName": "ressources_exemples_redaction",
-      "targetPath": "exemples-redaction/Version initiale - Solenciel - Réfugiés.info - février 2025.md",
+      "targetPath": "exemples-redaction/Version initiale - Solenciel - Réfugiés.info - février 2025.md",
       "totalChunks": 1,
       "weakExtractionReasons": ["PDF avec un seul chunk indexé, extraction à relire"],
       "exclusionReason": "source retirée du corpus cible après revue qualité"
@@ -320,7 +320,7 @@
       "processingStatus": "completed",
       "sourceId": "source-1",
       "sourceName": "ressources_exemples_redaction",
-      "targetPath": "exemples-redaction/Version initiale - Alliance française Aix Marseille BOp 104  -Réfugiés.info - sept 2025.md",
+      "targetPath": "exemples-redaction/Version initiale - Alliance française Aix Marseille BOp 104  -Réfugiés.info - sept 2025.md",
       "totalChunks": 1,
       "weakExtractionReasons": ["PDF avec un seul chunk indexé, extraction à relire"],
       "exclusionReason": "source retirée du corpus cible après revue qualité"

--- a/documentation/agent-migration/agent-knowledge/_export-manifest.json
+++ b/documentation/agent-migration/agent-knowledge/_export-manifest.json
@@ -5,10 +5,10 @@
   "generatedFiles": [
     "metadatas/mapping-data.md",
     "langage-clair/[PROCESS] Cas éditoriaux et jurisprudence.md",
-    "langage-clair/[guide dannotation] agent transformateur refugies-info.md",
+    "langage-clair/[Guide d'annotation] agent transformateur refugies-info.md",
     "langage-clair/DITP-Lexique-Administratif.md",
-    "langage-clair/[Charte éditorial] Réfugiés.info.md",
-    "langage-clair/[Lexique] administatif maison de la sagesse.md",
+    "langage-clair/[Charte éditoriale] Réfugiés.info.md",
+    "langage-clair/[Lexique] administratif maison de la sagesse.md",
     "langage-clair/[personas] bpi.md",
     "langage-clair/[Schéma] Fiche dispositif RI data.json",
     "metadatas/dispositif-letta.json",
@@ -59,9 +59,11 @@
       "processingStatus": "completed",
       "sourceId": "source-0",
       "sourceName": "ressources_langage_clair",
-      "targetPath": "langage-clair/[guide dannotation] agent transformateur refugies-info.md",
+      "targetPath": "langage-clair/[Guide d'annotation] agent transformateur refugies-info.md",
       "totalChunks": 15,
-      "weakExtractionReasons": []
+      "weakExtractionReasons": [],
+      "previousTargetPath": "langage-clair/[guide dannotation] agent transformateur refugies-info.md",
+      "targetPathNormalizationReason": "Correction du libellé du chemin cible, source Letta Cloud conservée en provenance"
     },
     {
       "chunksEmbedded": 970,
@@ -89,9 +91,11 @@
       "processingStatus": "completed",
       "sourceId": "source-0",
       "sourceName": "ressources_langage_clair",
-      "targetPath": "langage-clair/[Charte éditorial] Réfugiés.info.md",
+      "targetPath": "langage-clair/[Charte éditoriale] Réfugiés.info.md",
       "totalChunks": 12,
-      "weakExtractionReasons": []
+      "weakExtractionReasons": [],
+      "previousTargetPath": "langage-clair/[Charte éditorial] Réfugiés.info.md",
+      "targetPathNormalizationReason": "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance"
     },
     {
       "chunksEmbedded": 114,
@@ -104,9 +108,11 @@
       "processingStatus": "completed",
       "sourceId": "source-0",
       "sourceName": "ressources_langage_clair",
-      "targetPath": "langage-clair/[Lexique] administatif maison de la sagesse.md",
+      "targetPath": "langage-clair/[Lexique] administratif maison de la sagesse.md",
       "totalChunks": 114,
-      "weakExtractionReasons": []
+      "weakExtractionReasons": [],
+      "previousTargetPath": "langage-clair/[Lexique] administatif maison de la sagesse.md",
+      "targetPathNormalizationReason": "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance"
     },
     {
       "chunksEmbedded": 7,

--- a/documentation/agent-migration/agent-knowledge/langage-clair/README.md
+++ b/documentation/agent-migration/agent-knowledge/langage-clair/README.md
@@ -14,4 +14,6 @@ Il correspond au groupe `ressources_langage_clair/*` identifié dans l'inventair
 
 ## Notes de migration
 
-Les chemins d'origine exportés depuis Letta Cloud doivent être conservés ou documentés pour garder la traçabilité. Les éventuelles corrections de noms ou de coquilles doivent être explicites.
+Les chemins d'origine exportés depuis Letta Cloud doivent être conservés dans la provenance (`source_path`, `original_file_name`, manifeste) pour garder la traçabilité.
+
+Les chemins cible versionnés peuvent corriger une coquille évidente. Les corrections déjà appliquées dans ce dossier sont documentées dans le [README du corpus](../README.md#convention-de-nommage).

--- a/documentation/agent-migration/agent-knowledge/langage-clair/[Charte éditoriale] Réfugiés.info.md
+++ b/documentation/agent-migration/agent-knowledge/langage-clair/[Charte éditoriale] Réfugiés.info.md
@@ -6,6 +6,8 @@ file_size_bytes: 294682
 file_type: "application/pdf"
 original_file_name: "[Charte éditorial] Réfugiés.info.pdf"
 processing_status: "completed"
+previous_target_path: "langage-clair/[Charte éditorial] Réfugiés.info.md"
+target_path_normalization_reason: "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance"
 source_id: "source-0"
 source_name: "ressources_langage_clair"
 source_path: "ressources_langage_clair/ressources_langage_clair/[Charte éditorial] Réfugiés.info.pdf"
@@ -13,7 +15,7 @@ total_chunks: 12
 weak_extraction_reasons: []
 ---
 
-# [Charte éditorial] Réfugiés.info
+# [Charte éditoriale] Réfugiés.info
 
 > Source Letta Cloud : `ressources_langage_clair/ressources_langage_clair/[Charte éditorial] Réfugiés.info.pdf`
 

--- a/documentation/agent-migration/agent-knowledge/langage-clair/[Guide d'annotation] agent transformateur refugies-info.md
+++ b/documentation/agent-migration/agent-knowledge/langage-clair/[Guide d'annotation] agent transformateur refugies-info.md
@@ -6,6 +6,8 @@ file_size_bytes: 11826
 file_type: "text/x-markdown"
 original_file_name: "[guide dannotation] agent transformateur refugies-info.md"
 processing_status: "completed"
+previous_target_path: "langage-clair/[guide dannotation] agent transformateur refugies-info.md"
+target_path_normalization_reason: "Correction du libellé du chemin cible, source Letta Cloud conservée en provenance"
 source_id: "source-0"
 source_name: "ressources_langage_clair"
 source_path: "ressources_langage_clair/ressources_langage_clair/[guide dannotation] agent transformateur refugies-info.md"
@@ -13,7 +15,7 @@ total_chunks: 15
 weak_extraction_reasons: []
 ---
 
-# [guide dannotation] agent transformateur refugies-info
+# [Guide d'annotation] agent transformateur refugies-info
 
 > Source Letta Cloud : `ressources_langage_clair/ressources_langage_clair/[guide dannotation] agent transformateur refugies-info.md`
 

--- a/documentation/agent-migration/agent-knowledge/langage-clair/[Lexique] administratif maison de la sagesse.md
+++ b/documentation/agent-migration/agent-knowledge/langage-clair/[Lexique] administratif maison de la sagesse.md
@@ -6,6 +6,8 @@ file_size_bytes: 1175719
 file_type: "application/pdf"
 original_file_name: "[Lexique] administatif maison de la sagesse.pdf"
 processing_status: "completed"
+previous_target_path: "langage-clair/[Lexique] administatif maison de la sagesse.md"
+target_path_normalization_reason: "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance"
 source_id: "source-0"
 source_name: "ressources_langage_clair"
 source_path: "ressources_langage_clair/ressources_langage_clair/[Lexique] administatif maison de la sagesse.pdf"
@@ -13,7 +15,7 @@ total_chunks: 114
 weak_extraction_reasons: []
 ---
 
-# [Lexique] administatif maison de la sagesse
+# [Lexique] administratif maison de la sagesse
 
 > Source Letta Cloud : `ressources_langage_clair/ressources_langage_clair/[Lexique] administatif maison de la sagesse.pdf`
 

--- a/documentation/agent-migration/agent-skills/README.md
+++ b/documentation/agent-migration/agent-skills/README.md
@@ -10,18 +10,18 @@ Les skills sont stockés dans le dossier racine [`skills/`](../../../skills), af
 
 ## Mapping des commandes historiques
 
-| Slash command historique | Skill Letta Code | Rôle |
-| --- | --- | --- |
-| `/audit` | [`audit`](../../../skills/audit/SKILL.md) | Exécuter l'audit de conformité éditoriale et la détection de doublons. |
-| `/redaction` | [`redaction`](../../../skills/redaction/SKILL.md) | Transformer une fiche Data Inclusion en Markdown Réfugiés.info en langage clair. |
-| `/metadata` | [`metadata`](../../../skills/metadata/SKILL.md) | Produire le frontmatter `metadata_ri` et la provenance des métadonnées. |
-| `/pipeline` | Composition `audit` + `redaction` + `metadata` | Conserver le workflow historique Audit → Rédaction → Métadonnées. Aucun skill dédié n'est créé dans cette PR. |
+| Slash command historique | Skill Letta Code                                  | Rôle                                                                                                          |
+| ------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `/audit`                 | [`audit`](../../../skills/audit/SKILL.md)         | Exécuter l'audit de conformité éditoriale et la détection de doublons.                                        |
+| `/redaction`             | [`redaction`](../../../skills/redaction/SKILL.md) | Transformer une fiche Data Inclusion en Markdown Réfugiés.info en langage clair.                              |
+| `/metadata`              | [`metadata`](../../../skills/metadata/SKILL.md)   | Produire le frontmatter `metadata_ri` et la provenance des métadonnées.                                       |
+| `/pipeline`              | Composition `audit` + `redaction` + `metadata`    | Conserver le workflow historique Audit → Rédaction → Métadonnées. Aucun skill dédié n'est créé dans cette PR. |
 
 ## Mapping des commandes ajoutées par la migration
 
-| Slash command cible | Skill Letta Code | Rôle |
-| --- | --- | --- |
-| `/translate` | [`translate`](../../../skills/translate/SKILL.md) | Traduire ou vérifier un contenu Réfugiés.info en préservant la structure Markdown. |
+| Slash command cible | Skill Letta Code                                  | Rôle                                                                               |
+| ------------------- | ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `/translate`        | [`translate`](../../../skills/translate/SKILL.md) | Traduire ou vérifier un contenu Réfugiés.info en préservant la structure Markdown. |
 
 ## Relation avec le corpus `agent-knowledge`
 
@@ -32,7 +32,7 @@ Les skills ne dupliquent pas les règles métier longues. Ils pointent vers le c
 - `documentation/agent-migration/agent-knowledge/metadatas/` pour les schémas et mappings ;
 - `documentation/agent-migration/agent-knowledge/conformite-editoriale/` pour les référentiels de conformité.
 
-Les chemins de fichiers issus de l'export Letta Cloud sont volontairement conservés à l'identique, y compris quand ils contiennent une coquille. Si un libellé plus propre est nécessaire pour l'interface ou la documentation métier, l'ajouter comme alias lisible sans renommer le chemin source.
+Les skills référencent les chemins cible versionnés du corpus. Les chemins source Letta Cloud restent conservés dans la provenance (`source_path`, `original_file_name`, manifeste), même quand ils contiennent une coquille. Les corrections de chemins cible sont documentées dans la [convention de nommage du corpus](../agent-knowledge/README.md#convention-de-nommage).
 
 ## Notes de migration
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
       "i18next-fs-backend": "2.6.4",
       "follow-redirects": "1.16.0",
       "uuid": "11.1.1",
-      "check-dependency-version-consistency>js-yaml": "4.1.1"
+      "check-dependency-version-consistency>js-yaml": "4.1.1",
+      "shell-quote": "1.8.4"
     },
     "patchedDependencies": {
       "@codegouvfr/react-dsfr@1.20.2": "patches/@codegouvfr__react-dsfr@1.20.2.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,7 @@ overrides:
   follow-redirects: 1.16.0
   uuid: 11.1.1
   check-dependency-version-consistency>js-yaml: 4.1.1
+  shell-quote: 1.8.4
 
 patchedDependencies:
   '@codegouvfr/react-dsfr@1.20.2':
@@ -10875,8 +10876,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -18846,7 +18847,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -23910,7 +23911,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -24816,7 +24817,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   side-channel-list@1.0.0:
     dependencies:

--- a/scripts/export-letta-agent-knowledge.ts
+++ b/scripts/export-letta-agent-knowledge.ts
@@ -15,6 +15,21 @@ const SOURCE_FOLDER_MAP: Record<string, string> = {
   ressources_conformité_éditoriale: "conformite-editoriale",
 };
 
+const TARGET_PATH_RENAMES: Record<string, { reason: string; targetPath: string }> = {
+  "langage-clair/[Charte éditorial] Réfugiés.info.md": {
+    reason: "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance",
+    targetPath: "langage-clair/[Charte éditoriale] Réfugiés.info.md",
+  },
+  "langage-clair/[Lexique] administatif maison de la sagesse.md": {
+    reason: "Correction de la coquille du chemin cible, source Letta Cloud conservée en provenance",
+    targetPath: "langage-clair/[Lexique] administratif maison de la sagesse.md",
+  },
+  "langage-clair/[guide dannotation] agent transformateur refugies-info.md": {
+    reason: "Correction du libellé du chemin cible, source Letta Cloud conservée en provenance",
+    targetPath: "langage-clair/[Guide d'annotation] agent transformateur refugies-info.md",
+  },
+};
+
 const DEFAULT_EXCLUDED_SOURCE_NAMES = new Set(["ressources_exemples_redaction"]);
 const DEFAULT_EXCLUSION_REASON = "source retirée du corpus cible après revue qualité";
 
@@ -46,11 +61,19 @@ type ExportedResource = {
   logicalPath: string;
   originalFileName?: string;
   processingStatus?: string;
+  previousTargetPath?: string;
   sourceId?: string;
   sourceName?: string;
   targetPath: string;
+  targetPathNormalizationReason?: string;
   totalChunks?: number;
   weakExtractionReasons: string[];
+};
+
+type TargetPathResult = {
+  previousTargetPath?: string;
+  targetPath: string;
+  targetPathNormalizationReason?: string;
 };
 
 type ExcludedResource = Omit<ExportedResource, "content"> & {
@@ -260,10 +283,8 @@ function normalizeResources(agentExport: JsonRecord): ExportedResource[] {
     const logicalPath = deriveLogicalPath(file, fileName, sourceName);
     const fileType = readOptionalString(file.file_type);
     const originalExtension = path.extname(fileName || logicalPath).toLowerCase();
-    const targetPath = dedupeTargetPath(
-      toTargetPath(logicalPath, fileName, fileType, originalExtension),
-      seenTargets,
-    );
+    const targetPathResult = toTargetPath(logicalPath, fileName, fileType, originalExtension);
+    const targetPath = dedupeTargetPath(targetPathResult.targetPath, seenTargets);
     const totalChunks = readOptionalNumber(file.total_chunks);
     const chunksEmbedded = readOptionalNumber(file.chunks_embedded);
     const content = readOptionalString(file.content);
@@ -290,9 +311,11 @@ function normalizeResources(agentExport: JsonRecord): ExportedResource[] {
       logicalPath,
       originalFileName: readOptionalString(file.original_file_name),
       processingStatus,
+      previousTargetPath: targetPathResult.previousTargetPath,
       sourceId,
       sourceName,
       targetPath,
+      targetPathNormalizationReason: targetPathResult.targetPathNormalizationReason,
       totalChunks,
       weakExtractionReasons,
     };
@@ -340,7 +363,7 @@ function toTargetPath(
   fileName: string,
   fileType: string | undefined,
   originalExtension: string,
-): string {
+): TargetPathResult {
   const safeLogicalPath = makeSafeRelativePath(logicalPath);
   const segments = safeLogicalPath.split("/");
   const sourceFolder = segments[0];
@@ -352,17 +375,32 @@ function toTargetPath(
   const relativeSegments =
     rawRelativeSegments[0] === sourceFolder ? rawRelativeSegments.slice(1) : rawRelativeSegments;
   const normalizedSegments = [mappedSourceFolder, ...relativeSegments];
-  const normalizedPath = normalizedSegments.join("/");
+  const normalizedPath = normalizedSegments.join("/").normalize("NFC");
+
+  let targetPath: string;
 
   if (isPdf(fileType, originalExtension)) {
-    return replaceExtension(normalizedPath, ".md");
+    targetPath = replaceExtension(normalizedPath, ".md");
+  } else if (TEXT_EXTENSIONS.has(originalExtension)) {
+    targetPath = normalizedPath;
+  } else {
+    targetPath = replaceExtension(normalizedPath, ".md");
   }
 
-  if (TEXT_EXTENSIONS.has(originalExtension)) {
-    return normalizedPath;
+  return applyTargetPathRename(targetPath);
+}
+
+function applyTargetPathRename(targetPath: string): TargetPathResult {
+  const rename = TARGET_PATH_RENAMES[targetPath];
+  if (!rename) {
+    return { targetPath };
   }
 
-  return replaceExtension(normalizedPath, ".md");
+  return {
+    previousTargetPath: targetPath,
+    targetPath: rename.targetPath,
+    targetPathNormalizationReason: rename.reason,
+  };
 }
 
 function makeSafeRelativePath(value: string): string {
@@ -646,7 +684,7 @@ function isPrimitiveJsonValue(value: string): boolean {
 }
 
 function renderMarkdownResource(resource: ExportedResource, exportedAt: string): string {
-  const title = path.basename(resource.fileName, path.extname(resource.fileName));
+  const title = path.basename(resource.targetPath, path.extname(resource.targetPath));
   const frontmatter = {
     chunks_embedded: resource.chunksEmbedded,
     exported_at: exportedAt,
@@ -655,9 +693,11 @@ function renderMarkdownResource(resource: ExportedResource, exportedAt: string):
     file_type: resource.fileType,
     original_file_name: resource.originalFileName,
     processing_status: resource.processingStatus,
+    previous_target_path: resource.previousTargetPath,
     source_id: resource.sourceId,
     source_name: resource.sourceName,
     source_path: resource.logicalPath,
+    target_path_normalization_reason: resource.targetPathNormalizationReason,
     total_chunks: resource.totalChunks,
     weak_extraction_reasons: resource.weakExtractionReasons,
   };

--- a/scripts/export-letta-agent-knowledge.ts
+++ b/scripts/export-letta-agent-knowledge.ts
@@ -391,14 +391,19 @@ function toTargetPath(
 }
 
 function applyTargetPathRename(targetPath: string): TargetPathResult {
-  const rename = TARGET_PATH_RENAMES[targetPath];
-  if (!rename) {
-    return { targetPath };
+  const normalizedTargetPath = targetPath.normalize("NFC");
+  const renameEntry = Object.entries(TARGET_PATH_RENAMES).find(
+    ([path]) => path.normalize("NFC") === normalizedTargetPath,
+  );
+
+  if (!renameEntry) {
+    return { targetPath: normalizedTargetPath };
   }
 
+  const [, rename] = renameEntry;
   return {
-    previousTargetPath: targetPath,
-    targetPath: rename.targetPath,
+    previousTargetPath: normalizedTargetPath,
+    targetPath: rename.targetPath.normalize("NFC"),
     targetPathNormalizationReason: rename.reason,
   };
 }

--- a/skills/redaction/SKILL.md
+++ b/skills/redaction/SKILL.md
@@ -27,8 +27,7 @@ Consulter le corpus `agent-knowledge` indexé par `qmd`, en priorité :
 - `memory-blocks/regles-redaction-langage-clair.md` pour les règles éditoriales.
 - `memory-blocks/format-sortie-transformation.md` pour le format Markdown attendu.
 - `memory-blocks/lexique-vif.md` et `langage-clair/DITP-Lexique-Administratif.md` pour simplifier les termes administratifs.
-<!-- Note : Le nom du fichier ci-dessous contient une coquille d'origine (« Charte éditorial ») préservée pour des raisons de fidélité à la source. -->
-- `langage-clair/[Charte éditorial] Réfugiés.info.md` et `langage-clair/[personas] bpi.md` si la cible éditoriale doit être précisée.
+- `langage-clair/[Charte éditoriale] Réfugiés.info.md` et `langage-clair/[personas] bpi.md` si la cible éditoriale doit être précisée.
 
 ## Procédure
 

--- a/skills/translate/SKILL.md
+++ b/skills/translate/SKILL.md
@@ -26,8 +26,7 @@ Consulter le corpus `agent-knowledge` indexé par `qmd`, en priorité :
 
 - `memory-blocks/format-sortie-transformation.md` pour préserver la structure Markdown RI.
 - `memory-blocks/regles-redaction-langage-clair.md` pour conserver le niveau de langue clair.
-<!-- Note : Le nom du fichier ci-dessous contient une coquille d'origine (« administatif ») préservée pour des raisons de fidélité à la source. -->
-- `memory-blocks/lexique-vif.md` et `langage-clair/[Lexique] administatif maison de la sagesse.md` pour les termes administratifs sensibles.
+- `memory-blocks/lexique-vif.md` et `langage-clair/[Lexique] administratif maison de la sagesse.md` pour les termes administratifs sensibles.
 - `langage-clair/[personas] bpi.md` si la cible utilisateur doit guider le ton.
 
 ## Procédure


### PR DESCRIPTION
## Résumé

- normalise trois chemins cible du corpus `agent-knowledge` contenant des coquilles :
  - `langage-clair/[Charte éditoriale] Réfugiés.info.md`
  - `langage-clair/[Lexique] administratif maison de la sagesse.md`
  - `langage-clair/[Guide d'annotation] agent transformateur refugies-info.md`
- conserve la provenance Letta Cloud exacte via `source_path`, `original_file_name`, `previous_target_path`, `target_path_normalization_reason` et `_export-manifest.json`
- met à jour le script `agent-knowledge:export` pour que les prochains exports reproduisent ces chemins propres
- met à jour les références des skills `redaction` et `translate`
- documente la convention de nommage dans le README du corpus

## Sécurité / hook pre-push

Le hook pre-push a détecté une vulnérabilité transitive `shell-quote@1.8.3` déjà présente dans le lockfile. Cette PR ajoute aussi un override pnpm vers `shell-quote@1.8.4` pour permettre au hook de sécurité de passer sans changement React Native/Expo.

## Vérification

- `pnpm install --frozen-lockfile`
- validation statique manifeste : tous les `generatedFiles` existent
- validation statique skills → corpus : toutes les références `memory-blocks/`, `langage-clair/`, `metadatas/`, `conformite-editoriale/` existent
- `git diff --check`
- `pnpm exec tsx scripts/export-letta-agent-knowledge.ts --help`
- export synthétique via `--from-file` validant les trois renommages et leur provenance
- `QMD_BIN=/tmp/qmd-npx-wrapper pnpm agent-knowledge:qmd:smoke`
- skill-linter sur `skills/audit`, `skills/redaction`, `skills/metadata`, `skills/translate`
- `pnpm security:scan:js`
- hooks pre-commit/pre-push passés lors du commit/push

Note : `qmd` n’était pas installé globalement dans ce worktree ; le smoke test a été exécuté via un wrapper temporaire `QMD_BIN` vers `npx @tobilu/qmd`.

👾 Generated with [Letta Code](https://letta.com)