### PR TITLE
RI-1337 - Définir le contrat qmd et la suite de tests skills/corpus

### DIFF
--- a/documentation/agent-migration/agent-knowledge/README.md
+++ b/documentation/agent-migration/agent-knowledge/README.md
@@ -101,6 +101,45 @@ QMD_SMOKE_EXPECTED_RESULT="memory-blocks/audit-conformite-editoriale-di.md" \
 pnpm agent-knowledge:qmd:smoke
 ```
 
+### Contrat de test skills/corpus/qmd
+
+Avant d'ajouter ou de modifier un skill, lancer le contrat local complet :
+
+```bash
+pnpm agent-knowledge:test
+```
+
+Cette commande exécute d'abord `pnpm agent-knowledge:validate`, puis un smoke test `qmd` dans un index et une collection de test isolés :
+
+- index qmd de test : `refugies-info-agent-knowledge-test` ;
+- collection qmd de test : `agent-knowledge-test`.
+
+Le validateur statique vérifie :
+
+- que les fichiers listés dans `_export-manifest.json` existent dans le corpus ;
+- que chaque `resources.targetPath` du manifeste est listé dans `generatedFiles` ;
+- que les chemins cible du manifeste sont normalisés en Unicode NFC ;
+- que `previousTargetPath` reste différent du chemin cible normalisé ;
+- que les références corpus présentes dans les fichiers `skills/*/SKILL.md` pointent vers des fichiers existants.
+
+Le smoke test `qmd` reconstruit ensuite l'index de test et vérifie qu'une recherche lexicale retrouve une ressource attendue. Les variables restent surchargeables pour les cas de test ciblés :
+
+```bash
+QMD_BIN=/chemin/vers/qmd \
+QMD_INDEX=refugies-info-agent-knowledge-test \
+QMD_COLLECTION=agent-knowledge-test \
+QMD_SMOKE_QUERY="conformité éditoriale" \
+QMD_SMOKE_EXPECTED_RESULT="memory-blocks/audit-conformite-editoriale-di.md" \
+pnpm agent-knowledge:test
+```
+
+Pour les futures PRs de conversion des skills, les fixtures doivent rester déterministes et locales :
+
+- ajouter les cas d'entrée minimaux près du code de test qui les consomme ;
+- référencer les fichiers du corpus par chemin cible versionné, jamais par chemin source Letta Cloud ;
+- éviter les embeddings et les modèles distants dans la suite locale par défaut ;
+- étendre `agent-knowledge:validate` ou le smoke test `qmd` quand une nouvelle catégorie de référence devient obligatoire.
+
 ### Artefacts générés
 
 Les artefacts `qmd` ne doivent pas être commités :

--- a/documentation/agent-migration/agent-skills/README.md
+++ b/documentation/agent-migration/agent-skills/README.md
@@ -34,6 +34,18 @@ Les skills ne dupliquent pas les règles métier longues. Ils pointent vers le c
 
 Les skills référencent les chemins cible versionnés du corpus. Les chemins source Letta Cloud restent conservés dans la provenance (`source_path`, `original_file_name`, manifeste), même quand ils contiennent une coquille. Les corrections de chemins cible sont documentées dans la [convention de nommage du corpus](../agent-knowledge/README.md#convention-de-nommage).
 
+## Contrat de test
+
+Toute PR qui ajoute, renomme ou supprime une référence corpus dans un skill doit lancer :
+
+```bash
+pnpm agent-knowledge:test
+```
+
+Cette commande vérifie statiquement les références `skills/*/SKILL.md` vers le corpus, contrôle la cohérence du manifeste `_export-manifest.json`, puis reconstruit un index `qmd` de test isolé avant d'exécuter une recherche smoke.
+
+Les futures PRs de conversion détaillée (`audit`, `redaction`, `metadata`, `translate`) doivent ajouter leurs cas de test sans redéfinir ce contrat : elles peuvent spécialiser la requête `qmd` avec `QMD_SMOKE_QUERY` et `QMD_SMOKE_EXPECTED_RESULT`, ou étendre le validateur quand un nouveau type de référence devient obligatoire.
+
 ## Notes de migration
 
 - Les noms de skills restent volontairement proches des commandes Playground pour faciliter la transition.

--- a/package.json
+++ b/package.json
@@ -171,7 +171,9 @@
     "update-dependencies": "pnpm update -i --filter . --filter api-types --filter ui --filter server --filter client --filter mobile --filter storybook --filter mongo",
     "agent-knowledge:export": "tsx scripts/export-letta-agent-knowledge.ts",
     "agent-knowledge:qmd:index": "bash scripts/index-agent-knowledge-qmd.sh",
-    "agent-knowledge:qmd:smoke": "bash scripts/smoke-test-agent-knowledge-qmd.sh"
+    "agent-knowledge:qmd:smoke": "bash scripts/smoke-test-agent-knowledge-qmd.sh",
+    "agent-knowledge:validate": "tsx scripts/validate-agent-knowledge-contract.ts",
+    "agent-knowledge:test": "pnpm agent-knowledge:validate && QMD_INDEX=${QMD_INDEX:-refugies-info-agent-knowledge-test} QMD_COLLECTION=${QMD_COLLECTION:-agent-knowledge-test} pnpm agent-knowledge:qmd:smoke"
   },
   "engines": {
     "node": "24.14.0"

--- a/scripts/validate-agent-knowledge-contract.ts
+++ b/scripts/validate-agent-knowledge-contract.ts
@@ -38,18 +38,26 @@ async function main(): Promise<void> {
   await assertDirectoryExists(CORPUS_DIR, "Corpus agent-knowledge introuvable");
   await assertDirectoryExists(SKILLS_DIR, "Dossier skills introuvable");
 
+  if (failures.length > 0) {
+    printFailuresAndExit();
+  }
+
   validateManifest();
   await validateSkillReferences();
 
   if (failures.length > 0) {
-    console.error("Contrat agent-knowledge invalide :");
-    for (const failure of failures) {
-      console.error(`- ${failure}`);
-    }
-    process.exit(1);
+    printFailuresAndExit();
   }
 
   console.log("Contrat agent-knowledge valide.");
+}
+
+function printFailuresAndExit(): never {
+  console.error("Contrat agent-knowledge invalide :");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
 }
 
 async function assertDirectoryExists(directoryPath: string, message: string): Promise<void> {
@@ -109,7 +117,13 @@ function validateManifest(): void {
 
 function readJsonFile(filePath: string): unknown {
   try {
-    return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+    const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+    if (isRecord(parsed)) {
+      return parsed;
+    }
+
+    failures.push(`${filePath}: le contenu JSON doit être un objet`);
+    return {};
   } catch (error) {
     failures.push(`${filePath}: JSON invalide ou fichier illisible (${String(error)})`);
     return {};
@@ -173,7 +187,7 @@ async function findSkillFiles(directoryPath: string): Promise<string[]> {
   const skillFiles: string[] = [];
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) {
+    if (!entry.isDirectory() || entry.name.startsWith(".")) {
       continue;
     }
 
@@ -197,7 +211,7 @@ function extractCorpusReferences(content: string): string[] {
   let match: RegExpExecArray | null;
 
   while ((match = codeSpanRegex.exec(content)) !== null) {
-    const reference = match[1];
+    const reference = match[1].trim();
     if (CORPUS_REFERENCE_PREFIXES.some((prefix) => reference.startsWith(prefix))) {
       references.add(reference);
     }
@@ -209,6 +223,11 @@ function extractCorpusReferences(content: string): string[] {
 function validateCorpusTargetPath(relativePath: string, context: string): void {
   validateNfc(relativePath, context);
 
+  if (path.isAbsolute(relativePath)) {
+    failures.push(`${context}: chemin absolu refusé (${relativePath})`);
+    return;
+  }
+
   const absolutePath = path.resolve(CORPUS_DIR, relativePath);
   const relativeFromCorpus = path.relative(CORPUS_DIR, absolutePath);
   if (relativeFromCorpus.startsWith("..") || path.isAbsolute(relativeFromCorpus)) {
@@ -216,12 +235,8 @@ function validateCorpusTargetPath(relativePath: string, context: string): void {
     return;
   }
 
-  try {
-    const stats = statSyncSafe(absolutePath);
-    if (!stats?.isFile()) {
-      failures.push(`${context}: fichier introuvable dans le corpus (${relativePath})`);
-    }
-  } catch {
+  const stats = statSyncSafe(absolutePath);
+  if (!stats?.isFile()) {
     failures.push(`${context}: fichier introuvable dans le corpus (${relativePath})`);
   }
 }

--- a/scripts/validate-agent-knowledge-contract.ts
+++ b/scripts/validate-agent-knowledge-contract.ts
@@ -1,0 +1,264 @@
+import { readFileSync, statSync } from "node:fs";
+import { readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const CORPUS_DIR = path.resolve(
+  process.env.AGENT_KNOWLEDGE_CORPUS_DIR ||
+    path.join(ROOT_DIR, "documentation/agent-migration/agent-knowledge"),
+);
+const SKILLS_DIR = path.resolve(process.env.AGENT_SKILLS_DIR || path.join(ROOT_DIR, "skills"));
+const MANIFEST_PATH = path.join(CORPUS_DIR, "_export-manifest.json");
+
+const CORPUS_REFERENCE_PREFIXES = [
+  "memory-blocks/",
+  "langage-clair/",
+  "metadatas/",
+  "conformite-editoriale/",
+] as const;
+
+type JsonRecord = Record<string, unknown>;
+
+type ManifestResource = {
+  originalFileName?: string;
+  previousTargetPath?: string;
+  sourcePath?: string;
+  targetPath?: string;
+};
+
+type Manifest = {
+  generatedFiles?: unknown[];
+  resources?: unknown[];
+};
+
+const failures: string[] = [];
+
+async function main(): Promise<void> {
+  await assertDirectoryExists(CORPUS_DIR, "Corpus agent-knowledge introuvable");
+  await assertDirectoryExists(SKILLS_DIR, "Dossier skills introuvable");
+
+  validateManifest();
+  await validateSkillReferences();
+
+  if (failures.length > 0) {
+    console.error("Contrat agent-knowledge invalide :");
+    for (const failure of failures) {
+      console.error(`- ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Contrat agent-knowledge valide.");
+}
+
+async function assertDirectoryExists(directoryPath: string, message: string): Promise<void> {
+  try {
+    const stats = await stat(directoryPath);
+    if (!stats.isDirectory()) {
+      failures.push(`${message} : ${directoryPath} n'est pas un dossier`);
+    }
+  } catch {
+    failures.push(`${message} : ${directoryPath}`);
+  }
+}
+
+function validateManifest(): void {
+  const manifest = readJsonFile(MANIFEST_PATH) as Manifest;
+  const generatedFiles = readStringArray(manifest.generatedFiles, "generatedFiles");
+  const resources = readResourceArray(manifest.resources, "resources");
+  const generatedFileSet = new Set(generatedFiles);
+
+  for (const generatedFile of generatedFiles) {
+    validateCorpusTargetPath(generatedFile, "generatedFiles");
+  }
+
+  for (const resource of resources) {
+    if (!resource.targetPath) {
+      failures.push("_export-manifest.json: une ressource n'a pas de targetPath");
+      continue;
+    }
+
+    validateCorpusTargetPath(resource.targetPath, `resources.targetPath (${resource.targetPath})`);
+
+    if (!generatedFileSet.has(resource.targetPath)) {
+      failures.push(
+        `_export-manifest.json: resources.targetPath absent de generatedFiles : ${resource.targetPath}`,
+      );
+    }
+
+    validateNfc(resource.targetPath, `resources.targetPath (${resource.targetPath})`);
+    validateOptionalNfc(
+      resource.previousTargetPath,
+      `resources.previousTargetPath (${resource.targetPath})`,
+    );
+
+    if (resource.previousTargetPath && resource.previousTargetPath === resource.targetPath) {
+      failures.push(
+        `_export-manifest.json: previousTargetPath identique au targetPath pour ${resource.targetPath}`,
+      );
+    }
+
+    if (resource.sourcePath && resource.sourcePath === resource.targetPath) {
+      failures.push(
+        `_export-manifest.json: sourcePath ne doit pas remplacer la provenance Letta Cloud pour ${resource.targetPath}`,
+      );
+    }
+  }
+}
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+  } catch (error) {
+    failures.push(`${filePath}: JSON invalide ou fichier illisible (${String(error)})`);
+    return {};
+  }
+}
+
+function readStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) {
+    failures.push(`_export-manifest.json: ${label} doit être un tableau`);
+    return [];
+  }
+
+  return value.flatMap((item, index) => {
+    if (typeof item !== "string") {
+      failures.push(`_export-manifest.json: ${label}[${index}] doit être une chaîne`);
+      return [];
+    }
+    return [item];
+  });
+}
+
+function readResourceArray(value: unknown, label: string): ManifestResource[] {
+  if (!Array.isArray(value)) {
+    failures.push(`_export-manifest.json: ${label} doit être un tableau`);
+    return [];
+  }
+
+  return value.flatMap((item, index) => {
+    if (!isRecord(item)) {
+      failures.push(`_export-manifest.json: ${label}[${index}] doit être un objet`);
+      return [];
+    }
+
+    return [
+      {
+        originalFileName: readOptionalString(item.originalFileName),
+        previousTargetPath: readOptionalString(item.previousTargetPath),
+        sourcePath: readOptionalString(item.logicalPath),
+        targetPath: readOptionalString(item.targetPath),
+      },
+    ];
+  });
+}
+
+async function validateSkillReferences(): Promise<void> {
+  const skillFiles = await findSkillFiles(SKILLS_DIR);
+
+  for (const skillFile of skillFiles) {
+    const skillContent = readFileSync(skillFile, "utf8");
+    const references = extractCorpusReferences(skillContent);
+
+    for (const reference of references) {
+      validateNfc(reference, `${relativeToRoot(skillFile)}: référence corpus`);
+      validateCorpusTargetPath(reference, `${relativeToRoot(skillFile)}: ${reference}`);
+    }
+  }
+}
+
+async function findSkillFiles(directoryPath: string): Promise<string[]> {
+  const entries = await readdir(directoryPath, { withFileTypes: true });
+  const skillFiles: string[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const skillFile = path.join(directoryPath, entry.name, "SKILL.md");
+    try {
+      const stats = await stat(skillFile);
+      if (stats.isFile()) {
+        skillFiles.push(skillFile);
+      }
+    } catch {
+      failures.push(`${path.join("skills", entry.name)}: fichier SKILL.md introuvable`);
+    }
+  }
+
+  return skillFiles.sort();
+}
+
+function extractCorpusReferences(content: string): string[] {
+  const references = new Set<string>();
+  const codeSpanRegex = /`([^`]+)`/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = codeSpanRegex.exec(content)) !== null) {
+    const reference = match[1];
+    if (CORPUS_REFERENCE_PREFIXES.some((prefix) => reference.startsWith(prefix))) {
+      references.add(reference);
+    }
+  }
+
+  return [...references].sort();
+}
+
+function validateCorpusTargetPath(relativePath: string, context: string): void {
+  validateNfc(relativePath, context);
+
+  const absolutePath = path.resolve(CORPUS_DIR, relativePath);
+  const relativeFromCorpus = path.relative(CORPUS_DIR, absolutePath);
+  if (relativeFromCorpus.startsWith("..") || path.isAbsolute(relativeFromCorpus)) {
+    failures.push(`${context}: chemin hors corpus refusé (${relativePath})`);
+    return;
+  }
+
+  try {
+    const stats = statSyncSafe(absolutePath);
+    if (!stats?.isFile()) {
+      failures.push(`${context}: fichier introuvable dans le corpus (${relativePath})`);
+    }
+  } catch {
+    failures.push(`${context}: fichier introuvable dans le corpus (${relativePath})`);
+  }
+}
+
+function statSyncSafe(filePath: string): ReturnType<typeof import("node:fs").statSync> | null {
+  try {
+    return statSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function validateOptionalNfc(value: string | undefined, context: string): void {
+  if (value) {
+    validateNfc(value, context);
+  }
+}
+
+function validateNfc(value: string, context: string): void {
+  if (value !== value.normalize("NFC")) {
+    failures.push(`${context}: chemin non normalisé NFC (${value})`);
+  }
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function relativeToRoot(filePath: string): string {
+  return path.relative(ROOT_DIR, filePath);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Résumé

- ajoute `pnpm agent-knowledge:validate` pour vérifier le contrat statique entre `skills/*/SKILL.md`, le corpus `agent-knowledge` et `_export-manifest.json`
- ajoute `pnpm agent-knowledge:test`, qui compose cette validation avec un smoke test qmd dans un index/collection de test isolés
- documente le contrat de test dans les READMEs `agent-knowledge` et `agent-skills`
- prépare le socle de validation pour les prochaines PRs de conversion détaillée des skills (`audit`, `redaction`, `metadata`, `translate`)

## Contrat vérifié

- les `generatedFiles` du manifeste existent dans le corpus
- les `resources.targetPath` du manifeste existent et sont listés dans `generatedFiles`
- les chemins cible du manifeste sont normalisés en Unicode NFC
- `previousTargetPath` reste distinct du chemin cible normalisé
- les références corpus dans `skills/*/SKILL.md` pointent vers des fichiers versionnés existants
- le smoke qmd reconstruit un index de test isolé (`refugies-info-agent-knowledge-test` / `agent-knowledge-test`) et vérifie une recherche lexicale

## Vérification

- `pnpm install --frozen-lockfile`
- `pnpm agent-knowledge:validate`
- `QMD_BIN=/tmp/qmd-npx-wrapper pnpm agent-knowledge:test`
- `pnpm exec biome check scripts/validate-agent-knowledge-contract.ts package.json documentation/agent-migration/agent-knowledge/README.md documentation/agent-migration/agent-skills/README.md`
- `git diff --check`
- `pnpm security:scan:js`
- hooks pre-commit/pre-push passés

Note : `qmd` n’était pas installé globalement dans ce worktree ; le test complet a été exécuté via un wrapper temporaire `QMD_BIN` vers `npx @tobilu/qmd`.

👾 Generated with [Letta Code](https://letta.com)