### PR TITLE
Correctif Docker / build backend

### DIFF
--- a/apps/server/Dockerfile
+++ b/apps/server/Dockerfile
@@ -61,7 +61,7 @@ FROM base AS runner
   # Set working directory
   WORKDIR /app
 
-  # Copy built app
-  COPY --from=installer /app/apps/server/dist/index.js ./index.js
+  # Copy built app, including ncc chunks required by some dependencies
+  COPY --from=installer /app/apps/server/dist/ ./
 
   CMD ["node", "./index.js"]


### PR DESCRIPTION
## En bref
Pendant le test staging, la synchronisation AGIR arrivait bien jusqu’à l’étape d’upload GCS, mais échouait avec :

```txt
Cannot find module './774.index.js'
Require stack:
- /app/index.js
```

Le backend est buildé avec `ncc` :

```bash
ncc build src/server.ts -o dist
```

Or `ncc` ne produit pas toujours un seul fichier `index.js`. Certaines dépendances, notamment `googleapis`, peuvent générer des chunks runtime à côté du bundle principal :

```txt
dist/index.js
dist/774.index.js
dist/754.index.js
dist/7.index.js
```

L’ancien Dockerfile ne copiait que :

```dockerfile
COPY --from=installer /app/apps/server/dist/index.js ./index.js
```

Résultat : `index.js` était bien présent dans l’image Cloud Run, mais les chunks nécessaires au runtime ne l’étaient pas.

Le Dockerfile copie maintenant tout le dossier de sortie `dist` :

```dockerfile
COPY --from=installer /app/apps/server/dist/ ./
```

Cela garantit que `index.js` et les chunks/assets générés par `ncc` restent dans le même répertoire, comme attendu par les `require("./xxx.index.js")`.

Ce changement ne modifie pas les routes exposées ni l’authentification : il corrige uniquement le contenu embarqué dans l’image runtime Cloud Run.

---
## Quelques infos supplémentaires pour info : 

### 1. Qu’est-ce que ncc ?

Dans apps/server/package.json, le backend est buildé avec :

  "build:ncc": "NODE_OPTIONS='--max-old-space-size=4096' ncc build src/server.ts -o dist"

  ncc, c’est l’outil @vercel/ncc.

  Son rôle : prendre une entrée Node.js/TypeScript :

  src/server.ts

  et produire un dossier de sortie exécutable :

  dist/

  L’intérêt :
  - transpiler TypeScript ;
  - bundler le code serveur ;
  - embarquer la majorité des dépendances ;
  - éviter d’avoir besoin de tout node_modules dans l’image runtime ;
  - produire un artefact plus simple à lancer avec :
    node index.js

  Mais point important : `ncc` ne garantit pas forcément un seul fichier.

  Il produit souvent :

  dist/index.js

  mais il peut aussi produire :
  - des chunks JS ;
  - des assets nécessaires au runtime ;
  - des fichiers proto / protos ;
  - parfois des fichiers nécessaires à certaines libs générées.

  Dans notre cas local, après build, on a :

  apps/server/dist/index.js        ~71 MB
  apps/server/dist/774.index.js    ~286 KB
  apps/server/dist/754.index.js    ~10 KB
  apps/server/dist/7.index.js      ~11 KB
  apps/server/dist/proto/
  apps/server/dist/protos/
  ...

  Donc le vrai artefact de build, ce n’est pas seulement :

  dist/index.js

  C’est :

  dist/

  ───────────────────────────────

  ### 2. Ce qui cassait avant

  Avant, le Dockerfile faisait :

  COPY --from=installer /app/apps/server/dist/index.js ./index.js

  Donc dans l’image Cloud Run, on avait :

  /app/index.js

  mais pas :

  /app/774.index.js
  /app/754.index.js
  /app/7.index.js

  Or le bundle généré par ncc contient ce runtime :

  __nccwpck_require__.u = (chunkId) => {
    return "" + chunkId + ".index.js";
  };

  installChunk(require("./" + __nccwpck_require__.u(chunkId)));

  Donc quand une dépendance déclenche un import dynamique, index.js fait :

  require("./774.index.js")

  Et Cloud Run répond :

  Cannot find module './774.index.js'
  Require stack:
  - /app/index.js

  Ça correspond exactement au log staging.

  ───────────────────────────────

  ### 3. Quelle dépendance déclenche ça ?

  Le chunk qui a cassé est :

  774.index.js

  Dans index.js, on voit l’appel dynamique ici :

  static async #getFetch() {
    const hasWindow = typeof window !== 'undefined' && !!window;
    this.#fetch ||= hasWindow
      ? window.fetch
      : (await __nccwpck_require__.e(/* import() */ 774)
          .then(__nccwpck_require__.bind(__nccwpck_require__, 801774))).default;
    return this.#fetch;
  }

  Ce code est dans Gaxios.

  Gaxios, c’est la lib HTTP utilisée par l’écosystème Google Node.

  Chaîne concernée pour notre cas :

  uploadAgirOperatorsJsonToGcs.ts
  → googleapis
  → google-auth-library / gaxios
  → node-fetch chargé dynamiquement
  → 774.index.js

  Le fichier 774.index.js contient notamment :

  gaxios/node_modules/node-fetch
  fetch-blob
  formdata-polyfill
  web-streams-polyfill
  node-domexception

  Donc la dépendance principale qui déclenche le problème ici est :

  googleapis

  via :

  gaxios → node-fetch

  Pourquoi maintenant ?

  Le repo utilisait déjà googleapis ailleurs :

  apps/server/src/libs/googleIndexingApi.ts

  Mais le chemin AGIR a probablement déclenché pour la première fois en staging ce code précis :

  google.storage({ version: "v1", auth })
  storage.objects.insert(...)

  qui passe par gaxios et charge node-fetch dynamiquement.

  Donc ce bug Docker pouvait être latent avant, mais AGIR l’a rendu visible.

  ───────────────────────────────

### 4. Quels chunks existent et à quoi ils correspondent ?

  Après inspection :

  774.index.js

  C’est celui qui a cassé.

  Il contient :
  - gaxios/node_modules/node-fetch;
  - fetch-blob;
  - formdata-polyfill;
  - web-streams-polyfill;
  - node-domexception.

  Il est chargé par :

  Gaxios.#getFetch()

  Donc c’est lié aux appels HTTP Google.

  754.index.js

  Il est chargé depuis 774.index.js :

  const { toFormData } = await __webpack_require__.e(/* import() */ 754)

  Il contient une partie liée à :

  formdata-polyfill
  multipart/form-data

  Donc c’est une dépendance indirecte du fetch/form-data utilisé par node-fetch / gaxios.

  7.index.js

  Il contient du code :

  @smithy/core/event-streams

Celui-là n’est pas lié au crash AGIR observé, mais il montre le même phénomène : ncc peut générer des chunks runtime pour des imports dynamiques d’autres dépendances du serveur.

  ───────────────────────────────

  ### 5. Est-ce qu’on pouvait faire autrement que toucher au Dockerfile ?

  Oui, il y a des alternatives, mais elles sont moins bonnes à mon avis.

  Option A — Copier seulement les chunks connus

  On pourrait faire :

  COPY --from=installer /app/apps/server/dist/index.js ./index.js
  COPY --from=installer /app/apps/server/dist/*.index.js ./

  Éventuellement aussi :

  COPY --from=installer /app/apps/server/dist/proto ./proto
  COPY --from=installer /app/apps/server/dist/protos ./protos

  Avantage :
  - image un peu plus minimale.

  Inconvénients :
  - fragile ;
  - les noms de chunks peuvent changer ;
  - une nouvelle dépendance peut générer d’autres assets runtime ;
  - on risque de refaire exactement le même bug plus tard.

  Donc possible, mais pas idéal.

  Option B — Forcer ncc à produire un seul fichier

  J’ai regardé l’aide ncc.

  Options disponibles :

  --out
  --minify
  --no-cache
  --source-map
  --asset-builds
  --external
  --target
  ...

  Il n’y a pas d’option claire du style :

  --single-file
  --no-code-splitting

  Le chunk est généré à cause d’un import() dynamique dans une dépendance (gaxios). Donc le forcer proprement en single-file demanderait une configuration webpack/ncc plus invasive, ou un
  patch de dépendance. Pas adapté ici.

  Option C — Changer le code AGIR pour ne pas utiliser googleapis

  On pourrait éviter googleapis et faire l’upload GCS autrement :
  - appel direct à l’API REST GCS via fetch;
  - récupération manuelle d’un token OAuth ;
  - ou utiliser une autre lib comme @google-cloud/storage.

  Mais :
  - ça touche davantage de code ;
  - ça ajoute du risque auth/IAM ;
  - ça ne garantit pas forcément l’absence de chunks ;
  - ça résout le symptôme AGIR, pas le problème général du Dockerfile.

  Et surtout : si une autre route serveur utilise demain une dépendance qui produit un chunk ncc, on retombe sur le même souci.

  Option D — Copier le dossier dist/

  C’est ce qu’on a fait :

  COPY --from=installer /app/apps/server/dist/ ./

  Avantage :
  - respecte le contrat de sortie de ncc;
  - robuste aux chunks futurs ;
  - robuste aux assets runtime ;
  - simple ;
  - cohérent avec CMD ["node", "./index.js"].

  Inconvénient :
  - l’image runtime embarque un peu plus de fichiers.

  C’est l’option la plus saine.

  ───────────────────────────────

 ### 6. Comparaison avant / après

  Avant

  Image runtime :

  /app/index.js

  Seulement.

  Mais index.js pouvait faire :

  require("./774.index.js")

  Donc crash runtime.

  Après

  Image runtime :

  /app/index.js
  /app/774.index.js
  /app/754.index.js
  /app/7.index.js
  /app/proto/
  /app/protos/
  ...

  Donc les fichiers attendus par index.js sont présents.

  Taille

  Sur le build local :

  dist/             ~87 MB
  dist/index.js     ~71 MB

  Donc on ajoute environ :

  ~16 MB

  Mais attention : ce chiffre local peut inclure des artefacts présents dans dist selon l’état de dev. En Docker, le build part d’un contexte pruné et propre, donc l’écart exact peut
  varier.

  Les chunks directement liés au crash sont petits :

  774.index.js  ~286 KB
  754.index.js  ~10 KB
  7.index.js    ~11 KB

  Le reste vient surtout d’assets/protos et fichiers générés.

  ───────────────────────────────

### 7. Niveau sécurité

  Le changement est acceptable.

  Ce que ça ne fait pas

  Ça ne rend pas ces fichiers publics.

  Cloud Run ne sert pas automatiquement le filesystem /app.

  Le serveur Express ne fait pas :

  app.use(express.static("/app"))

  Donc un visiteur ne peut pas lire :

  https://api.refugies.info/774.index.js

  Il tombera sur les routes Express, puis sur le 404 applicatif.

  Secrets

  Les secrets ne sont pas copiés dans dist.

  Ils sont injectés au runtime via Cloud Run :

  --set-secrets ...

  Donc copier dist/ ne copie pas :
  - .env;
  - Secret Manager ;
  - valeurs de GRIST_AGIR_API_KEY;
  - valeurs de GCLOUD_PKEY.

  La .dockerignore exclut d’ailleurs les .env.

  Surface d’attaque

  La surface HTTP ne change pas.

  On ne crée :
  - aucune nouvelle route ;
  - aucun nouveau static serving ;
  - aucune nouvelle auth ;
  - aucune nouvelle permission.

  On embarque seulement les fichiers runtime nécessaires au bundle.


Risque résiduel

  Le seul petit inconvénient sécurité/ops, c’est que l’image contient un peu plus d’artefacts de build que strictement nécessaire.

  Mais :
  - l’image contient déjà index.js, qui contient quasiment tout le code ;
  - les chunks ne contiennent pas des secrets ;
  - ne pas copier les chunks casse le runtime ;
  - copier sélectivement est plus fragile.