### PR TITLE
feat(dispositif): rendre le titreMarque optionnel

### DIFF
--- a/apps/client/src/components/Backend/screens/Admin/AdminContenu/ImprovementsMailModal/functions.ts
+++ b/apps/client/src/components/Backend/screens/Admin/AdminContenu/ImprovementsMailModal/functions.ts
@@ -58,9 +58,9 @@ export const getFormattedStatus = (dispoStatus: string | undefined) => {
 export const getTitle = (
   titreInformatif: string,
   typeContenu: string,
-  titreMarque: string | undefined,
+  titreMarque: string | null | undefined,
 ) => {
-  if (typeContenu === "dispositif") {
+  if (typeContenu === "dispositif" && titreMarque) {
     return titreInformatif + " avec " + titreMarque;
   }
   return titreInformatif;

--- a/apps/client/src/components/Pages/dispositif/Edition/CustomNavbar/CustomNavbarEdit/functions.ts
+++ b/apps/client/src/components/Pages/dispositif/Edition/CustomNavbar/CustomNavbarEdit/functions.ts
@@ -61,7 +61,6 @@ export const getMissingStepsEdit = (
   if (typeContenu === ContentType.DISPOSITIF) {
     return [
       dispositif.titreInformatif ? null : "titreInformatif",
-      dispositif.titreMarque ? null : "titreMarque",
       dispositif.what ? null : "what",
       isAccordionOk(dispositif.why, 3) ? null : "why",
       isAccordionOk(dispositif.how, 1) ? null : "how",

--- a/apps/client/src/lib/webhookSchemas.ts
+++ b/apps/client/src/lib/webhookSchemas.ts
@@ -15,7 +15,7 @@ const BaseWebhookSchema = z.object({
 const DispositifContentSchema = z
   .object({
     titreInformatif: z.string().optional(),
-    titreMarque: z.string().optional(),
+    titreMarque: z.string().nullish(),
     abstract: z.string().optional(),
     markdown: z.string().optional(),
     // Add more content fields if needed based on usage
@@ -395,7 +395,7 @@ const TranslationSchema = z
 export const DispositifCreateSchema = BaseWebhookSchema.extend({
   dispositif: z.object({
     titreInformatif: z.string().optional(),
-    titreMarque: z.string().optional(),
+    titreMarque: z.string().nullish(),
     abstract: z.string().optional(),
     theme: ObjectIdSchema.optional(),
     secondaryThemes: z.array(ObjectIdSchema).optional(),
@@ -418,7 +418,7 @@ export const DispositifUpdateSchema = BaseWebhookSchema.extend({
   dispositif: z.object({
     _id: ObjectIdSchema,
     titreInformatif: z.string().optional(),
-    titreMarque: z.string().optional(),
+    titreMarque: z.string().nullish(),
     abstract: z.string().optional(),
     theme: ObjectIdSchema.optional(),
     secondaryThemes: z.array(ObjectIdSchema).optional(),

--- a/packages/api-types/src/generics.ts
+++ b/packages/api-types/src/generics.ts
@@ -281,7 +281,7 @@ export interface Metadatas {
 export interface SimpleDispositif {
   _id: Id;
   titreInformatif?: string;
-  titreMarque?: string;
+  titreMarque?: string | null;
   abstract?: string;
   typeContenu: ContentType;
   status: DispositifStatus;

--- a/packages/api-types/src/modules/dispositif.ts
+++ b/packages/api-types/src/modules/dispositif.ts
@@ -84,7 +84,7 @@ export interface GetContentsForAppRequest {
 export interface ContentForApp {
   _id: string;
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   abstract: string;
   theme: Id;
   secondaryThemes: Id[];
@@ -159,7 +159,7 @@ export interface UpdateDispositifPropertiesRequest {
 
 export interface DispositifRequest {
   titreInformatif?: string;
-  titreMarque?: string;
+  titreMarque?: string | null;
   abstract?: string;
   what?: string;
   markdown?: string;
@@ -243,7 +243,7 @@ export interface CreateDispositifRequest extends DispositifRequest {
 export type BaseGetDispositifResponse = {
   _id: Id;
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   abstract: string;
   why?: InfoSections;
   next?: InfoSections;
@@ -298,7 +298,7 @@ export type GetDispositifResponse = BaseGetDispositifResponse &
 export interface GetUserContributionsResponse {
   _id: Id;
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   typeContenu: ContentType;
   mainSponsor: {
     _id: Id;
@@ -386,7 +386,7 @@ export type GetDispositifsHasTextChanges = boolean;
 export interface GetAllDispositifsResponse {
   _id: Id;
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   typeContenu: ContentType;
   status: DispositifStatus;
   theme?: Id;

--- a/packages/api-types/src/modules/translations.ts
+++ b/packages/api-types/src/modules/translations.ts
@@ -30,7 +30,7 @@ export enum TraductionsStatus {
 
 export interface Content {
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   abstract: string;
 }
 
@@ -131,7 +131,7 @@ export interface SaveTranslationRequest {
     content: {
       // Partial<Content> & not working, see: https://github.com/lukeautry/tsoa/issues/1425
       titreInformatif?: string;
-      titreMarque?: string;
+      titreMarque?: string | null;
       abstract?: string;
       what?: RichText;
       why?: { [key: string]: PartialTranslatedContent }; // Partial<InfoSection> not working, see: https://github.com/lukeautry/tsoa/issues/1515
@@ -163,7 +163,7 @@ export interface GetDefaultTraductionResponse {
 export interface GetDispositifsWithTranslationAvancementResponse {
   _id: string;
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   nbMots: number;
   created_at: Date;
   type: ContentType;

--- a/packages/mongo/src/schemas/Dispositif.ts
+++ b/packages/mongo/src/schemas/Dispositif.ts
@@ -138,7 +138,7 @@ export type Poi = z.infer<typeof PoiZodSchema>;
 
 export const DispositifContentZodSchema = z.object({
   titreInformatif: z.string(),
-  titreMarque: z.string(),
+  titreMarque: z.string().nullable(),
   abstract: z.string(),
   what: z.string(),
   // PATCHED: z.record() → Map in Mongoose, relaxed for compatibility
@@ -148,7 +148,7 @@ export const DispositifContentZodSchema = z.object({
 // Strict type for application code
 export type DispositifContent = {
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   abstract: string;
   what: string;
   why: Record<string, InfoSection>;
@@ -157,7 +157,7 @@ export type DispositifContent = {
 
 export const DemarcheContentZodSchema = z.object({
   titreInformatif: z.string(),
-  titreMarque: z.string(),
+  titreMarque: z.string().nullable(),
   abstract: z.string(),
   what: z.string(),
   // PATCHED: z.record() → Map in Mongoose, relaxed for compatibility
@@ -168,7 +168,7 @@ export const DemarcheContentZodSchema = z.object({
 // Strict type for application code
 export type DemarcheContent = {
   titreInformatif: string;
-  titreMarque: string;
+  titreMarque: string | null;
   abstract: string;
   what: string;
   how: Record<string, InfoSection>;


### PR DESCRIPTION
## Contexte

Le `titreMarque` doit être **optionnel** : on doit pouvoir publier une fiche sans le renseigner. 

## Changements

- **Validation publication** : `titreMarque` retiré des étapes obligatoires (`getMissingStepsEdit`).
- **Schémas webhook** (`webhookSchemas.ts`) : `z.string().optional()` → `z.string().nullish()` (accepte `null` et l'absence, stocké tel quel).
- **Types alignés en `string | null`** dans `@refugies-info/api-types` et `@refugies-info/mongo` (contenu dispositif/démarche, réponses API, requêtes, traductions).
- **Affichage mail d'améliorations** : garde ajoutée pour éviter « … avec null ».

## Vérifications

- ✅ Typecheck client, serveur et mobile OK (plus aucune erreur liée à `titreMarque`).
- `wordCounter` déjà protégé (`isString`), exports CSV/mails retombent sur `""`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

lié à cette pr : 
https://github.com/refugies-info/playground/pull/301

A merger en 1er