### PR TITLE
fix(a11y): gestionnaire de cookies (RGAA 7.1, 8.9)

### DIFF
--- a/patches/@codegouvfr__react-dsfr@1.20.2.patch
+++ b/patches/@codegouvfr__react-dsfr@1.20.2.patch
@@ -1,3 +1,46 @@
+diff --git a/consentManagement/ConsentBannerAndConsentManagement/ConsentBanner.js b/consentManagement/ConsentBannerAndConsentManagement/ConsentBanner.js
+index e1f2baababfca4e042e7daf8dbbb5ef5b17b9c3c..7e7433e4c747831b0429b57b2ecc388a017b3747 100644
+--- a/consentManagement/ConsentBannerAndConsentManagement/ConsentBanner.js
++++ b/consentManagement/ConsentBannerAndConsentManagement/ConsentBanner.js
+@@ -22,19 +22,19 @@ export function createConsentBanner(params) {
+                     React.createElement("p", { className: fr.cx("fr-text--sm") }, t("welcome message", { personalDataPolicyLinkProps }))),
+                 React.createElement("ul", { className: fr.cx("fr-consent-banner__buttons", "fr-btns-group", "fr-btns-group--right", "fr-btns-group--inline-reverse", "fr-btns-group--inline-sm") },
+                     React.createElement("li", null,
+-                        React.createElement("button", { id: `${id}-button-accept-all`, className: fr.cx("fr-btn"), title: t("accept all - title"), onClick: async () => {
++                        React.createElement("button", { id: `${id}-button-accept-all`, className: fr.cx("fr-btn"), onClick: async () => {
+                                 setIsProcessingChanges(true);
+                                 await processConsentChanges({ "type": "grantAll" });
+                                 setIsProcessingChanges(false);
+                             }, disabled: isProcessingChanges }, t("accept all"))),
+                     React.createElement("li", null,
+-                        React.createElement("button", { id: `${id}-button-refuse-app`, className: fr.cx("fr-btn"), title: t("refuse all - title"), onClick: () => {
++                        React.createElement("button", { id: `${id}-button-refuse-app`, className: fr.cx("fr-btn"), onClick: () => {
+                                 setIsProcessingChanges(true);
+                                 processConsentChanges({ "type": "denyAll" });
+                                 setIsProcessingChanges(false);
+                             }, disabled: isProcessingChanges }, t("refuse all"))),
+                     React.createElement("li", null,
+-                        React.createElement("button", Object.assign({ id: `${id}-button-customize`, className: fr.cx("fr-btn", "fr-btn--secondary"), title: t("customize cookies - title"), disabled: isProcessingChanges }, consentModalButtonProps), t("customize")))))));
++                        React.createElement("button", Object.assign({ id: `${id}-button-customize`, className: fr.cx("fr-btn", "fr-btn--secondary"), disabled: isProcessingChanges }, consentModalButtonProps), t("customize")))))));
+     }
+     return { ConsentBanner };
+ }
+diff --git a/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js b/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js
+index a4e2f016566c0883f63bfb944e55a73c39e501d6..416b1c0e0d681cfa29b270f345d7cf58be8a3c4c 100644
+--- a/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js
++++ b/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js
+@@ -70,9 +70,9 @@ export function createConsentManagement(params) {
+                         React.createElement("legend", { className: fr.cx("fr-consent-service__title") }, t("preferences for all services", { personalDataPolicyLinkProps })),
+                         React.createElement("div", { className: fr.cx("fr-consent-service__radios") },
+                             React.createElement("div", { className: fr.cx("fr-btns-group", "fr-btns-group--inline", "fr-btns-group--right") },
+-                                React.createElement("button", { id: `${modal.id}-button-accept-all`, title: t("accept all - title"), className: fr.cx("fr-btn"), onClick: createOnClick("grantAll"), disabled: isProcessingChanges }, t("accept all")),
++                                React.createElement("button", { id: `${modal.id}-button-accept-all`, className: fr.cx("fr-btn"), onClick: createOnClick("grantAll"), disabled: isProcessingChanges }, t("accept all")),
+                                 " ",
+-                                React.createElement("button", { id: `${modal.id}-button-refuse-all`, title: t("refuse all - title"), className: fr.cx("fr-btn", "fr-btn--secondary"), disabled: isProcessingChanges, onClick: createOnClick("denyAll") }, t("refuse all")))))),
++                                React.createElement("button", { id: `${modal.id}-button-refuse-all`, className: fr.cx("fr-btn", "fr-btn--secondary"), disabled: isProcessingChanges, onClick: createOnClick("denyAll") }, t("refuse all")))))),
+                 React.createElement(ConsentService, { title: t("mandatory cookies"), description: t("mandatory cookies - description"), finalityConsent: true, onChange: undefined, subFinalities: undefined }),
+                 objectKeys(finalityDescription)
+                     .map(finality => ({
 diff --git a/dsfr/dsfr.min.css b/dsfr/dsfr.min.css
 index 7b5b508f740e2145c052c383f98f6c18408a3456..5457df1d8d91ec08f4d0201d090e02f05f2e086e 100644
 --- a/dsfr/dsfr.min.css

--- a/patches/@codegouvfr__react-dsfr@1.20.2.patch
+++ b/patches/@codegouvfr__react-dsfr@1.20.2.patch
@@ -26,7 +26,7 @@ index e1f2baababfca4e042e7daf8dbbb5ef5b17b9c3c..7e7433e4c747831b0429b57b2ecc388a
      return { ConsentBanner };
  }
 diff --git a/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js b/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js
-index a4e2f016566c0883f63bfb944e55a73c39e501d6..416b1c0e0d681cfa29b270f345d7cf58be8a3c4c 100644
+index a4e2f016566c0883f63bfb944e55a73c39e501d6..43df6b6c7022c47d4500f1e8216236bcc481ce32 100644
 --- a/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js
 +++ b/consentManagement/ConsentBannerAndConsentManagement/ConsentManagement.js
 @@ -70,9 +70,9 @@ export function createConsentManagement(params) {
@@ -41,6 +41,18 @@ index a4e2f016566c0883f63bfb944e55a73c39e501d6..416b1c0e0d681cfa29b270f345d7cf58
                  React.createElement(ConsentService, { title: t("mandatory cookies"), description: t("mandatory cookies - description"), finalityConsent: true, onChange: undefined, subFinalities: undefined }),
                  objectKeys(finalityDescription)
                      .map(finality => ({
+@@ -88,9 +88,8 @@ export function createConsentManagement(params) {
+                         finality,
+                         isConsentGiven
+                     })), finalityConsent: localFinalityConsent[finality] }))),
+-                React.createElement("ul", { className: fr.cx("fr-consent-manager__buttons", "fr-btns-group", "fr-btns-group--right", "fr-btns-group--inline-sm") },
+-                    React.createElement("li", null,
+-                        React.createElement("button", { id: `${modal.id}-button-confirm`, className: fr.cx("fr-btn"), disabled: isProcessingChanges, onClick: createOnClick("apply local changes") }, t("confirm choices")))))));
++                React.createElement("div", { className: fr.cx("fr-consent-manager__buttons", "fr-btns-group", "fr-btns-group--right", "fr-btns-group--inline-sm") },
++                    React.createElement("button", { id: `${modal.id}-button-confirm`, className: fr.cx("fr-btn"), disabled: isProcessingChanges, onClick: createOnClick("apply local changes") }, t("confirm choices"))))));
+     }
+     function ConsentService(props) {
+         const { title, description, subFinalities, finalityConsent, onChange } = props;
 diff --git a/dsfr/dsfr.min.css b/dsfr/dsfr.min.css
 index 7b5b508f740e2145c052c383f98f6c18408a3456..5457df1d8d91ec08f4d0201d090e02f05f2e086e 100644
 --- a/dsfr/dsfr.min.css

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ overrides:
 
 patchedDependencies:
   '@codegouvfr/react-dsfr@1.20.2':
-    hash: ccdb6ee3a9458eeb45869cf78316c98ef03e5884200760879b187f88fa121aff
+    hash: 47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9
     path: patches/@codegouvfr__react-dsfr@1.20.2.patch
 
 importers:
@@ -90,7 +90,7 @@ importers:
         version: 2.3.7
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=ccdb6ee3a9458eeb45869cf78316c98ef03e5884200760879b187f88fa121aff)
+        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
       '@refugies-info/api-types':
         specifier: workspace:*
         version: link:packages/api-types
@@ -147,7 +147,7 @@ importers:
         version: 5.49.1
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=ccdb6ee3a9458eeb45869cf78316c98ef03e5884200760879b187f88fa121aff)
+        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
       '@lexical/html':
         specifier: ^0.27.2
         version: 0.27.2
@@ -945,7 +945,7 @@ importers:
     dependencies:
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=ccdb6ee3a9458eeb45869cf78316c98ef03e5884200760879b187f88fa121aff)
+        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
       '@refugies-info/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -1094,7 +1094,7 @@ importers:
     dependencies:
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=ccdb6ee3a9458eeb45869cf78316c98ef03e5884200760879b187f88fa121aff)
+        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
       '@lottiefiles/dotlottie-react':
         specifier: ^0.13.5
         version: 0.13.5(react@19.1.0)
@@ -13920,7 +13920,7 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
-  '@codegouvfr/react-dsfr@1.20.2(patch_hash=ccdb6ee3a9458eeb45869cf78316c98ef03e5884200760879b187f88fa121aff)':
+  '@codegouvfr/react-dsfr@1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)':
     dependencies:
       tsafe: 1.8.10
       yargs-parser: 21.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ overrides:
 
 patchedDependencies:
   '@codegouvfr/react-dsfr@1.20.2':
-    hash: 47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9
+    hash: e4d4535ed52cd68ab97c98870c705dcbf7dc6756fcf49f61ab94a9464c223ae9
     path: patches/@codegouvfr__react-dsfr@1.20.2.patch
 
 importers:
@@ -90,7 +90,7 @@ importers:
         version: 2.3.7
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
+        version: 1.20.2(patch_hash=e4d4535ed52cd68ab97c98870c705dcbf7dc6756fcf49f61ab94a9464c223ae9)
       '@refugies-info/api-types':
         specifier: workspace:*
         version: link:packages/api-types
@@ -147,7 +147,7 @@ importers:
         version: 5.49.1
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
+        version: 1.20.2(patch_hash=e4d4535ed52cd68ab97c98870c705dcbf7dc6756fcf49f61ab94a9464c223ae9)
       '@lexical/html':
         specifier: ^0.27.2
         version: 0.27.2
@@ -945,7 +945,7 @@ importers:
     dependencies:
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
+        version: 1.20.2(patch_hash=e4d4535ed52cd68ab97c98870c705dcbf7dc6756fcf49f61ab94a9464c223ae9)
       '@refugies-info/ui':
         specifier: workspace:*
         version: link:../../packages/ui
@@ -1094,7 +1094,7 @@ importers:
     dependencies:
       '@codegouvfr/react-dsfr':
         specifier: 1.20.2
-        version: 1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)
+        version: 1.20.2(patch_hash=e4d4535ed52cd68ab97c98870c705dcbf7dc6756fcf49f61ab94a9464c223ae9)
       '@lottiefiles/dotlottie-react':
         specifier: ^0.13.5
         version: 0.13.5(react@19.1.0)
@@ -13920,7 +13920,7 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
-  '@codegouvfr/react-dsfr@1.20.2(patch_hash=47aacf2e315e8967ccd51dd2a4579f8bfea5ebc82520f1eea194e3b08ee9a1b9)':
+  '@codegouvfr/react-dsfr@1.20.2(patch_hash=e4d4535ed52cd68ab97c98870c705dcbf7dc6756fcf49f61ab94a9464c223ae9)':
     dependencies:
       tsafe: 1.8.10
       yargs-parser: 21.1.1


### PR DESCRIPTION

Audit RGAA Ideance, RGA-6.

Les défauts viennent du composant consent de `@codegouvfr/react-dsfr`, pas du site. Correction par extension du patch pnpm existant : 5 attributs `title` retirés, et le bouton « Confirmer mes choix » sort de sa fausse liste.

À savoir pour la suite : ce patch est à reporter lors des montées de version de react-dsfr. Monter de version ne corrigerait rien, l'amont assume ces défauts. Aucun changement visuel.
