### PR TITLE
fix(a11y): boîte newsletter (RGAA 11.1, 11.10, 11.13, 7.5, 1.2, 8.9)

### DIFF
--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -84,7 +84,7 @@ const EmailField = (props: EmailProps) => {
         id="email"
         type="email"
         autoComplete="email"
-        title={t("Register.Votre adresse email", "Votre adresse email")}
+        title={t("Register.Votre email", "Votre email")}
         placeholder={t("Register.Votre email", "Votre email")}
         error={props.notEmailError}
         ariaDescribedby={props.notEmailError ? "newsletter-email-error" : undefined}

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -80,6 +80,7 @@ const EmailField = (props: EmailProps) => {
         onChange={props.onChange}
         id="email"
         type="email"
+        autoComplete="email"
         title={t("Register.Votre adresse email", "Votre adresse email")}
         placeholder={t("Register.Votre email", "Votre email")}
         error={props.notEmailError}

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -158,14 +158,10 @@ export const SubscribeNewsletterModal = () => {
       <MainContainer>
         {isMobile && (
           <CloseIconContainer onClick={toggle}>
-            <EVAIcon name="close" fill="white" size={"large"} />
+            <EVAIcon name="close" fill="white" size={"large"} aria-hidden="true" />
           </CloseIconContainer>
         )}
-        <Image
-          src={newsletter}
-          alt="image newsletter"
-          style={{ maxWidth: "100%", height: "auto" }}
-        />
+        <Image src={newsletter} alt="" style={{ maxWidth: "100%", height: "auto" }} />
         <TitleContainer>
           {isMobile
             ? t("Footer.Newsletter", "Newsletter")

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -38,7 +38,7 @@ const MainContainer = styled.div`
   padding-top: 50px;
   margin: 8px;
 `;
-const TextContainer = styled.div`
+const TextContainer = styled.p`
   font-size: 18px;
   font-weight: normal;
   margin: 16px;
@@ -50,11 +50,13 @@ const ButtonContainer = styled.div`
   margin-top: 12px;
 `;
 
-const ErrorMessageContainer = styled.div`
+const ErrorMessageContainer = styled.p`
   color: ${colors.error};
   font-size: 16px;
   line-height: 20px;
   margin-top: 16px;
+  // p reçoit une marge basse de bootstrap, absente du div d'origine
+  margin-bottom: 0;
 `;
 
 const CloseIconContainer = styled.div`

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -6,6 +6,7 @@ import { Modal } from "reactstrap";
 import styled from "styled-components";
 import Swal from "sweetalert2";
 import { newsletter } from "~/assets/figma";
+import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import EVAIcon from "~/components/UI/EVAIcon/EVAIcon";
 import FButton from "~/components/UI/FButton/FButton";
 import { FButtonMobile } from "~/components/UI/FButtonMobile/FButtonMobile";
@@ -97,6 +98,7 @@ export const SubscribeNewsletterModal = () => {
   const [email, setEmail] = useState("");
   const [notEmailError, setNotEmailError] = useState(false);
   const { t } = useTranslation();
+  const announce = useAnnounce();
 
   const show = useSelector(showNewsletterModalSelector);
   const toggle = () => dispatch(toggleNewsletterModalAction(false));
@@ -129,12 +131,17 @@ export const SubscribeNewsletterModal = () => {
             icon: "success",
             timer: 1500,
           });
+          announce("Mail correctement enregistré !");
           setEmail("");
         })
         .catch((e) => {
-          if (e.response?.data?.code === "CONTACT_ALREADY_EXIST")
+          if (e.response?.data?.code === "CONTACT_ALREADY_EXIST") {
             Swal.fire("Oh non...", t("Footer.newsletter_contact_already_exist"), "error");
-          else Swal.fire("Oh non...", "Une erreur s'est produite", "error");
+            announce(t("Footer.newsletter_contact_already_exist"));
+          } else {
+            Swal.fire("Oh non...", "Une erreur s'est produite", "error");
+            announce("Une erreur s'est produite");
+          }
         });
     } else {
       setNotEmailError(true);

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -133,7 +133,14 @@ export const SubscribeNewsletterModal = () => {
             icon: "success",
             timer: 1500,
           });
-          announce("Mail correctement enregistré !");
+          // Le libellé partagé avec la section d'accueil porte du gras pour l'affichage,
+          // une région vocale ne restitue que du texte.
+          announce(
+            t("NewsletterForm.confirmMessageText", {
+              defaultValue: "Mail correctement enregistré !",
+              email,
+            }).replace(/<[^>]*>/g, ""),
+          );
           setEmail("");
         })
         .catch((e) => {
@@ -142,7 +149,7 @@ export const SubscribeNewsletterModal = () => {
             announce(t("Footer.newsletter_contact_already_exist"));
           } else {
             Swal.fire("Oh non...", "Une erreur s'est produite", "error");
-            announce("Une erreur s'est produite");
+            announce(t("NewsletterForm.errorsSystemerror", "Une erreur s'est produite"));
           }
         });
     } else {

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -83,6 +83,7 @@ const EmailField = (props: EmailProps) => {
         title={t("Register.Votre adresse email", "Votre adresse email")}
         placeholder={t("Register.Votre email", "Votre email")}
         error={props.notEmailError}
+        ariaDescribedby={props.notEmailError ? "newsletter-email-error" : undefined}
         errorIcon="email-outline"
         newSize
       />
@@ -175,7 +176,7 @@ export const SubscribeNewsletterModal = () => {
           notEmailError={notEmailError}
         />
         {notEmailError && (
-          <ErrorMessageContainer>{`${t("Register.not_an_email")} ${t("Register.check_mail")}`}</ErrorMessageContainer>
+          <ErrorMessageContainer id="newsletter-email-error">{`${t("Register.not_an_email")} ${t("Register.check_mail")}`}</ErrorMessageContainer>
         )}
         {isMobile ? (
           <FButtonMobile

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -154,6 +154,7 @@ export const SubscribeNewsletterModal = () => {
     <Modal
       isOpen={show}
       toggle={toggle}
+      labelledBy="newsletter-modal-title"
       className={styles.modal}
       contentClassName={styles.modal_content}
     >
@@ -164,7 +165,7 @@ export const SubscribeNewsletterModal = () => {
           </CloseIconContainer>
         )}
         <Image src={newsletter} alt="" style={{ maxWidth: "100%", height: "auto" }} />
-        <TitleContainer>
+        <TitleContainer id="newsletter-modal-title">
           {isMobile
             ? t("Footer.Newsletter", "Newsletter")
             : t("Footer.subscribe_to_newsletter_modal_title", "Inscription à la newsletter")}

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -80,6 +80,7 @@ const EmailField = (props: EmailProps) => {
         onChange={props.onChange}
         id="email"
         type="email"
+        title={t("Register.Votre adresse email", "Votre adresse email")}
         placeholder={t("Register.Votre email", "Votre email")}
         error={props.notEmailError}
         errorIcon="email-outline"

--- a/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
@@ -99,6 +99,7 @@ const Newsletter = () => {
                 type: "email",
                 value: email,
                 name: "email",
+                autoComplete: "email",
                 onChange: (e: any) => setEmail(e.target.value),
                 id: "newsletter-email",
               }}

--- a/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
@@ -61,25 +61,29 @@ const Newsletter = () => {
         <Image src={NewsletterIllu} alt="" width={433} height={320} className="m-auto max-w-full" />
 
         <div className="stacked relative grid h-full grid-cols-1 grid-rows-1 items-center">
-          {newsletterFormState === "success" && (
-            <Alert
-              closable
-              onClose={() => setNewsletterFormState("default")}
-              severity="success"
-              description={
-                <span
-                  dangerouslySetInnerHTML={{
-                    __html: t("NewsletterForm.confirmMessageText", {
-                      defaultValue: "Mail correctement enregistré !",
-                      email: email,
-                    }),
-                  }}
-                ></span>
-              }
-              title={t("NewsletterForm.confirmMessageTitle", "Yay...")}
-              className={cls("z-20 col-start-1 row-start-1 w-full bg-white transition")}
-            />
-          )}
+          {/* Région vivante permanente : role="status" doit exister avant l'arrivée du message
+              pour que les lecteurs d'écran restituent le succès (RGAA 7.5) */}
+          <div role="status" className="z-20 col-start-1 row-start-1 w-full">
+            {newsletterFormState === "success" && (
+              <Alert
+                closable
+                onClose={() => setNewsletterFormState("default")}
+                severity="success"
+                description={
+                  <span
+                    dangerouslySetInnerHTML={{
+                      __html: t("NewsletterForm.confirmMessageText", {
+                        defaultValue: "Mail correctement enregistré !",
+                        email: email,
+                      }),
+                    }}
+                  ></span>
+                }
+                title={t("NewsletterForm.confirmMessageTitle", "Yay...")}
+                className={cls("w-full bg-white transition")}
+              />
+            )}
+          </div>
           <form
             onSubmit={sendMail}
             className={cls(

--- a/apps/client/src/components/UI/FInput/FInput.tsx
+++ b/apps/client/src/components/UI/FInput/FInput.tsx
@@ -34,6 +34,7 @@ interface Props {
   name?: string;
   maxlength?: number;
   title?: string;
+  ariaDescribedby?: string;
 }
 
 const FInput = (props: Props) => {
@@ -62,6 +63,7 @@ const FInput = (props: Props) => {
         disabled={props.disabled}
         name={props.name}
         title={props.title}
+        aria-describedby={props.ariaDescribedby}
         maxLength={props.maxlength || undefined}
         className={cls(
           props.inputClassName || "",

--- a/apps/client/src/components/UI/FInput/FInput.tsx
+++ b/apps/client/src/components/UI/FInput/FInput.tsx
@@ -33,6 +33,7 @@ interface Props {
   errorType?: string;
   name?: string;
   maxlength?: number;
+  title?: string;
 }
 
 const FInput = (props: Props) => {
@@ -60,6 +61,7 @@ const FInput = (props: Props) => {
         autoComplete={props.autoComplete}
         disabled={props.disabled}
         name={props.name}
+        title={props.title}
         maxLength={props.maxlength || undefined}
         className={cls(
           props.inputClassName || "",


### PR DESCRIPTION

Audit RGAA Ideance, RGA-7.

Champ email : étiquette, `autocomplete`, message d'erreur relié par `aria-describedby`, et résultat d'envoi annoncé aux lecteurs d'écran (`useAnnounce` en modale, `role="status"` sur l'accueil).

Aussi : illustration et croix décoratives masquées, paragraphes en `<p>`, nom accessible de la modale. Aucun changement visuel.
