### PR TITLE
fix(a11y): alternatives textuelles des images du corps de page (RGAA 1.2, 1.3, 6.1)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -42,7 +42,7 @@
     "accordionItemsdesktopText4": "Sur Réfugiés.info, l’information est simplifiée, traduite en 7 langues et écoutable. Les fiches peuvent servir de support pour communiquer ou expliquer une information. Cet outil peut ainsi faciliter le travail d’accompagnement social.",
     "resourcesTitle": "Des ressources gratuites à votre disposition",
     "resourcesText": "Nous vous fournissons un ensemble d’outils numériques et physiques pour découvrir le projet et en parler autour de vous : vidéos animées, flyers multilangues, brochures de présentation, visuels, etc.",
-    "ressourcesImgAlt": "Capture d'écran du kit de communication de Réfugiés.info. L'interface affiche un site web avec une vidéo de présentation, un message d'accueil expliquant l'objectif du kit et une section d'accès rapide contenant des boutons vers différentes ressources. À droite, une série de flyers multilingues est disposée en éventail, représentant les supports physiques disponibles pour informer sur le projet.",
+    "ressourcesImgAlt": "Kit de communication de Réfugiés.info",
     "resourcesCTA": "Voir les outils",
     "webinaireCTA": "Participer à un webinaire",
     "StructuresLogosText": "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !",

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -666,8 +666,8 @@
     "AnnotationsEasyfrench": "Français facile",
     "AnnotationsVocalize": "Vocalisation des contenus",
     "AnnotationsListen": "Écoute",
-    "appStoreBadge": "Télécharger sur l'app store apple",
-    "playStoreBadge": "Télécharger sur Google Play",
+    "appStoreBadge": "Télécharger dans l'App Store",
+    "playStoreBadge": "Disponible sur Google Play",
     "description": "Téléchargez l'application mobile pour accéder à toutes les fonctionnalités de partage, de changement de langue, de langage clair et de vocalisation centralisées dans une seule application.",
     "sectionLabel": "Section application mobile"
   },

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -650,6 +650,7 @@
   "MobileApp": {
     "rankingText": "Top 3 des applications publiques",
     "rankingLabel": "Note : 5 sur 5",
+    "ratingAlt": "Note sur 5 :",
     "titleDesktop": "Envoyez un lien de téléchargement de l’application à vos bénéficiaires !",
     "titleMobile": "Télécharge l’application !",
     "subtitleDesktop": "Gratuite, l’application a été conçue avec et pour les personnes réfugiées. Elles pourront y trouver de l’information simplifiée, traduite en 7 langues et écoutable.",

--- a/apps/client/src/components/Modals/DownloadAppModal/DownloadAppModal.tsx
+++ b/apps/client/src/components/Modals/DownloadAppModal/DownloadAppModal.tsx
@@ -39,7 +39,13 @@ const DownloadAppModal = ({ show, toggle }: Props) => {
 
       <p className={styles.text}>{t("MobileAppModal.description")}</p>
       <div className={styles.rating}>
-        <Image src={RatingStars} width={136} height={24} alt="4,8" className="me-2" />
+        <Image
+          src={RatingStars}
+          width={136}
+          height={24}
+          alt={t("MobileApp.ratingAlt", "Note sur 5 :")}
+          className="me-2"
+        />
         4,8
       </div>
 

--- a/apps/client/src/components/Modals/DownloadAppModal/DownloadAppModal.tsx
+++ b/apps/client/src/components/Modals/DownloadAppModal/DownloadAppModal.tsx
@@ -30,12 +30,7 @@ const DownloadAppModal = ({ show, toggle }: Props) => {
         title={t("close")}
         className={styles.close}
       />
-      <Image
-        src={MobileAppIllu}
-        width={327}
-        alt="Réfugiés.info mobile app"
-        className={styles.illu}
-      />
+      <Image src={MobileAppIllu} width={327} alt="" className={styles.illu} />
 
       <p className={styles.text}>{t("MobileAppModal.description")}</p>
       <div className={styles.rating}>

--- a/apps/client/src/components/Pages/auth/Layout/Layout.tsx
+++ b/apps/client/src/components/Pages/auth/Layout/Layout.tsx
@@ -85,7 +85,7 @@ const Layout = (props: Props) => {
                 Plus de 100 000 réfugiés et 2 000 professionnels ont adopté Réfugiés.info&nbsp;!
               </p>
               <div className={styles.rating}>
-                <Image src={RatingStars} width={136} height={24} alt="4,8" />
+                <Image src={RatingStars} width={136} height={24} alt="Note sur 5 :" />
                 4,8
               </div>
               <p className={styles.small}>Application disponible sur Android et iOS</p>

--- a/apps/client/src/components/Pages/auth/Layout/Layout.tsx
+++ b/apps/client/src/components/Pages/auth/Layout/Layout.tsx
@@ -1,4 +1,5 @@
 import { Notice } from "@codegouvfr/react-dsfr/Notice";
+import { useTranslation } from "next-i18next";
 import { useEffect } from "react";
 import PersosIllu from "~/assets/auth/illu-persos.svg";
 import AuthIllu from "~/assets/auth/login-illu.svg";
@@ -17,6 +18,7 @@ interface Props {
 }
 
 const Layout = (props: Props) => {
+  const { t } = useTranslation();
   const isRTL = useRTL();
 
   // force french language for login
@@ -85,7 +87,7 @@ const Layout = (props: Props) => {
                 Plus de 100 000 réfugiés et 2 000 professionnels ont adopté Réfugiés.info&nbsp;!
               </p>
               <div className={styles.rating}>
-                <Image src={RatingStars} width={136} height={24} alt="Note sur 5 :" />
+                <Image src={RatingStars} width={136} height={24} alt={t("MobileApp.ratingAlt", "Note sur 5 :")} />
                 4,8
               </div>
               <p className={styles.small}>Application disponible sur Android et iOS</p>

--- a/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
@@ -39,10 +39,7 @@ const FreeResources = () => {
         <Link href="https://kit.refugies.info/" target="_blank" rel="noopener noreferrer">
           <Image
             src={FreeResourcesImg}
-            alt={t(
-              "Homepage.ressourcesImgAlt",
-              "Capture d'écran du kit de communication de Réfugiés.info. L'interface affiche un site web avec une vidéo de présentation, un message d'accueil expliquant l'objectif du kit et une section d'accès rapide contenant des boutons vers différentes ressources. À droite, une série de flyers multilingues est disposée en éventail, représentant les supports physiques disponibles pour informer sur le projet.",
-            )}
+            alt={t("Homepage.ressourcesImgAlt", "Kit de communication de Réfugiés.info")}
             width={576}
             height={362}
           />

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -33,7 +33,7 @@ const MobileApp = () => {
         >
           <Image
             src={appStoreBadge}
-            alt={t("MobileApp.appStoreBadge", "Télécharger sur l'app store apple")}
+            alt={t("MobileApp.appStoreBadge", "Télécharger dans l'App Store")}
             fill
           />
         </a>
@@ -47,7 +47,7 @@ const MobileApp = () => {
             src={playStoreBadge}
             width={128}
             height={40}
-            alt={t("MobileApp.playStoreBadge", "Télécharger sur Google Play")}
+            alt={t("MobileApp.playStoreBadge", "Disponible sur Google Play")}
           />
         </a>
       </p>


### PR DESCRIPTION
Audit RGAA Ideance, RGA-9.

Les étoiles de notation annoncent « Note sur 5 : » au lieu de répéter le « 4,8 » déjà écrit à côté. L'illustration de la modale de téléchargement passe en décoratif. Les images-liens décrivent leur destination : les badges des stores reprennent leur intitulé visible (mêmes valeurs que la navbar corrigée par #3868, même prescription), l'image du kit annonce « Kit de communication de Réfugiés.info » au lieu d'une description de 400 caractères.

Les logos partenaires de l'accueil ne sont pas touchés : leur `alt=""` et le paragraphe « Nos partenaires : … » sont un choix délibéré de RI (f2f7de17b, 20d968086) qui atteint l'objectif du critère autrement. Divergence à acter avec Ideance.

Clés à verser au flux de traduction : `MobileApp.ratingAlt` (nouvelle), `MobileApp.appStoreBadge`, `MobileApp.playStoreBadge`, `Homepage.ressourcesImgAlt` (les trois dernières n'existaient déjà qu'en français). Aucun changement visuel.
