### PR TITLE
fix(a11y): titres de page et hiérarchie (RGAA 8.5, 8.6, 9.1)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -50,6 +50,7 @@
   },
   "Recherche": {
     "pageTitle": "Recherche",
+    "pageTitleWithSearch": "Résultats de la recherche sur \"{{search}}\"",
     "title": "Trouver une fiche d'information",
     "yourResults": "Vos {{count}} résultats de recherche",
     "yourResults_other": "Vos {{count}} résultats de recherche",

--- a/apps/client/src/components/Content/Dispositif/Dispositif.tsx
+++ b/apps/client/src/components/Content/Dispositif/Dispositif.tsx
@@ -58,7 +58,7 @@ const Dispositif = (props: Props) => {
   return (
     <div ref={dispositifRef} className={cn("w-full", isEditMode && "edit")} id="top">
       <SEO
-        title={dispositif?.titreMarque || dispositif?.titreInformatif || ""}
+        title={[dispositif?.titreMarque, dispositif?.titreInformatif].filter(Boolean).join(" - ")}
         description={dispositif?.abstract || ""}
         image={theme?.shareImage?.secure_url}
       />

--- a/apps/client/src/components/Pages/dispositif/RichText/RichText.tsx
+++ b/apps/client/src/components/Pages/dispositif/RichText/RichText.tsx
@@ -19,7 +19,7 @@ const RichText = (props: Props) => {
   return (
     <div className={cn(pageContext.mode !== "edit" && "prose no-dsfr", styles.content)}>
       {pageContext.mode !== "edit" ? (
-        <Text id={props.id} html>
+        <Text id={props.id} html calloutTitleAs="h2">
           {props.value || ""}
         </Text>
       ) : (

--- a/apps/client/src/components/Pages/dispositif/ShareButtons/ShareButtons.tsx
+++ b/apps/client/src/components/Pages/dispositif/ShareButtons/ShareButtons.tsx
@@ -45,9 +45,9 @@ const ShareButtons = ({ className }: { className?: string }) => {
   return (
     <div className="mb-4 flex flex-col gap-2 print:hidden">
       <div className={cn("bg-white/50 p-4 backdrop-blur-[30px]", className)}>
-        <p className="text-title-xxs text-title-grey mb-4 font-bold">
+        <h2 className="text-title-xxs text-title-grey mb-4 font-bold">
           {t("Dispositif.share", "Partager la fiche")}
-        </p>
+        </h2>
         <div className="flex items-center">
           <Tooltip kind="hover" title={t("Dispositif.sendBySMS")}>
             <Button

--- a/apps/client/src/components/Pages/dispositif/Text/Text.tsx
+++ b/apps/client/src/components/Pages/dispositif/Text/Text.tsx
@@ -17,6 +17,8 @@ interface Props {
   children: string;
   html?: boolean;
   className?: string;
+  /** Heading level of the callout labels, to match the surrounding hierarchy */
+  calloutTitleAs?: "h2" | "h3" | "h4" | "h5" | "h6";
 }
 
 const Text = (props: Props) => {
@@ -186,8 +188,13 @@ const Text = (props: Props) => {
           const calloutSegment = segment as CalloutSegment;
 
           return (
-            <CallOut key={`callout-${calloutSegment.calloutType}-${index}`} className="p-4 ps-6">
-              <b className="mb-2 block text-xl">{calloutSegment.title}</b>
+            <CallOut
+              key={`callout-${calloutSegment.calloutType}-${index}`}
+              className="p-4 ps-6"
+              title={calloutSegment.title}
+              titleAs={props.calloutTitleAs ?? "h4"}
+              classes={{ title: "!mb-2 !mt-0 block text-xl !font-bold !text-inherit" }}
+            >
               <div
                 className="not-prose text-base max-sm:text-lg"
                 dangerouslySetInnerHTML={{ __html: calloutSegment.content }}

--- a/apps/client/src/lib/markdown/directive-to-component.tsx
+++ b/apps/client/src/lib/markdown/directive-to-component.tsx
@@ -126,8 +126,12 @@ export function getDirectiveComponents(t: TFunction) {
     // :::important
     important: ({ children }: DirectiveComponentProps) => {
       return (
-        <CallOut className="p-4 ps-6 not-prose">
-          <b className="mb-2 block text-xl">{t(getCalloutTranslationKey("important"))}</b>
+        <CallOut
+          className="p-4 ps-6 not-prose"
+          title={t(getCalloutTranslationKey("important"))}
+          titleAs="h2"
+          classes={{ title: "!mb-2 !mt-0 block text-xl !font-bold !text-inherit" }}
+        >
           <span className="block text-base max-sm:text-lg">{children}</span>
         </CallOut>
       );
@@ -136,8 +140,12 @@ export function getDirectiveComponents(t: TFunction) {
     // :::good-to-know
     "good-to-know": ({ children }: DirectiveComponentProps) => {
       return (
-        <CallOut className="p-4 ps-6 not-prose">
-          <b className="mb-2 block text-xl">{t(getCalloutTranslationKey("info"))}</b>
+        <CallOut
+          className="p-4 ps-6 not-prose"
+          title={t(getCalloutTranslationKey("info"))}
+          titleAs="h2"
+          classes={{ title: "!mb-2 !mt-0 block text-xl !font-bold !text-inherit" }}
+        >
           <span className="block text-base max-sm:text-lg">{children}</span>
         </CallOut>
       );

--- a/apps/client/src/pages/plan-du-site.tsx
+++ b/apps/client/src/pages/plan-du-site.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { useTranslation } from "next-i18next";
 import type { ReactElement, ReactNode } from "react";
 import LegalPagesLayout from "~/components/Layout/LegalPagesLayout";
+import SEO from "~/components/Seo";
 import { defaultStaticProps } from "~/lib/getDefaultStaticProps";
 import { Event } from "~/lib/tracking";
 
@@ -207,6 +208,7 @@ const PlanDuSite = () => {
 
   return (
     <>
+      <SEO title={t("sitemap.title", "Plan du site")} />
       <h1 className="mb-8 md:mb-20">{t("sitemap.title", "Plan du site")}</h1>
 
       <div className="space-y-10 md:space-y-20">

--- a/apps/client/src/pages/recherche.tsx
+++ b/apps/client/src/pages/recherche.tsx
@@ -157,7 +157,17 @@ const Recherche = () => {
 
   return (
     <div className={cls(styles.container)}>
-      <SEO title={t("Recherche.pageTitle", "Recherche")} />
+      <SEO
+        title={
+          query.search
+            ? t("Recherche.pageTitleWithSearch", {
+                search: query.search,
+                defaultValue: 'Résultats de la recherche sur "{{search}}"',
+                interpolation: { escapeValue: false },
+              })
+            : t("Recherche.pageTitle", "Recherche")
+        }
+      />
 
       <HelpNotice />
       <SearchHeader counts={counts} nbResults={pagination.total} />


### PR DESCRIPTION
Audit RGAA Ideance, RGA-12. Un commit par geste.

Plan du site : la page a maintenant un `<title>`. Recherche : le titre reprend les termes cherchés, « Résultats de la recherche sur "..." ». Fiche dispositif : le titre complète le nom de marque par le titre informatif. « Partager la fiche » et les encadrés « Important » / « Bon à savoir » : de vrais titres à la place de paragraphes en gras.

Pour les encadrés, le `h4` prescrit est appliqué là où Ideance l'a mesuré. En introduction, juste sous le `h1`, le niveau est adapté pour ne pas créer de saut. Relevé complet dans la note du ticket.

Les `<h3>` « Votre demande est irrecevable / inopportune » viennent du contenu en base, pas du code : correction éditoriale, hors PR.

Clé à faire traduire : `Recherche.pageTitleWithSearch` (créée en français).
