### PR TITLE
fix(a11y): pied de page et bloc-marque auth, liens distinguables et intitulés explicites (RGAA 6.1, 10.6)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -475,7 +475,9 @@
     "mission_impact": "Mission et impact",
     "useful_links": "Liens utiles",
     "contact_team_closed": "Contacter l'équipe du lundi au jeudi, de 9h30 à 12h30 et de 14h à 18h",
-    "contact_team_unavailable": "Contacter l'équipe (momentanément indisponible)"
+    "contact_team_unavailable": "Contacter l'équipe (momentanément indisponible)",
+    "diair_full_name": "Délégation interministérielle à l’accueil et à l’intégration des réfugiés",
+    "open_new_window": "ouvre une nouvelle fenêtre"
   },
   "Consent": {
     "analytics_title": "Analyse",

--- a/apps/client/src/components/Layout/Footer/FooterDSFR.module.scss
+++ b/apps/client/src/components/Layout/Footer/FooterDSFR.module.scss
@@ -17,6 +17,32 @@
     display: none;
   }
 
+  /* RGAA 10.6: the etalab licence link carries no `fr-*` class, so it matches
+     `a:not(.underline):not(.fr-default)` in `scss/_dsfr-fix.scss`, which sets
+     `text-decoration: none` and `background-image: none` and therefore removes
+     the DSFR underline. That file is imported outside any cascade layer, so it
+     wins over `@layer dsfr` whatever the specificity: this override must stay
+     outside `@layer` too.
+
+     We target the container, not the link's id. react-dsfr only sets
+     `id="footer-etalab-licence-link"` in its French message; the English one
+     renders the same link with no id (Footer.js), and `useLang` follows
+     `router.locale`, so an id-based rule is inert on /en. The
+     `fr-footer__bottom-copy` class is emitted for every locale and wraps this
+     link alone.
+
+     On specificity: `[href]` counts at class level, so the bare selector
+     `.fr-footer__bottom-copy a[href]` is (0,2,1) and merely ties with
+     `_dsfr-fix.scss`, leaving source order to decide. What actually wins is the
+     module's root class. CSS Modules compiles this rule to
+     `.FooterDSFR_footer__<hash> .fr-footer__bottom-copy a[href]`, i.e. (0,3,1),
+     which beats (0,2,1) whatever the order. Keep the rule nested inside
+     `.footer`; hoisting it out would reintroduce the tie.
+     `:global()` is required because CSS Modules scopes these selectors. */
+  :global(.fr-footer__bottom-copy) a[href] {
+    text-decoration: underline;
+  }
+
   @media print {
     display: none;
   }

--- a/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
+++ b/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
@@ -86,7 +86,10 @@ const Footer = () => {
         // reprend l'intitulé et signale la nouvelle fenêtre, comme les autres liens du Footer DSFR.
         homeLinkProps={{
           href: "https://accueil-integration-refugies.fr/",
-          title: "Délégation interministérielle à l’accueil et à l’intégration des réfugiés - ouvre une nouvelle fenêtre",
+          title: `${t(
+            "Footer.diair_full_name",
+            "Délégation interministérielle à l’accueil et à l’intégration des réfugiés",
+          )} - ${t("Footer.open_new_window", "ouvre une nouvelle fenêtre")}`,
         }}
         bottomItems={[
           <Link

--- a/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
+++ b/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
@@ -72,7 +72,10 @@ const Footer = () => {
         id="fr-footer"
         className={cn(styles.footer)}
         operatorLogo={{
-          alt: "Délégation interministérielle à l’accueil et à l’intégration des réfugiés",
+          alt: t(
+            "Footer.diair_full_name",
+            "Délégation interministérielle à l’accueil et à l’intégration des réfugiés",
+          ),
           imgUrl: "/images/Logo-DIAIR.png",
           orientation: "horizontal",
         }}
@@ -81,7 +84,8 @@ const Footer = () => {
           "Réfugiés.info est un portail d’information collaboratif visant à donner de l’information simple et traduite aux personnes réfugiées en France.",
         )}
         // Le lien du bloc marque pointe vers le site de la DIAIR (décision du 26/08, audit RGAA 6.1) :
-        // l'alt du logo, seul contenu du lien, en est le nom accessible et reflète la destination.
+        // l'alt du logo, seul contenu du lien, en est le nom accessible et reflète la destination
+        // (même clé Footer.diair_full_name que la première partie du title).
         // Le target est explicite ; l'URL étant absolue, le Link enregistré par react-dsfr rend de
         // toute façon ce lien en target="_blank" avec rel="noreferrer". Le title reprend l'intitulé
         // et signale la nouvelle fenêtre, comme les autres liens du Footer DSFR.

--- a/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
+++ b/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
@@ -72,7 +72,7 @@ const Footer = () => {
         id="fr-footer"
         className={cn(styles.footer)}
         operatorLogo={{
-          alt: "Logo DIAIR",
+          alt: "Délégation interministérielle à l’accueil et à l’intégration des réfugiés",
           imgUrl: "/images/Logo-DIAIR.png",
           orientation: "horizontal",
         }}
@@ -80,9 +80,13 @@ const Footer = () => {
           "Footer.info",
           "Réfugiés.info est un portail d’information collaboratif visant à donner de l’information simple et traduite aux personnes réfugiées en France.",
         )}
+        // Le lien du bloc marque pointe vers le site de la DIAIR (décision du 26/08, audit RGAA 6.1) :
+        // l'alt du logo, seul contenu du lien, en est le nom accessible et reflète la destination.
+        // L'URL étant absolue, le Link enregistré par react-dsfr impose target="_blank" ; le title
+        // reprend l'intitulé et signale la nouvelle fenêtre, comme les autres liens du Footer DSFR.
         homeLinkProps={{
-          href: "/",
-          title: "Accueil - Réfugiés.info",
+          href: "https://accueil-integration-refugies.fr/",
+          title: "Délégation interministérielle à l’accueil et à l’intégration des réfugiés - ouvre une nouvelle fenêtre",
         }}
         bottomItems={[
           <Link

--- a/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
+++ b/apps/client/src/components/Layout/Footer/FooterDSFR.tsx
@@ -82,10 +82,12 @@ const Footer = () => {
         )}
         // Le lien du bloc marque pointe vers le site de la DIAIR (décision du 26/08, audit RGAA 6.1) :
         // l'alt du logo, seul contenu du lien, en est le nom accessible et reflète la destination.
-        // L'URL étant absolue, le Link enregistré par react-dsfr impose target="_blank" ; le title
-        // reprend l'intitulé et signale la nouvelle fenêtre, comme les autres liens du Footer DSFR.
+        // Le target est explicite ; l'URL étant absolue, le Link enregistré par react-dsfr rend de
+        // toute façon ce lien en target="_blank" avec rel="noreferrer". Le title reprend l'intitulé
+        // et signale la nouvelle fenêtre, comme les autres liens du Footer DSFR.
         homeLinkProps={{
           href: "https://accueil-integration-refugies.fr/",
+          target: "_blank",
           title: `${t(
             "Footer.diair_full_name",
             "Délégation interministérielle à l’accueil et à l’intégration des réfugiés",

--- a/apps/client/src/components/Navigation/AuthNavbar/AuthNavbar.tsx
+++ b/apps/client/src/components/Navigation/AuthNavbar/AuthNavbar.tsx
@@ -11,8 +11,8 @@ const AuthNavbar = () => {
         </>
       }
       homeLinkProps={{
-        href: "#",
-        title: "Se connecter - Réfugiés.info",
+        href: "/",
+        title: "Accueil - Réfugiés.info",
       }}
       operatorLogo={{
         alt: "Réfugiés.info",


### PR DESCRIPTION
Audit RGAA Ideance, ticket RGA-2. Trois corrections, toutes petites.

**1. Le lien « licence etalab-2.0 » en bas de page est maintenant souligné.** Avant, il avait exactement la couleur du texte autour : rien ne montrait que c'était un lien. C'est le seul changement visible de la PR.

**2. Sur les écrans de connexion et d'inscription, le bloc Marianne en haut mène maintenant à l'accueil.** Avant, c'était un faux lien : un clic ne faisait rien.

**3. Le logo DIAIR du bas de page pointe maintenant vers le site de la DIAIR.** Avant, il s'annonçait « Logo DIAIR » aux lecteurs d'écran mais menait à l'accueil du site : contradiction relevée par l'audit. Julie a tranché dans le ticket (commentaire du 10/08) : le lien va vers accueil-integration-refugies.fr.

Suite à la revue : le nom de la DIAIR et la mention « ouvre une nouvelle fenêtre » passent par deux clés de traduction (`Footer.diair_full_name`, `Footer.open_new_window`), repli français en attendant la traduction. Deux clés à verser à votre flux de traduction. Le `target="_blank"` est maintenant explicite.

Tout est vert : types, tests, instantanés inchangés. Vérifié en français et en anglais, y compris le nom annoncé par les lecteurs d'écran.

La PR vise la branche rga-3 en attendant la fusion de #3867, elle sera rebasée sur dev ensuite.