### PR TITLE
fix(a11y): les navigations du corps de page deviennent des liens (RGAA 7.1)

### DIFF
--- a/apps/client/src/components/Modals/DownloadAppModal/DownloadAppModal.tsx
+++ b/apps/client/src/components/Modals/DownloadAppModal/DownloadAppModal.tsx
@@ -1,7 +1,6 @@
 import Button from "@codegouvfr/react-dsfr/Button";
 import { androidStoreLink, iosStoreLink } from "data/storeLinks";
 import { useTranslation } from "next-i18next";
-import { useCallback } from "react";
 import { isIOS } from "react-device-detect";
 import { Modal } from "reactstrap";
 import RatingStars from "~/assets/auth/rating-stars.svg";
@@ -19,7 +18,6 @@ const STORE_LINK = isIOS ? iosStoreLink : androidStoreLink;
 
 const DownloadAppModal = ({ show, toggle }: Props) => {
   const { t } = useTranslation();
-  const goToStore = useCallback(() => window.open(STORE_LINK), []);
 
   return (
     <Modal isOpen={show} toggle={toggle} className={styles.modal} contentClassName={styles.content}>
@@ -50,7 +48,11 @@ const DownloadAppModal = ({ show, toggle }: Props) => {
           className="mb-2"
           iconId="fr-icon-download-line"
           iconPosition="right"
-          onClick={goToStore}
+          linkProps={{
+            href: STORE_LINK,
+            target: "_blank",
+            rel: "noopener noreferrer",
+          }}
         >
           {t("MobileAppModal.download")}
         </Button>

--- a/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
@@ -20,14 +20,22 @@ const FreeResources = () => {
           </p>
           <div className="flex flex-col gap-4">
             <Button
-              onClick={() => window.open("https://kit.refugies.info/formation/", "_blank")}
+              linkProps={{
+                href: "https://kit.refugies.info/formation/",
+                target: "_blank",
+                rel: "noopener noreferrer",
+              }}
               iconId="fr-icon-arrow-right-line"
               iconPosition="right"
             >
               {t("Homepage.webinaireCTA", "Participer à un webinaire")}
             </Button>
             <Button
-              onClick={() => window.open("https://kit.refugies.info/", "_blank")}
+              linkProps={{
+                href: "https://kit.refugies.info/",
+                target: "_blank",
+                rel: "noopener noreferrer",
+              }}
               iconId="fr-icon-arrow-right-line"
               iconPosition="right"
               priority="tertiary"

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.module.scss
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.module.scss
@@ -1,0 +1,9 @@
+// DSFR displays an external link icon (::after pseudo-element) on any
+// .fr-btn with target="_blank". _dsfr-fix.scss removes this indicator
+// everywhere except on .fr-link and .fr-btn, so the store download links
+// below would show it. Neutralize it locally to keep these links icon-free,
+// as they were before becoming real links (RGAA 7.1).
+// This rule is unlayered so it wins over the DSFR bundle (@layer dsfr).
+.storeLink[target="_blank"]::after {
+  content: none;
+}

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -55,10 +55,6 @@ const MobileApp = () => {
     [appStoreBadge, playStoreBadge, t],
   );
 
-  const handleOpenStoreLink = (storelink: string) => {
-    window.open(storelink, "_blank");
-  };
-
   return (
     <section
       id="application"
@@ -139,7 +135,11 @@ const MobileApp = () => {
               iconId={"ri-app-store-fill"}
               iconPosition="right"
               className={cn("justify-center max-md:w-full", isAndroid && "hidden")}
-              onClick={() => handleOpenStoreLink(iosStoreLink)}
+              linkProps={{
+                href: iosStoreLink,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              }}
             >
               {t("MobileApp.downloadButtonText", "Télécharger l’application")}
             </Button>
@@ -147,7 +147,11 @@ const MobileApp = () => {
               iconId={"ri-android-fill"}
               iconPosition="right"
               className={cn("justify-center max-md:w-full", isIOS && "hidden")}
-              onClick={() => handleOpenStoreLink(androidStoreLink)}
+              linkProps={{
+                href: androidStoreLink,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              }}
             >
               {t("MobileApp.downloadButtonText", "Télécharger l’application")}
             </Button>

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -9,6 +9,7 @@ import application from "~/assets/homepage/application.png";
 import Image from "~/components/UI/Image";
 import { useLocale } from "~/hooks";
 import { cn } from "~/lib/classname";
+import styles from "./MobileApp.module.scss";
 import MobileAppSmsForm from "./MobileAppSmsForm";
 
 const MobileApp = () => {
@@ -134,7 +135,11 @@ const MobileApp = () => {
             <Button
               iconId={"ri-app-store-fill"}
               iconPosition="right"
-              className={cn("justify-center max-md:w-full", isAndroid && "hidden")}
+              className={cn(
+                "justify-center max-md:w-full",
+                styles.storeLink,
+                isAndroid && "hidden",
+              )}
               linkProps={{
                 href: iosStoreLink,
                 target: "_blank",
@@ -147,7 +152,7 @@ const MobileApp = () => {
             <Button
               iconId={"ri-android-fill"}
               iconPosition="right"
-              className={cn("justify-center max-md:w-full", isIOS && "hidden")}
+              className={cn("justify-center max-md:w-full", styles.storeLink, isIOS && "hidden")}
               linkProps={{
                 href: androidStoreLink,
                 target: "_blank",

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -139,6 +139,7 @@ const MobileApp = () => {
                 href: iosStoreLink,
                 target: "_blank",
                 rel: "noopener noreferrer",
+                "aria-label": `${t("MobileApp.downloadButtonText", "Télécharger l’application")} App Store`,
               }}
             >
               {t("MobileApp.downloadButtonText", "Télécharger l’application")}
@@ -151,6 +152,7 @@ const MobileApp = () => {
                 href: androidStoreLink,
                 target: "_blank",
                 rel: "noopener noreferrer",
+                "aria-label": `${t("MobileApp.downloadButtonText", "Télécharger l’application")} Google Play`,
               }}
             >
               {t("MobileApp.downloadButtonText", "Télécharger l’application")}


### PR DESCRIPTION
Audit RGAA Ideance, ticket RGA-10.

**1. Quatre commandes de la page d'accueil deviennent de vrais liens** (« Participer à un webinaire », « Voir les outils », « Télécharger l'application », lien de la modale d'application). Elles étaient codées comme des boutons alors qu'elles naviguent.

**2. Les liens App Store et Google Play sont maintenant distinguables.** Ils portaient le même texte, chacun annonce désormais sa boutique.

**3. Aucun changement visuel.** L'icône « lien externe » que le DSFR ajoutait sur les deux liens de boutique est neutralisée, apparence identique à avant.

À savoir : le nom des liens réutilise une phrase déjà traduite dans les 8 langues, suivie du nom de la boutique. Dans 4 langues la tournure est à la première personne (« Je télécharge l'application App Store ») : dis-nous si tu préfères deux textes dédiés à faire passer en traduction.

Types, lint et tests verts, aucun instantané modifié. Vérifié en navigateur en français, arabe et ukrainien.

Construite au-dessus de rga-9 et rga-5, toutes deux mergées : la branche est rebasée sur dev à jour.
