### PR TITLE
fix(a11y): émojis décoratifs restitués par les lecteurs d'écran (RGAA 13.5)

### DIFF
--- a/apps/client/public/locales/ar/common.json
+++ b/apps/client/public/locales/ar/common.json
@@ -575,7 +575,7 @@
     "northStar_no": "لا",
     "northStar_yes": "نعم",
     "northStar_notUseful": "غير مفيدة",
-    "northStar_useful": "هل ذلك مفيد ؟ ✨",
+    "northStar_useful": "هل ذلك مفيد ؟",
     "northStar_thanks": "شكراً لك لرأيك"
   }
 }

--- a/apps/client/public/locales/en/common.json
+++ b/apps/client/public/locales/en/common.json
@@ -582,7 +582,7 @@
     "northStar_no": "No",
     "northStar_yes": "Yes",
     "northStar_notUseful": "Not useful",
-    "northStar_useful": "Is it useful? ✨",
+    "northStar_useful": "Is it useful?",
     "northStar_thanks": "Thank you for your feedback"
   }
 }

--- a/apps/client/public/locales/fa/common.json
+++ b/apps/client/public/locales/fa/common.json
@@ -576,7 +576,7 @@
     "northStar_no": "خیر",
     "northStar_yes": "بله",
     "northStar_notUseful": "مفید نبود",
-    "northStar_useful": "آیا مفید بود؟ ✨",
+    "northStar_useful": "آیا مفید بود؟",
     "northStar_thanks": "از نظر شما سپاسگزاریم"
   }
 }

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -888,7 +888,7 @@
     "northStar_no": "Non",
     "northStar_yes": "Oui",
     "northStar_notUseful": "Pas utile",
-    "northStar_useful": "C'est utile ? ✨",
+    "northStar_useful": "C'est utile ?",
     "northStar_thanks": "Merci pour votre retour",
     "northStar_error": "Une erreur est survenue lors de la soumission de votre avis",
     "northStar_vote_cancelled": "Votre vote a été retiré"

--- a/apps/client/public/locales/ru/common.json
+++ b/apps/client/public/locales/ru/common.json
@@ -576,7 +576,7 @@
     "northStar_no": "Нет",
     "northStar_yes": "Да",
     "northStar_notUseful": "Бесполезна",
-    "northStar_useful": "Это полезно? ✨",
+    "northStar_useful": "Это полезно?",
     "northStar_thanks": "Спасибо за ваш отзыв"
   }
 }

--- a/apps/client/public/locales/ti/common.json
+++ b/apps/client/public/locales/ti/common.json
@@ -576,7 +576,7 @@
     "northStar_no": "ኣይፋሉን",
     "northStar_yes": "እወ",
     "northStar_notUseful": "ጠቓሚ ኣይኮነን",
-    "northStar_useful": "ጠቓሚ ድዩ  ? ✨",
+    "northStar_useful": "ጠቓሚ ድዩ  ?",
     "northStar_thanks": "ንርእይቶኹም ኣዚና ነመስግን"
   }
 }

--- a/apps/client/public/locales/uk/common.json
+++ b/apps/client/public/locales/uk/common.json
@@ -576,7 +576,7 @@
     "northStar_no": "Ні",
     "northStar_yes": "Так",
     "northStar_notUseful": "Не корисна",
-    "northStar_useful": "Чи це для вас корисно? ✨",
+    "northStar_useful": "Чи це для вас корисно?",
     "northStar_thanks": "Дякуємо за ваш відгук"
   }
 }

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -958,7 +958,12 @@ exports[`publier renders publier 1`] = `
               <div
                 class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2"
               >
-                Votre fiche est publiée ! 🎉
+                Votre fiche est publiée ! 
+                <span
+                  aria-hidden="true"
+                >
+                  🎉
+                </span>
               </div>
             </div>
             <div

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -605,7 +605,12 @@ exports[`traduire renders traduire 1`] = `
               <div
                 class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2 !bottom-0"
               >
-                La traduction est publiée 🎉
+                La traduction est publiée 
+                <span
+                  aria-hidden="true"
+                >
+                  🎉
+                </span>
               </div>
             </div>
             <div

--- a/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
@@ -18,7 +18,7 @@ interface Props {
   image?: any;
   dottedLine?: boolean;
   width?: number;
-  buttonStep?: string;
+  buttonStep?: React.ReactNode;
   buttonStepEnd?: boolean;
   badge?: string;
 }

--- a/apps/client/src/pages/publier.tsx
+++ b/apps/client/src/pages/publier.tsx
@@ -310,7 +310,11 @@ const RecensezVotreAction = (props: Props) => {
                 "Vous êtes informé par email lorsque la fiche est visible par les utilisateurs.",
               ]}
               image={StepImage4}
-              buttonStep="Votre fiche est publiée ! 🎉"
+              buttonStep={
+                <>
+                  Votre fiche est publiée ! <span aria-hidden="true">🎉</span>
+                </>
+              }
               width={440}
             />
             <StepContent

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -221,7 +221,11 @@ const RecensezVotreAction = (props: Props) => {
               ]}
               image={StepImage4}
               width={440}
-              buttonStep="La traduction est publiée 🎉"
+              buttonStep={
+                <>
+                  La traduction est publiée <span aria-hidden="true">🎉</span>
+                </>
+              }
               buttonStepEnd
             />
           </div>

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -89,7 +89,7 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
           )}
           aria-hidden="true"
         >
-          {t("ui.northStar_thanks", "Merci pour votre retour")} ☺️
+          {t("ui.northStar_thanks", "Merci pour votre retour")} <span aria-hidden="true">☺️</span>
         </p>
       </div>
     );

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -67,8 +67,9 @@ const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
                 themeId="light"
               />
             </div>
-
-            {t("ui.northStar_useful", "C'est utile ? ✨")}
+            <span>
+              {t("ui.northStar_useful", "C'est utile ?")} <span aria-hidden="true">✨</span>
+            </span>
           </Button>
           <hr className="h-[1rem] w-px bg-gray-300" />
           <Button


### PR DESCRIPTION
Audit RGAA Ideance, RGA-17. Les émojis décoratifs (✨, ☺️, 🎉) ne sont plus lus par les lecteurs d'écran sur le bouton d'avis, le message de remerciement et les pastilles des pages publier et traduire ; à l'écran rien ne change. Le ✨ a juste été retiré de la valeur de `ui.northStar_useful` dans les 7 langues qui le portaient.
