### PR TITLE
fix(a11y): listes et citations dans les corps de page (RGAA 9.3, 9.4)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -347,6 +347,7 @@
     "frenchLevel": "Niveau de français",
     "age": "Âge",
     "public": "Public spécifique",
+    "not_relevant": "Non pertinent pour mon action",
     "alpha": "Alphabétisation",
     "asile": "Demandeurs d'asile",
     "refugie": "Réfugiés statutaires",

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -256,6 +256,7 @@ exports[`publier renders publier 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«r7»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -297,6 +298,7 @@ exports[`publier renders publier 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«r9»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -338,6 +340,7 @@ exports[`publier renders publier 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«rb»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -1338,6 +1341,7 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
+                        aria-controls="radix-«rg»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1379,6 +1383,7 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
+                        aria-controls="radix-«ri»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1420,6 +1425,7 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
+                        aria-controls="radix-«rk»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1461,6 +1467,7 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
+                        aria-controls="radix-«rm»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1502,6 +1509,7 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
+                        aria-controls="radix-«ro»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -256,7 +256,6 @@ exports[`publier renders publier 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«r7»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -298,7 +297,6 @@ exports[`publier renders publier 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«r9»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -340,7 +338,6 @@ exports[`publier renders publier 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«rb»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -1341,7 +1338,6 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
-                        aria-controls="radix-«rg»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1383,7 +1379,6 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
-                        aria-controls="radix-«ri»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1425,7 +1420,6 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
-                        aria-controls="radix-«rk»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1467,7 +1461,6 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
-                        aria-controls="radix-«rm»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"
@@ -1509,7 +1502,6 @@ exports[`publier renders publier 1`] = `
                       data-state="closed"
                     >
                       <button
-                        aria-controls="radix-«ro»"
                         aria-expanded="false"
                         class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                         data-orientation="vertical"

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -417,11 +417,15 @@ exports[`publier renders publier 1`] = `
                 style="color: transparent;"
                 width="40"
               />
-              <p
-                class="!text-large !mb-6"
+              <blockquote
+                class="m-0"
               >
-                « J’ai eu le plaisir de découvrir Réfugiés.info en 2021 et d’en constater toute l’étendue et l’utilité pour les personnes que nous accompagnons dans le cadre de notre dispositif sur le département de Loire-Atlantique. Le résultat final est impressionnant ! »
-              </p>
+                <p
+                  class="!text-large !mb-6"
+                >
+                  « J’ai eu le plaisir de découvrir Réfugiés.info en 2021 et d’en constater toute l’étendue et l’utilité pour les personnes que nous accompagnons dans le cadre de notre dispositif sur le département de Loire-Atlantique. Le résultat final est impressionnant ! »
+                </p>
+              </blockquote>
               <div>
                 <div
                   class="mb-2 font-bold"
@@ -447,11 +451,15 @@ exports[`publier renders publier 1`] = `
                 style="color: transparent;"
                 width="40"
               />
-              <p
-                class="!text-large !mb-6"
+              <blockquote
+                class="m-0"
               >
-                « Réfugiés.info est un très bon site ressource, très complet, qui balaye de nombreuses thématiques, facile d’accès et intuitif. Un bon complément à mes connaissances actuelles. Les acteurs sont bien accompagnés dans la construction de fiches. »
-              </p>
+                <p
+                  class="!text-large !mb-6"
+                >
+                  « Réfugiés.info est un très bon site ressource, très complet, qui balaye de nombreuses thématiques, facile d’accès et intuitif. Un bon complément à mes connaissances actuelles. Les acteurs sont bien accompagnés dans la construction de fiches. »
+                </p>
+              </blockquote>
               <div>
                 <div
                   class="mb-2 font-bold"
@@ -477,11 +485,15 @@ exports[`publier renders publier 1`] = `
                 style="color: transparent;"
                 width="40"
               />
-              <p
-                class="!text-large !mb-6"
+              <blockquote
+                class="m-0"
               >
-                « UniR partage toutes ses actions sur la plateforme Réfugiés.info. C'est très intuitif à utiliser et ça permet de mettre en avant les informations clés sur chaque programme. À chaque nouvelle session, nous mettons à jour seulement les cases concernées et cela maintient nos informations accessibles à toutes et tous ! »
-              </p>
+                <p
+                  class="!text-large !mb-6"
+                >
+                  « UniR partage toutes ses actions sur la plateforme Réfugiés.info. C'est très intuitif à utiliser et ça permet de mettre en avant les informations clés sur chaque programme. À chaque nouvelle session, nous mettons à jour seulement les cases concernées et cela maintient nos informations accessibles à toutes et tous ! »
+                </p>
+              </blockquote>
               <div>
                 <div
                   class="mb-2 font-bold"

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -427,14 +427,16 @@ exports[`publier renders publier 1`] = `
                 </p>
               </blockquote>
               <div>
-                <div
+                <p
                   class="mb-2 font-bold"
                 >
                   Vincent Le Lann
-                </div>
-                <div>
+                </p>
+                <p
+                  class="mb-0"
+                >
                   Compagnons du Tour de France à Nantes
-                </div>
+                </p>
               </div>
             </div>
             <div
@@ -461,14 +463,16 @@ exports[`publier renders publier 1`] = `
                 </p>
               </blockquote>
               <div>
-                <div
+                <p
                   class="mb-2 font-bold"
                 >
                   Rémi Crouzel
-                </div>
-                <div>
+                </p>
+                <p
+                  class="mb-0"
+                >
                   Mission Locale de Dijon & Conseiller IPeRACTIFS21
-                </div>
+                </p>
               </div>
             </div>
             <div
@@ -495,14 +499,16 @@ exports[`publier renders publier 1`] = `
                 </p>
               </blockquote>
               <div>
-                <div
+                <p
                   class="mb-2 font-bold"
                 >
                   Paola Salazar
-                </div>
-                <div>
+                </p>
+                <p
+                  class="mb-0"
+                >
                   Directrice adjointe UniR
-                </div>
+                </p>
               </div>
             </div>
           </div>

--- a/apps/client/src/__tests__/__snapshots__/recherche.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/recherche.test.tsx.snap
@@ -317,30 +317,47 @@ exports[`recherche renders search results 1`] = `
           <div
             class="grid"
           >
-            <div
+            <ul
               class="tabsbar"
+              role="list"
             >
-              <button
-                class="tabitem active"
+              <li
+                class="tabitemwrapper"
               >
-                Filters.typeAll 
-              </button>
-              <button
-                class="tabitem"
+                <button
+                  class="tabitem active"
+                >
+                  Filters.typeAll 
+                </button>
+              </li>
+              <li
+                class="tabitemwrapper"
               >
-                Filters.typeDemarche 
-              </button>
-              <button
-                class="tabitem"
+                <button
+                  class="tabitem"
+                >
+                  Filters.typeDemarche 
+                </button>
+              </li>
+              <li
+                class="tabitemwrapper"
               >
-                Filters.typeDispositif 
-              </button>
-              <button
-                class="tabitem"
+                <button
+                  class="tabitem"
+                >
+                  Filters.typeDispositif 
+                </button>
+              </li>
+              <li
+                class="tabitemwrapper"
               >
-                Filters.typeRessource 
-              </button>
-            </div>
+                <button
+                  class="tabitem"
+                >
+                  Filters.typeRessource 
+                </button>
+              </li>
+            </ul>
             <button
               aria-expanded="false"
               aria-haspopup="true"

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -315,44 +315,53 @@ exports[`traduire renders traduire 1`] = `
           >
             On cherche des traducteurs en :
           </h2>
-          <div
-            class="flex flex-wrap gap-6 md:justify-center"
+          <ul
+            class="m-0 flex list-none flex-wrap gap-6 p-0 md:justify-center"
+            role="list"
           >
-            <a
-              class="border-default-grey hover:hover-tint inline-flex items-center gap-2 border bg-white p-3 md:p-4"
-              href="/undefined#register"
+            <li
+              class="p-0"
             >
-              <span
-                class="text-h6 md:text-h5 font-bold"
-              />
-              <p
-                class="fr-badge fr-badge--warning fr-badge--no-icon"
-                id="fr-badge-«r4»"
+              <a
+                class="border-default-grey hover:hover-tint inline-flex items-center gap-2 border bg-white p-3 md:p-4"
+                href="/undefined#register"
               >
-                Besoin fort
-              </p>
-            </a>
-            <a
-              class="border-default-grey hover:hover-tint inline-flex items-center gap-2 border bg-white p-3 md:p-4"
-              href="/undefined#register"
+                <span
+                  class="text-h6 md:text-h5 font-bold"
+                />
+                <p
+                  class="fr-badge fr-badge--warning fr-badge--no-icon"
+                  id="fr-badge-«r4»"
+                >
+                  Besoin fort
+                </p>
+              </a>
+            </li>
+            <li
+              class="p-0"
             >
-              <span
-                class="flag fi fi-en"
-                title="en"
-              />
-              <span
-                class="text-h6 md:text-h5 font-bold"
+              <a
+                class="border-default-grey hover:hover-tint inline-flex items-center gap-2 border bg-white p-3 md:p-4"
+                href="/undefined#register"
               >
-                Anglais
-              </span>
-              <p
-                class="fr-badge fr-badge--new fr-badge--no-icon"
-                id="fr-badge-«r5»"
-              >
-                Besoin moyen
-              </p>
-            </a>
-          </div>
+                <span
+                  class="flag fi fi-en"
+                  title="en"
+                />
+                <span
+                  class="text-h6 md:text-h5 font-bold"
+                >
+                  Anglais
+                </span>
+                <p
+                  class="fr-badge fr-badge--new fr-badge--no-icon"
+                  id="fr-badge-«r5»"
+                >
+                  Besoin moyen
+                </p>
+              </a>
+            </li>
+          </ul>
         </div>
       </div>
     </div>
@@ -801,6 +810,7 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«r8»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -842,6 +852,7 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«ra»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -883,6 +894,7 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«rc»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -924,6 +936,7 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«re»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -965,6 +978,7 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
+                      aria-controls="radix-«rg»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -810,7 +810,6 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«r8»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -852,7 +851,6 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«ra»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -894,7 +892,6 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«rc»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -936,7 +933,6 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«re»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"
@@ -978,7 +974,6 @@ exports[`traduire renders traduire 1`] = `
                     data-state="closed"
                   >
                     <button
-                      aria-controls="radix-«rg»"
                       aria-expanded="false"
                       class="border-default-grey flex w-full items-center gap-4 border-t px-4 py-3"
                       data-orientation="vertical"

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardConditions/CardConditions.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardConditions/CardConditions.tsx
@@ -53,7 +53,9 @@ const CardConditions = ({ formData, ...props }: Props) => {
       title={t("Infocards.conditions")}
       onClick={() => setActiveModal?.("Conditions")}
     >
-      {conditions === null ? "Non pertinent pour mon action" : undefined}
+      {conditions === null
+        ? t("Infocards.not_relevant", "Non pertinent pour mon action")
+        : undefined}
     </MetaDataCard>
   ) : null;
 };

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
@@ -144,7 +144,9 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
                   >
                     {hasDepartments
                       ? (location as string[]).map((loc: string) => (
-                          <li key={loc} className="inline sm:flex">
+                          // role="listitem" : le li passe en inline ou en flex pour garder le
+                          // rendu d'origine, ce qui lui retire son rôle natif.
+                          <li key={loc} className="inline sm:flex" role="listitem">
                             <FRLink
                               href={isEditMode ? "#" : getLocationLink(loc)}
                               onClick={() => Event("DISPO_VIEW", "click location", "Left sidebar")}

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
@@ -51,7 +51,7 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
               onClick={isEditMode ? () => setActiveModal?.("Price") : undefined}
             >
               {price === null
-                ? "Non pertinent pour mon action"
+                ? t("Infocards.not_relevant", "Non pertinent pour mon action")
                 : price
                   ? getPrice(price, t)
                   : undefined}
@@ -73,7 +73,7 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
               }
             >
               {commitment === null
-                ? "Non pertinent pour mon action"
+                ? t("Infocards.not_relevant", "Non pertinent pour mon action")
                 : commitment
                   ? getCommitment(commitment, t)
                   : undefined}
@@ -95,7 +95,7 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
               }
             >
               {frequency === null
-                ? "Non pertinent pour mon action"
+                ? t("Infocards.not_relevant", "Non pertinent pour mon action")
                 : frequency
                   ? getFrequency(frequency, t)
                   : undefined}
@@ -117,7 +117,7 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
               }
             >
               {timeSlots === null
-                ? "Non pertinent pour mon action"
+                ? t("Infocards.not_relevant", "Non pertinent pour mon action")
                 : timeSlots
                   ? getTimeSlots(timeSlots, t)
                   : undefined}

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
@@ -129,22 +129,29 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
                 let title = t("Infocards.departements", "Departements :");
                 if (location === "france") title = t("Infocards.france", "France");
                 else if (location === "online") title = t("Recherche.online", "En ligne");
+                // La liste des départements est une énumération : elle se structure en ul/li
+                // (RGAA 9.3). contentAs="ul" est nécessaire parce qu'un ul ne peut pas vivre
+                // dans le p que MetaDataItem pose par défaut. Le li est en display:inline
+                // pour ne pas changer le flux, que le conteneur soit en flex ou en inline.
+                const hasDepartments = Array.isArray(location) && location.length > 0;
                 return (
                   <MetaDataItem
                     icon={location === "online" ? "ri-at-line" : "fr-icon-france-line"}
                     title={title}
                     state={formSubmitted && location === undefined ? "invalid" : undefined}
                     onClick={isEditMode ? () => setActiveModal?.("Location") : undefined}
+                    contentAs={hasDepartments ? "ul" : "p"}
                   >
-                    {Array.isArray(location)
-                      ? location.map((loc: string) => (
-                          <FRLink
-                            key={loc}
-                            href={isEditMode ? "#" : getLocationLink(loc)}
-                            onClick={() => Event("DISPO_VIEW", "click location", "Left sidebar")}
-                          >
-                            {formatDepartment(loc)}
-                          </FRLink>
+                    {hasDepartments
+                      ? (location as string[]).map((loc: string) => (
+                          <li key={loc} className="inline sm:flex">
+                            <FRLink
+                              href={isEditMode ? "#" : getLocationLink(loc)}
+                              onClick={() => Event("DISPO_VIEW", "click location", "Left sidebar")}
+                            >
+                              {formatDepartment(loc)}
+                            </FRLink>
+                          </li>
                         ))
                       : null}
                   </MetaDataItem>

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
@@ -129,7 +129,7 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
                 let title = t("Infocards.departements", "Departements :");
                 if (location === "france") title = t("Infocards.france", "France");
                 else if (location === "online") title = t("Recherche.online", "En ligne");
-                // Énumération de départements : ul/li (RGAA 9.3), d'où contentAs="ul".
+                // Department enumeration: ul/li (RGAA 9.3), hence contentAs="ul".
                 const hasDepartments = Array.isArray(location) && location.length > 0;
                 return (
                   <MetaDataItem

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardInfo/CardInfo.tsx
@@ -129,10 +129,7 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
                 let title = t("Infocards.departements", "Departements :");
                 if (location === "france") title = t("Infocards.france", "France");
                 else if (location === "online") title = t("Recherche.online", "En ligne");
-                // La liste des départements est une énumération : elle se structure en ul/li
-                // (RGAA 9.3). contentAs="ul" est nécessaire parce qu'un ul ne peut pas vivre
-                // dans le p que MetaDataItem pose par défaut. Le li est en display:inline
-                // pour ne pas changer le flux, que le conteneur soit en flex ou en inline.
+                // Énumération de départements : ul/li (RGAA 9.3), d'où contentAs="ul".
                 const hasDepartments = Array.isArray(location) && location.length > 0;
                 return (
                   <MetaDataItem
@@ -144,8 +141,6 @@ const CardInfo = ({ onClick, formData, className, ...props }: CardInfoProps) => 
                   >
                     {hasDepartments
                       ? (location as string[]).map((loc: string) => (
-                          // role="listitem" : le li passe en inline ou en flex pour garder le
-                          // rendu d'origine, ce qui lui retire son rôle natif.
                           <li key={loc} className="inline sm:flex" role="listitem">
                             <FRLink
                               href={isEditMode ? "#" : getLocationLink(loc)}

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
@@ -13,9 +13,27 @@ import {
   getFrenchLevel,
   getFrenchLevelLink,
   getPublic,
+  getPublicItems,
   getPublicStatus,
+  getPublicStatusItems,
 } from "../functions";
 import styles from "./CardPublic.module.scss";
+
+/**
+ * Rend une énumération de publics en ul/li (RGAA 9.3) sans changer le rendu : les li restent
+ * en flux inline et les virgules d'origine sont conservées, masquées aux technologies
+ * d'assistance puisque la structure de liste porte déjà la séparation.
+ */
+const PublicList = ({ items }: { items: string[] }) => (
+  <>
+    {items.map((label, index) => (
+      <li key={label} className="inline">
+        {label}
+        {index < items.length - 1 && <span aria-hidden="true">, </span>}
+      </li>
+    ))}
+  </>
+);
 
 type Props = HTMLAttributes<HTMLDivElement> & {
   onClick?: () => void;
@@ -36,6 +54,9 @@ const CardPublic = ({ formData, ...props }: Props) => {
   const publicAge = dispositif?.metadatas?.age;
   const publicFrenchLevel = dispositif?.metadatas?.frenchLevel;
   const { setActiveModal, setModalPage, formSubmitted } = useContext(PageContext);
+
+  const publicStatusItems = getPublicStatusItems(publicStatus, t);
+  const publicSpecificItems = getPublicItems(publicSpecific, t);
 
   // Toggle visibility, if edit mode true, else check if there is any data
   const showCard = isEditMode
@@ -64,8 +85,14 @@ const CardPublic = ({ formData, ...props }: Props) => {
                     }
                   : undefined
               }
+              contentAs={publicStatusItems ? "ul" : "p"}
+              contentClassName={publicStatusItems ? "!inline" : undefined}
             >
-              {publicStatus ? getPublicStatus(publicStatus, t) : undefined}
+              {publicStatusItems ? (
+                <PublicList items={publicStatusItems} />
+              ) : publicStatus ? (
+                getPublicStatus(publicStatus, t)
+              ) : undefined}
             </MetaDataItem>
           ) : null}
 
@@ -82,10 +109,16 @@ const CardPublic = ({ formData, ...props }: Props) => {
                     }
                   : undefined
               }
+              contentAs={publicSpecificItems ? "ul" : "p"}
+              contentClassName={publicSpecificItems ? "!inline" : undefined}
             >
-              {publicSpecific
-                ? getPublic(publicSpecific, t)
-                : publicSpecific === null && "Non pertinent pour mon action"}
+              {publicSpecificItems ? (
+                <PublicList items={publicSpecificItems} />
+              ) : publicSpecific ? (
+                getPublic(publicSpecific, t)
+              ) : (
+                publicSpecific === null && "Non pertinent pour mon action"
+              )}
             </MetaDataItem>
           ) : null}
 

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
@@ -119,7 +119,8 @@ const CardPublic = ({ formData, ...props }: Props) => {
               ) : publicSpecific ? (
                 getPublic(publicSpecific, t)
               ) : (
-                publicSpecific === null && "Non pertinent pour mon action"
+                publicSpecific === null &&
+                t("Infocards.not_relevant", "Non pertinent pour mon action")
               )}
             </MetaDataItem>
           ) : null}
@@ -139,7 +140,7 @@ const CardPublic = ({ formData, ...props }: Props) => {
               }
             >
               {publicFrenchLevel === null ? (
-                "Non pertinent pour mon action"
+                t("Infocards.not_relevant", "Non pertinent pour mon action")
               ) : publicFrenchLevel ? (
                 !publicFrenchLevel || publicFrenchLevel.length === 0 ? (
                   publicFrenchLevel
@@ -171,7 +172,7 @@ const CardPublic = ({ formData, ...props }: Props) => {
               }
             >
               {publicAge === null ? (
-                "Non pertinent pour mon action"
+                t("Infocards.not_relevant", "Non pertinent pour mon action")
               ) : publicAge ? (
                 <FRLink href={isEditMode ? "#" : getAgeLink(publicAge)}>
                   {getAge(publicAge, t)}

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
@@ -27,7 +27,9 @@ import styles from "./CardPublic.module.scss";
 const PublicList = ({ items }: { items: string[] }) => (
   <>
     {items.map((label, index) => (
-      <li key={label} className="inline">
+      // role="listitem" : le li reste en flux inline pour ne pas changer le rendu, ce qui
+      // lui retire son rôle natif.
+      <li key={label} className="inline" role="listitem">
         {label}
         {index < items.length - 1 && <span aria-hidden="true">, </span>}
       </li>

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
@@ -20,9 +20,9 @@ import {
 import styles from "./CardPublic.module.scss";
 
 /**
- * Énumération de publics en ul/li (RGAA 9.3) sans changer le rendu : les li restent en flux
- * inline et les virgules d'origine sont masquées aux technologies d'assistance, la structure
- * de liste portant déjà la séparation.
+ * Audience enumeration as ul/li (RGAA 9.3) without changing the rendering: the li stay in
+ * inline flow and the original commas are hidden from assistive technologies, since the list
+ * structure already conveys the separation.
  */
 const PublicList = ({ items }: { items: string[] }) => (
   <>

--- a/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/CardPublic/CardPublic.tsx
@@ -20,15 +20,13 @@ import {
 import styles from "./CardPublic.module.scss";
 
 /**
- * Rend une énumération de publics en ul/li (RGAA 9.3) sans changer le rendu : les li restent
- * en flux inline et les virgules d'origine sont conservées, masquées aux technologies
- * d'assistance puisque la structure de liste porte déjà la séparation.
+ * Énumération de publics en ul/li (RGAA 9.3) sans changer le rendu : les li restent en flux
+ * inline et les virgules d'origine sont masquées aux technologies d'assistance, la structure
+ * de liste portant déjà la séparation.
  */
 const PublicList = ({ items }: { items: string[] }) => (
   <>
     {items.map((label, index) => (
-      // role="listitem" : le li reste en flux inline pour ne pas changer le rendu, ce qui
-      // lui retire son rôle natif.
       <li key={label} className="inline" role="listitem">
         {label}
         {index < items.length - 1 && <span aria-hidden="true">, </span>}

--- a/apps/client/src/components/Pages/dispositif/Metadatas/functions.ts
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/functions.ts
@@ -15,9 +15,8 @@ import {
   getCommitmentText,
   getFrenchLevelText,
   getFrequencyText,
+  getInfocardsLabels,
   getPriceText,
-  getPublicList,
-  getPublicStatusList,
   getPublicStatusText,
   getPublicText,
   getTimeSlotsText,
@@ -49,10 +48,10 @@ export const getPublic = (publicType: Metadatas["public"] | null | undefined, t:
 export const getPublicStatusItems = (
   publicStatus: Metadatas["publicStatus"] | null | undefined,
   t: TFunction,
-) => (publicStatus ? getPublicStatusList(publicStatus, t) : null);
+) => getInfocardsLabels(publicStatus, t);
 /** Mêmes libellés que getPublic, en liste, pour la structuration ul/li (RGAA 9.3). */
 export const getPublicItems = (publicType: Metadatas["public"] | null | undefined, t: TFunction) =>
-  publicType ? getPublicList(publicType, t) : null;
+  getInfocardsLabels(publicType, t);
 export const getAge = (age: Metadatas["age"] | null | undefined, t: TFunction) => {
   if (!age) return age; // null or undefined
   return getAgeText(age, t);

--- a/apps/client/src/components/Pages/dispositif/Metadatas/functions.ts
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/functions.ts
@@ -16,6 +16,8 @@ import {
   getFrenchLevelText,
   getFrequencyText,
   getPriceText,
+  getPublicList,
+  getPublicStatusList,
   getPublicStatusText,
   getPublicText,
   getTimeSlotsText,
@@ -43,6 +45,14 @@ export const getPublic = (publicType: Metadatas["public"] | null | undefined, t:
   if (!publicType) return publicType;
   return getPublicText(publicType, t);
 };
+/** Mêmes libellés que getPublicStatus, en liste, pour la structuration ul/li (RGAA 9.3). */
+export const getPublicStatusItems = (
+  publicStatus: Metadatas["publicStatus"] | null | undefined,
+  t: TFunction,
+) => (publicStatus ? getPublicStatusList(publicStatus, t) : null);
+/** Mêmes libellés que getPublic, en liste, pour la structuration ul/li (RGAA 9.3). */
+export const getPublicItems = (publicType: Metadatas["public"] | null | undefined, t: TFunction) =>
+  publicType ? getPublicList(publicType, t) : null;
 export const getAge = (age: Metadatas["age"] | null | undefined, t: TFunction) => {
   if (!age) return age; // null or undefined
   return getAgeText(age, t);

--- a/apps/client/src/components/Pages/dispositif/Metadatas/functions.ts
+++ b/apps/client/src/components/Pages/dispositif/Metadatas/functions.ts
@@ -44,12 +44,12 @@ export const getPublic = (publicType: Metadatas["public"] | null | undefined, t:
   if (!publicType) return publicType;
   return getPublicText(publicType, t);
 };
-/** Mêmes libellés que getPublicStatus, en liste, pour la structuration ul/li (RGAA 9.3). */
+/** Same labels as getPublicStatus, as a list, for the ul/li structure (RGAA 9.3). */
 export const getPublicStatusItems = (
   publicStatus: Metadatas["publicStatus"] | null | undefined,
   t: TFunction,
 ) => getInfocardsLabels(publicStatus, t);
-/** Mêmes libellés que getPublic, en liste, pour la structuration ul/li (RGAA 9.3). */
+/** Same labels as getPublic, as a list, for the ul/li structure (RGAA 9.3). */
 export const getPublicItems = (publicType: Metadatas["public"] | null | undefined, t: TFunction) =>
   getInfocardsLabels(publicType, t);
 export const getAge = (age: Metadatas["age"] | null | undefined, t: TFunction) => {

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
@@ -25,8 +25,8 @@ export const SectionMission = () => {
             />
           </div>
           <div className="flex-1">
-            {/* Levée de fait du 9.4 prescrit ici : la citation a disparu du contenu le 25/06
-                (commit 4efd162f5), voir docs/notes-tickets/rga-13.md. */}
+            {/* De facto lifting of the 9.4 prescribed here: the quote disappeared from the
+                content on 25/06 (commit 4efd162f5), see docs/notes-tickets/rga-13.md. */}
             <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
             <p className="!text-large">{t("MissionImpact.mission_p2")}</p>
             <p className="!text-large !mb-0">{t("MissionImpact.mission_p3")}</p>

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
@@ -25,13 +25,11 @@ export const SectionMission = () => {
             />
           </div>
           <div className="flex-1">
-            {/* Blockquote prescrit nommément par l'audit Ideance, page P11, critère 9.4,
-                section "La mission de Réfugiés.info". */}
-            <blockquote className="m-0">
-              <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
-              <p className="!text-large">{t("MissionImpact.mission_p2")}</p>
-              <p className="!text-large !mb-0">{t("MissionImpact.mission_p3")}</p>
-            </blockquote>
+            {/* Levée de fait du 9.4 prescrit ici : la citation a disparu du contenu le 25/06
+                (commit 4efd162f5), voir docs/notes-tickets/rga-13.md. */}
+            <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
+            <p className="!text-large">{t("MissionImpact.mission_p2")}</p>
+            <p className="!text-large !mb-0">{t("MissionImpact.mission_p3")}</p>
           </div>
         </div>
       </div>

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
@@ -25,8 +25,6 @@ export const SectionMission = () => {
             />
           </div>
           <div className="flex-1">
-            {/* De facto lifting of the 9.4 prescribed here: the quote disappeared from the
-                content on 25/06 (commit 4efd162f5), see docs/notes-tickets/rga-13.md. */}
             <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
             <p className="!text-large">{t("MissionImpact.mission_p2")}</p>
             <p className="!text-large !mb-0">{t("MissionImpact.mission_p3")}</p>

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
@@ -25,8 +25,8 @@ export const SectionMission = () => {
             />
           </div>
           <div className="flex-1">
-            {/* Bloc de citation relevé par l'audit : structuré en blockquote (RGAA 9.4).
-                m-0 explicite, la base annule déjà la marge par défaut du blockquote. */}
+            {/* Blockquote prescrit nommément par l'audit Ideance, page P11, critère 9.4,
+                section "La mission de Réfugiés.info". */}
             <blockquote className="m-0">
               <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
               <p className="!text-large">{t("MissionImpact.mission_p2")}</p>

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionMission.tsx
@@ -25,9 +25,13 @@ export const SectionMission = () => {
             />
           </div>
           <div className="flex-1">
-            <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
-            <p className="!text-large">{t("MissionImpact.mission_p2")}</p>
-            <p className="!text-large !mb-0">{t("MissionImpact.mission_p3")}</p>
+            {/* Bloc de citation relevé par l'audit : structuré en blockquote (RGAA 9.4).
+                m-0 explicite, la base annule déjà la marge par défaut du blockquote. */}
+            <blockquote className="m-0">
+              <p className="!text-large">{t("MissionImpact.mission_p1")}</p>
+              <p className="!text-large">{t("MissionImpact.mission_p2")}</p>
+              <p className="!text-large !mb-0">{t("MissionImpact.mission_p3")}</p>
+            </blockquote>
           </div>
         </div>
       </div>

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
@@ -20,9 +20,9 @@ export const SectionUsers = () => {
                 __html: t("MissionImpact.users_text_1"),
               }}
             ></p>
-            {/* Citations en ligne en q, prescrites par l'audit Ideance, P11, critère 9.4. Les
-                guillemets sont déjà dans le texte traduit, ceux du navigateur sont neutralisés
-                pour ne pas les doubler à l'écran. */}
+            {/* Inline quotes as q, prescribed by the Ideance audit, P11, criterion 9.4. The
+                quotation marks are already in the translated text, the browser's ones are
+                neutralised so they are not doubled on screen. */}
             <p className="text-large">
               <q className="after:content-none before:content-none">
                 {t("MissionImpact.users_testimony_1")}

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
@@ -20,9 +20,9 @@ export const SectionUsers = () => {
                 __html: t("MissionImpact.users_text_1"),
               }}
             ></p>
-            {/* Citation en ligne : structurée en q (RGAA 9.4). Les guillemets font partie du
-                texte traduit, on neutralise donc ceux que le navigateur ajoute sur q, sans
-                quoi ils apparaîtraient en double à l'écran. */}
+            {/* Citations en ligne en q, prescrites par l'audit Ideance, P11, critère 9.4. Les
+                guillemets sont déjà dans le texte traduit, ceux du navigateur sont neutralisés
+                pour ne pas les doubler à l'écran. */}
             <p className="text-large">
               <q className="after:content-none before:content-none">
                 {t("MissionImpact.users_testimony_1")}

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
@@ -20,7 +20,14 @@ export const SectionUsers = () => {
                 __html: t("MissionImpact.users_text_1"),
               }}
             ></p>
-            <p className="text-large">{t("MissionImpact.users_testimony_1")}</p>
+            {/* Citation en ligne : structurée en q (RGAA 9.4). Les guillemets font partie du
+                texte traduit, on neutralise donc ceux que le navigateur ajoute sur q, sans
+                quoi ils apparaîtraient en double à l'écran. */}
+            <p className="text-large">
+              <q className="after:content-none before:content-none">
+                {t("MissionImpact.users_testimony_1")}
+              </q>
+            </p>
             <div className="space-x-2">
               <Badge small severity="info" noIcon>
                 {t("MissionImpact.users_badges1_badge1")}
@@ -58,7 +65,11 @@ export const SectionUsers = () => {
                 __html: t("MissionImpact.users_text_2"),
               }}
             ></p>
-            <p className="text-large">{t("MissionImpact.users_testimony_2")}</p>
+            <p className="text-large">
+              <q className="after:content-none before:content-none">
+                {t("MissionImpact.users_testimony_2")}
+              </q>
+            </p>
             <div className="space-x-2">
               <Badge small severity="info" noIcon>
                 {t("MissionImpact.users_badges2_badge")}

--- a/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
+++ b/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
@@ -17,8 +17,8 @@ const TestimonySlider = (props: Props) => {
       {props.testimonies.map((testimony, i) => (
         <div key={i} className="flex-1 space-y-6 md:px-8">
           <Image src={TestimonyIcon} width={40} height={40} alt="" />
-          {/* Blockquote prescrit par l'audit Ideance, P12, critère 9.4. Le nom et la fonction
-              restent dehors, ils sont la source de la citation. */}
+          {/* Blockquote prescribed by the Ideance audit, P12, criterion 9.4. The name and the
+              position stay outside, they are the source of the quote. */}
           <blockquote className="m-0">
             <p className="!text-large !mb-6">{testimony.text}</p>
           </blockquote>

--- a/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
+++ b/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
@@ -17,7 +17,11 @@ const TestimonySlider = (props: Props) => {
       {props.testimonies.map((testimony, i) => (
         <div key={i} className="flex-1 space-y-6 md:px-8">
           <Image src={TestimonyIcon} width={40} height={40} alt="" />
-          <p className="!text-large !mb-6">{testimony.text}</p>
+          {/* Bloc de citation relevé par l'audit : structuré en blockquote (RGAA 9.4).
+              Le nom et la fonction restent hors du blockquote, ils en sont la source. */}
+          <blockquote className="m-0">
+            <p className="!text-large !mb-6">{testimony.text}</p>
+          </blockquote>
           <div>
             <div className="mb-2 font-bold">{testimony.name}</div>
             <div>{testimony.position}</div>

--- a/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
+++ b/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
@@ -23,8 +23,8 @@ const TestimonySlider = (props: Props) => {
             <p className="!text-large !mb-6">{testimony.text}</p>
           </blockquote>
           <div>
-            <div className="mb-2 font-bold">{testimony.name}</div>
-            <div>{testimony.position}</div>
+            <p className="mb-2 font-bold">{testimony.name}</p>
+            <p className="mb-0">{testimony.position}</p>
           </div>
         </div>
       ))}

--- a/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
+++ b/apps/client/src/components/Pages/staticPages/publier/TestimonySlider/TestimonySlider.tsx
@@ -17,8 +17,8 @@ const TestimonySlider = (props: Props) => {
       {props.testimonies.map((testimony, i) => (
         <div key={i} className="flex-1 space-y-6 md:px-8">
           <Image src={TestimonyIcon} width={40} height={40} alt="" />
-          {/* Bloc de citation relevé par l'audit : structuré en blockquote (RGAA 9.4).
-              Le nom et la fonction restent hors du blockquote, ils en sont la source. */}
+          {/* Blockquote prescrit par l'audit Ideance, P12, critère 9.4. Le nom et la fonction
+              restent dehors, ils sont la source de la citation. */}
           <blockquote className="m-0">
             <p className="!text-large !mb-6">{testimony.text}</p>
           </blockquote>

--- a/apps/client/src/components/UI/Tabs/TabItem.module.scss
+++ b/apps/client/src/components/UI/Tabs/TabItem.module.scss
@@ -1,7 +1,6 @@
 @import "~/scss/mixins/unit";
 
-// Le li n'est qu'un porteur de sémantique : aucune boîte propre, aucun espacement.
-// padding: 0 annule celui que la base DSFR pose sur tous les li.
+// Le li ne porte que la sémantique : aucune boîte propre, espacement DSFR annulé.
 .tabitemwrapper {
   margin: 0;
   padding: 0;

--- a/apps/client/src/components/UI/Tabs/TabItem.module.scss
+++ b/apps/client/src/components/UI/Tabs/TabItem.module.scss
@@ -1,5 +1,12 @@
 @import "~/scss/mixins/unit";
 
+// Le li n'est qu'un porteur de sémantique : aucune boîte propre, aucun espacement.
+// padding: 0 annule celui que la base DSFR pose sur tous les li.
+.tabitemwrapper {
+  margin: 0;
+  padding: 0;
+}
+
 .tabitem {
   border: 1px solid transparent;
   border-radius: u(1);

--- a/apps/client/src/components/UI/Tabs/TabItem.module.scss
+++ b/apps/client/src/components/UI/Tabs/TabItem.module.scss
@@ -1,6 +1,6 @@
 @import "~/scss/mixins/unit";
 
-// Le li ne porte que la sémantique : aucune boîte propre, espacement DSFR annulé.
+// The li only carries the semantics: no box of its own, DSFR spacing cancelled.
 .tabitemwrapper {
   margin: 0;
   padding: 0;

--- a/apps/client/src/components/UI/Tabs/TabItem.tsx
+++ b/apps/client/src/components/UI/Tabs/TabItem.tsx
@@ -12,13 +12,15 @@ interface TabItemProps {
 const TabItem = React.forwardRef<HTMLButtonElement, TabItemProps>(
   ({ children, isActive, className, ...props }, ref) => {
     return (
-      <button
-        className={cls(styles.tabitem, isActive && styles.active, className)}
-        {...props}
-        ref={ref}
-      >
-        {children}
-      </button>
+      <li className={styles.tabitemwrapper}>
+        <button
+          className={cls(styles.tabitem, isActive && styles.active, className)}
+          {...props}
+          ref={ref}
+        >
+          {children}
+        </button>
+      </li>
     );
   },
 );

--- a/apps/client/src/components/UI/Tabs/TabsBar.module.scss
+++ b/apps/client/src/components/UI/Tabs/TabsBar.module.scss
@@ -8,7 +8,7 @@
   border: 1px solid $gray50;
   border-radius: u(1);
 
-  // Rendu de l'ancien div de boutons inline-block, puce et retrait DSFR neutralisés.
+  // Rendering of the former inline-block buttons div, DSFR bullet and indent neutralised.
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/apps/client/src/components/UI/Tabs/TabsBar.module.scss
+++ b/apps/client/src/components/UI/Tabs/TabsBar.module.scss
@@ -7,4 +7,14 @@
 .tabsbar {
   border: 1px solid $gray50;
   border-radius: u(1);
+
+  // La barre était un div contenant des boutons inline-block. En ul/li il faut redonner
+  // explicitement la disposition en rangée, et neutraliser puce, retrait et marges que la
+  // base DSFR pose sur ul et li.
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  margin: 0;
+  padding: 0;
+  list-style: none;
 }

--- a/apps/client/src/components/UI/Tabs/TabsBar.module.scss
+++ b/apps/client/src/components/UI/Tabs/TabsBar.module.scss
@@ -8,9 +8,7 @@
   border: 1px solid $gray50;
   border-radius: u(1);
 
-  // La barre était un div contenant des boutons inline-block. En ul/li il faut redonner
-  // explicitement la disposition en rangée, et neutraliser puce, retrait et marges que la
-  // base DSFR pose sur ul et li.
+  // Rendu de l'ancien div de boutons inline-block, puce et retrait DSFR neutralisés.
   display: flex;
   flex-wrap: wrap;
   align-items: center;

--- a/apps/client/src/components/UI/Tabs/TabsBar.tsx
+++ b/apps/client/src/components/UI/Tabs/TabsBar.tsx
@@ -11,8 +11,7 @@ const TabsBar = React.forwardRef<HTMLUListElement, TabsBarProps>(({ children, ..
   const stylesDisabled = useStylesDisabled();
 
   return (
-    // role="list" : parade défensive, un ul sans puce peut perdre sa nature de liste sous
-    // Safari et VoiceOver. Les li gardent display: list-item, ils n'ont besoin de rien.
+    // Rôle explicite justifié sur la prop contentAs de MetaDataItem.
     <ul className={cls(styles.tabsbar)} role="list" {...props} ref={ref}>
       {children}
       {stylesDisabled && (

--- a/apps/client/src/components/UI/Tabs/TabsBar.tsx
+++ b/apps/client/src/components/UI/Tabs/TabsBar.tsx
@@ -7,19 +7,19 @@ interface TabsBarProps {
   children: React.ReactNode;
 }
 
-const TabsBar = React.forwardRef<HTMLDivElement, TabsBarProps>(({ children, ...props }, ref) => {
+const TabsBar = React.forwardRef<HTMLUListElement, TabsBarProps>(({ children, ...props }, ref) => {
   const stylesDisabled = useStylesDisabled();
 
   return (
-    <div className={cls(styles.tabsbar)} {...props} ref={ref}>
+    <ul className={cls(styles.tabsbar)} {...props} ref={ref}>
       {children}
       {stylesDisabled && (
-        <>
+        <li aria-hidden="true">
           <br />
           <br />
-        </>
+        </li>
       )}
-    </div>
+    </ul>
   );
 });
 

--- a/apps/client/src/components/UI/Tabs/TabsBar.tsx
+++ b/apps/client/src/components/UI/Tabs/TabsBar.tsx
@@ -11,7 +11,9 @@ const TabsBar = React.forwardRef<HTMLUListElement, TabsBarProps>(({ children, ..
   const stylesDisabled = useStylesDisabled();
 
   return (
-    <ul className={cls(styles.tabsbar)} {...props} ref={ref}>
+    // role="list" : parade défensive, un ul sans puce peut perdre sa nature de liste sous
+    // Safari et VoiceOver. Les li gardent display: list-item, ils n'ont besoin de rien.
+    <ul className={cls(styles.tabsbar)} role="list" {...props} ref={ref}>
       {children}
       {stylesDisabled && (
         <li aria-hidden="true">

--- a/apps/client/src/components/UI/Tabs/TabsBar.tsx
+++ b/apps/client/src/components/UI/Tabs/TabsBar.tsx
@@ -11,7 +11,7 @@ const TabsBar = React.forwardRef<HTMLUListElement, TabsBarProps>(({ children, ..
   const stylesDisabled = useStylesDisabled();
 
   return (
-    // Rôle explicite justifié sur la prop contentAs de MetaDataItem.
+    // Explicit role justified on the contentAs prop of MetaDataItem.
     <ul className={cls(styles.tabsbar)} role="list" {...props} ref={ref}>
       {children}
       {stylesDisabled && (

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -335,25 +335,30 @@ const EditDepartments = (props: Props) => {
 
         {selectedDepartments.length > 0 && (
           <div className="mt-12">
-            {selectedDepartments.map((dep, i) => (
-              <div key={dep} className={styles.option}>
-                {formatDepartment(dep)}
-                <Button
-                  iconId="fr-icon-close-line"
-                  priority="tertiary no outline"
-                  title={t("EditDepartments.remove_department", {
-                    department: formatDepartment(dep),
-                    defaultValue: "Retirer le département {{department}}",
-                    interpolation: { escapeValue: false },
-                  })}
-                  size="small"
-                  // Without this the DSFR button falls back to type="submit" and
-                  // removing a chip saves the form.
-                  nativeButtonProps={{ type: "button" }}
-                  onClick={() => removeDepartment(dep)}
-                />
-              </div>
-            ))}
+            {/* list-none p-0 m-0 sur le ul : neutralise la puce et le retrait posés par la base
+                DSFR, pour un rendu identique à l'ancienne structure en div. Le padding bas que
+                DSFR pose sur les li est déjà écrasé par le raccourci padding de .option. */}
+            <ul className="m-0 list-none p-0">
+              {selectedDepartments.map((dep) => (
+                <li key={dep} className={styles.option}>
+                  {formatDepartment(dep)}
+                  <Button
+                    iconId="fr-icon-close-line"
+                    priority="tertiary no outline"
+                    title={t("EditDepartments.remove_department", {
+                      department: formatDepartment(dep),
+                      defaultValue: "Retirer le département {{department}}",
+                      interpolation: { escapeValue: false },
+                    })}
+                    size="small"
+                    // Without this the DSFR button falls back to type="submit" and
+                    // removing a chip saves the form.
+                    nativeButtonProps={{ type: "button" }}
+                    onClick={() => removeDepartment(dep)}
+                  />
+                </li>
+              ))}
+            </ul>
           </div>
         )}
       </div>

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -335,14 +335,9 @@ const EditDepartments = (props: Props) => {
 
         {selectedDepartments.length > 0 && (
           <div className="mt-12">
-            {/* list-none p-0 m-0 sur le ul : neutralise la puce et le retrait posés par la base
-                DSFR, pour un rendu identique à l'ancienne structure en div. Le padding bas que
-                DSFR pose sur les li est déjà écrasé par le raccourci padding de .option. */}
-            {/* role="list" et role="listitem" : parade défensive, pas une exigence RGAA.
-                Un ul sans puce peut perdre sa nature de liste sous Safari et VoiceOver, et
-                .option met les li en inline-flex, ce qui leur retire leur rôle natif.
-                Mesure au lecteur d'écran en attente, ces deux attributs sautent si elle
-                conclut qu'ils sont inutiles. */}
+            {/* Énumération de départements : ul/li (RGAA 9.3), puce et retrait DSFR neutralisés
+                pour un rendu identique à l'ancienne structure en div. Rôles explicites justifiés
+                sur la prop contentAs de MetaDataItem. */}
             <ul className="m-0 list-none p-0" role="list">
               {selectedDepartments.map((dep) => (
                 <li key={dep} className={styles.option} role="listitem">

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -338,9 +338,14 @@ const EditDepartments = (props: Props) => {
             {/* list-none p-0 m-0 sur le ul : neutralise la puce et le retrait posés par la base
                 DSFR, pour un rendu identique à l'ancienne structure en div. Le padding bas que
                 DSFR pose sur les li est déjà écrasé par le raccourci padding de .option. */}
-            <ul className="m-0 list-none p-0">
+            {/* role="list" et role="listitem" : parade défensive, pas une exigence RGAA.
+                Un ul sans puce peut perdre sa nature de liste sous Safari et VoiceOver, et
+                .option met les li en inline-flex, ce qui leur retire leur rôle natif.
+                Mesure au lecteur d'écran en attente, ces deux attributs sautent si elle
+                conclut qu'ils sont inutiles. */}
+            <ul className="m-0 list-none p-0" role="list">
               {selectedDepartments.map((dep) => (
-                <li key={dep} className={styles.option}>
+                <li key={dep} className={styles.option} role="listitem">
                   {formatDepartment(dep)}
                   <Button
                     iconId="fr-icon-close-line"

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -335,9 +335,9 @@ const EditDepartments = (props: Props) => {
 
         {selectedDepartments.length > 0 && (
           <div className="mt-12">
-            {/* Énumération de départements : ul/li (RGAA 9.3), puce et retrait DSFR neutralisés
-                pour un rendu identique à l'ancienne structure en div. Rôles explicites justifiés
-                sur la prop contentAs de MetaDataItem. */}
+            {/* Department enumeration: ul/li (RGAA 9.3), DSFR bullet and indent neutralised
+                for a rendering identical to the former div structure. Explicit roles justified
+                on the contentAs prop of MetaDataItem. */}
             <ul className="m-0 list-none p-0" role="list">
               {selectedDepartments.map((dep) => (
                 <li key={dep} className={styles.option} role="listitem">

--- a/apps/client/src/lib/dispositif/getMetadataText.ts
+++ b/apps/client/src/lib/dispositif/getMetadataText.ts
@@ -47,31 +47,25 @@ export const getPriceText = (data: Metadatas["price"] | undefined, t: TFunction)
 };
 
 /**
- * jsUcfirst ne portant que sur le premier caractère, l'appliquer au seul premier élément
- * redonne exactement la chaîne d'origine une fois les éléments recollés par ", ".
+ * Valeurs dont le libellé se lit dans le namespace Infocards. Union fermée et non string :
+ * c'est elle qui laisse t() vérifier les clés `Infocards.${valeur}` à la compilation.
  */
-const ucfirstFirstItem = (labels: string[]): string[] =>
-  labels.length === 0 ? [] : [jsUcfirst(labels[0]), ...labels.slice(1)];
+type InfocardsValue = NonNullable<Metadatas["public"] | Metadatas["publicStatus"]>[number];
 
 /**
- * Mêmes libellés que getPublicStatusText, mais élément par élément au lieu d'une chaîne
- * jointe, pour pouvoir structurer l'énumération en ul/li (RGAA 9.3).
+ * Libellés d'une énumération de métadonnées, un par élément au lieu d'une chaîne jointe,
+ * pour pouvoir la structurer en ul/li (RGAA 9.3). Seul le premier porte la majuscule,
+ * comme la chaîne jointe que ces listes remplacent.
  */
-export const getPublicStatusList = (
-  data: Metadatas["publicStatus"] | undefined,
+export const getInfocardsLabels = (
+  data: readonly InfocardsValue[] | null | undefined,
   t: TFunction,
 ): string[] | null => {
   if (!data || data.length === 0) return null;
-  return ucfirstFirstItem(data.map((d) => t(`Infocards.${d}`) as string));
-};
-
-/** Mêmes libellés que getPublicText, en liste. Voir getPublicStatusList. */
-export const getPublicList = (
-  data: Metadatas["public"] | undefined,
-  t: TFunction,
-): string[] | null => {
-  if (!data || data.length === 0) return null;
-  return ucfirstFirstItem(data.map((d) => t(`Infocards.${d}`) as string));
+  return data.map((value, index) => {
+    const label = t(`Infocards.${value}`) as string;
+    return index === 0 ? jsUcfirst(label) : label;
+  });
 };
 
 export const getPublicStatusText = (

--- a/apps/client/src/lib/dispositif/getMetadataText.ts
+++ b/apps/client/src/lib/dispositif/getMetadataText.ts
@@ -47,15 +47,15 @@ export const getPriceText = (data: Metadatas["price"] | undefined, t: TFunction)
 };
 
 /**
- * Valeurs dont le libellé se lit dans le namespace Infocards. Union fermée et non string :
- * c'est elle qui laisse t() vérifier les clés `Infocards.${valeur}` à la compilation.
+ * Values whose label is read from the Infocards namespace. A closed union rather than string:
+ * it is what lets t() check the `Infocards.${value}` keys at compile time.
  */
 type InfocardsValue = NonNullable<Metadatas["public"] | Metadatas["publicStatus"]>[number];
 
 /**
- * Libellés d'une énumération de métadonnées, un par élément au lieu d'une chaîne jointe,
- * pour pouvoir la structurer en ul/li (RGAA 9.3). Seul le premier porte la majuscule,
- * comme la chaîne jointe que ces listes remplacent.
+ * Labels of a metadata enumeration, one per item instead of a joined string, so that it can
+ * be structured as ul/li (RGAA 9.3). Only the first one is capitalised, like the joined
+ * string these lists replace.
  */
 export const getInfocardsLabels = (
   data: readonly InfocardsValue[] | null | undefined,

--- a/apps/client/src/lib/dispositif/getMetadataText.ts
+++ b/apps/client/src/lib/dispositif/getMetadataText.ts
@@ -46,6 +46,34 @@ export const getPriceText = (data: Metadatas["price"] | undefined, t: TFunction)
   return jsUcfirst(`${data.values[0]}€ ${data.details ? t(`Infocards.${data.details}`) : ""}`);
 };
 
+/**
+ * jsUcfirst ne portant que sur le premier caractère, l'appliquer au seul premier élément
+ * redonne exactement la chaîne d'origine une fois les éléments recollés par ", ".
+ */
+const ucfirstFirstItem = (labels: string[]): string[] =>
+  labels.length === 0 ? [] : [jsUcfirst(labels[0]), ...labels.slice(1)];
+
+/**
+ * Mêmes libellés que getPublicStatusText, mais élément par élément au lieu d'une chaîne
+ * jointe, pour pouvoir structurer l'énumération en ul/li (RGAA 9.3).
+ */
+export const getPublicStatusList = (
+  data: Metadatas["publicStatus"] | undefined,
+  t: TFunction,
+): string[] | null => {
+  if (!data || data.length === 0) return null;
+  return ucfirstFirstItem(data.map((d) => t(`Infocards.${d}`) as string));
+};
+
+/** Mêmes libellés que getPublicText, en liste. Voir getPublicStatusList. */
+export const getPublicList = (
+  data: Metadatas["public"] | undefined,
+  t: TFunction,
+): string[] | null => {
+  if (!data || data.length === 0) return null;
+  return ucfirstFirstItem(data.map((d) => t(`Infocards.${d}`) as string));
+};
+
 export const getPublicStatusText = (
   data: Metadatas["publicStatus"] | undefined,
   t: TFunction,

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -161,7 +161,9 @@ const RecensezVotreAction = (props: Props) => {
                 p-0 sur les li neutralisent puce, retrait et espacements de la base DSFR, la
                 disposition en flex reste celle de l'ancien div. */}
             {translationNeeds.length > 0 && (
-              <ul className="m-0 flex list-none flex-wrap gap-6 p-0 md:justify-center">
+              // role="list" : parade défensive, un ul sans puce peut perdre sa nature de liste
+              // sous Safari et VoiceOver. Les li gardent display: list-item, rien à ajouter.
+              <ul className="m-0 flex list-none flex-wrap gap-6 p-0 md:justify-center" role="list">
                 {translationNeeds.map((item, i) => (
                   <li key={i} className="p-0">
                     <LanguageCard href="#register" languageId={item.languageId} need={item.need} />

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -157,8 +157,8 @@ const RecensezVotreAction = (props: Props) => {
         <Section className="bg-action-low-blue-france">
           <div className="fr-container">
             <Title2>On cherche des traducteurs en :</Title2>
-            {/* Énumération de liens : ul/li (RGAA 9.3), rôle explicite justifié sur la prop
-                contentAs de MetaDataItem. Le flex reprend la disposition de l'ancien div. */}
+            {/* Link enumeration: ul/li (RGAA 9.3), explicit role justified on the contentAs
+                prop of MetaDataItem. The flex reproduces the layout of the former div. */}
             {translationNeeds.length > 0 && (
               <ul className="m-0 flex list-none flex-wrap gap-6 p-0 md:justify-center" role="list">
                 {translationNeeds.map((item, i) => (

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -157,16 +157,18 @@ const RecensezVotreAction = (props: Props) => {
         <Section className="bg-action-low-blue-france">
           <div className="fr-container">
             <Title2>On cherche des traducteurs en :</Title2>
-            <div className="flex flex-wrap gap-6 md:justify-center">
-              {translationNeeds.map((item, i) => (
-                <LanguageCard
-                  href="#register"
-                  key={i}
-                  languageId={item.languageId}
-                  need={item.need}
-                />
-              ))}
-            </div>
+            {/* Énumération de liens : structurée en ul/li (RGAA 9.3). list-none p-0 m-0 et
+                p-0 sur les li neutralisent puce, retrait et espacements de la base DSFR, la
+                disposition en flex reste celle de l'ancien div. */}
+            {translationNeeds.length > 0 && (
+              <ul className="m-0 flex list-none flex-wrap gap-6 p-0 md:justify-center">
+                {translationNeeds.map((item, i) => (
+                  <li key={i} className="p-0">
+                    <LanguageCard href="#register" languageId={item.languageId} need={item.need} />
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </Section>
       </div>

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -157,12 +157,9 @@ const RecensezVotreAction = (props: Props) => {
         <Section className="bg-action-low-blue-france">
           <div className="fr-container">
             <Title2>On cherche des traducteurs en :</Title2>
-            {/* Énumération de liens : structurée en ul/li (RGAA 9.3). list-none p-0 m-0 et
-                p-0 sur les li neutralisent puce, retrait et espacements de la base DSFR, la
-                disposition en flex reste celle de l'ancien div. */}
+            {/* Énumération de liens : ul/li (RGAA 9.3), rôle explicite justifié sur la prop
+                contentAs de MetaDataItem. Le flex reprend la disposition de l'ancien div. */}
             {translationNeeds.length > 0 && (
-              // role="list" : parade défensive, un ul sans puce peut perdre sa nature de liste
-              // sous Safari et VoiceOver. Les li gardent display: list-item, rien à ajouter.
               <ul className="m-0 flex list-none flex-wrap gap-6 p-0 md:justify-center" role="list">
                 {translationNeeds.map((item, i) => (
                   <li key={i} className="p-0">

--- a/packages/ui/src/components/composites/Map/AdressContent.tsx
+++ b/packages/ui/src/components/composites/Map/AdressContent.tsx
@@ -6,45 +6,58 @@ type AdressContentProps = {
   poi: Poi;
 };
 
+// Chaque ligne garde exactement les classes qu'elle portait en <p>, plus p-0 pour annuler
+// le padding bas que la base DSFR pose sur les li.
+const LINE_CLASS =
+  "text-default-grey text-corps-sm !m-0 flex w-full items-center justify-between gap-2 p-0";
+
 export default function AdressContent({ poi }: AdressContentProps) {
   const { t } = useTranslation();
   const clipBoardCopy = (address: string) => {
     navigator.clipboard.writeText(address);
   };
 
+  // Les informations du lieu sont une énumération : elles se structurent en ul/li (RGAA 9.3).
+  // On ne rend aucune liste quand il n'y a rien à lister.
+  const lines = [
+    poi.address && poi.address.length > 1 ? (
+      <li key="address" className={LINE_CLASS}>
+        <span className="min-w-0 flex-1">{poi.address}</span>
+        <CopyButton
+          title={t("Dispositif.mapCopyAddress", "Copier l'adresse")}
+          onClick={() => clipBoardCopy(poi.address)}
+        />
+      </li>
+    ) : null,
+    poi.phone && poi.phone.length > 1 ? (
+      <li key="phone" className={LINE_CLASS}>
+        <a href={`tel:${poi.phone}`} className="min-w-0 flex-1">
+          {poi.phone}
+        </a>
+        <CopyButton
+          title={t("Dispositif.mapCopyPhone", "Copier le numéro de téléphone")}
+          onClick={() => clipBoardCopy(poi.phone as string)}
+        />
+      </li>
+    ) : null,
+    poi.email && poi.email !== "ajouter@votreemail.fr" && poi.email.length > 1 ? (
+      <li key="email" className={LINE_CLASS}>
+        <a href={`mailto:${poi.email}`} className="min-w-0 flex-1">
+          {poi.email}
+        </a>
+        <CopyButton
+          title={t("Dispositif.mapCopyEmail", "Copier l'email")}
+          onClick={() => clipBoardCopy(poi.email as string)}
+        />
+      </li>
+    ) : null,
+  ].filter(Boolean);
+
   return (
-    <address className="h-full bg-white p-4 not-italic flex flex-col gap-2">
-      {poi.address && poi.address.length > 1 ? (
-        <p className="text-default-grey text-corps-sm !m-0 flex w-full items-center justify-between gap-2">
-          <span className="flex-1 min-w-0">{poi.address}</span>
-          <CopyButton
-            title={t("Dispositif.mapCopyAddress", "Copier l'adresse")}
-            onClick={() => clipBoardCopy(poi.address)}
-          />
-        </p>
-      ) : null}
-      {poi.phone && poi.phone.length > 1 ? (
-        <p className="text-default-grey text-corps-sm !m-0 flex w-full items-center justify-between gap-2">
-          <a href={`tel:${poi.phone}`} className="flex-1 min-w-0">
-            {poi.phone}
-          </a>
-          <CopyButton
-            title={t("Dispositif.mapCopyPhone", "Copier le numéro de téléphone")}
-            onClick={() => clipBoardCopy(poi.phone as string)}
-          />
-        </p>
-      ) : null}
-      {poi.email && poi.email !== "ajouter@votreemail.fr" && poi.email.length > 1 ? (
-        <p className="text-default-grey text-corps-sm !m-0 flex w-full items-center justify-between gap-2">
-          <a href={`mailto:${poi.email}`} className="flex-1 min-w-0">
-            {poi.email}
-          </a>
-          <CopyButton
-            title={t("Dispositif.mapCopyEmail", "Copier l'email")}
-            onClick={() => clipBoardCopy(poi.email as string)}
-          />
-        </p>
-      ) : null}
+    <address className="flex h-full flex-col gap-2 bg-white p-4 not-italic">
+      {lines.length > 0 && (
+        <ul className="m-0 flex w-full list-none flex-col gap-2 p-0">{lines}</ul>
+      )}
     </address>
   );
 }

--- a/packages/ui/src/components/composites/Map/AdressContent.tsx
+++ b/packages/ui/src/components/composites/Map/AdressContent.tsx
@@ -6,6 +6,9 @@ type AdressContentProps = {
   poi: Poi;
 };
 
+// role="list" et role="listitem" : parade défensive. Un ul sans puce peut perdre sa nature
+// de liste sous Safari et VoiceOver, et les li sont en display:flex, ce qui leur retire leur
+// rôle natif. Les deux sautent si la mesure au lecteur d'écran conclut qu'ils sont inutiles.
 // Chaque ligne garde exactement les classes qu'elle portait en <p>, plus p-0 pour annuler
 // le padding bas que la base DSFR pose sur les li.
 const LINE_CLASS =
@@ -21,7 +24,7 @@ export default function AdressContent({ poi }: AdressContentProps) {
   // On ne rend aucune liste quand il n'y a rien à lister.
   const lines = [
     poi.address && poi.address.length > 1 ? (
-      <li key="address" className={LINE_CLASS}>
+      <li key="address" className={LINE_CLASS} role="listitem">
         <span className="min-w-0 flex-1">{poi.address}</span>
         <CopyButton
           title={t("Dispositif.mapCopyAddress", "Copier l'adresse")}
@@ -30,7 +33,7 @@ export default function AdressContent({ poi }: AdressContentProps) {
       </li>
     ) : null,
     poi.phone && poi.phone.length > 1 ? (
-      <li key="phone" className={LINE_CLASS}>
+      <li key="phone" className={LINE_CLASS} role="listitem">
         <a href={`tel:${poi.phone}`} className="min-w-0 flex-1">
           {poi.phone}
         </a>
@@ -41,7 +44,7 @@ export default function AdressContent({ poi }: AdressContentProps) {
       </li>
     ) : null,
     poi.email && poi.email !== "ajouter@votreemail.fr" && poi.email.length > 1 ? (
-      <li key="email" className={LINE_CLASS}>
+      <li key="email" className={LINE_CLASS} role="listitem">
         <a href={`mailto:${poi.email}`} className="min-w-0 flex-1">
           {poi.email}
         </a>
@@ -56,7 +59,9 @@ export default function AdressContent({ poi }: AdressContentProps) {
   return (
     <address className="flex h-full flex-col gap-2 bg-white p-4 not-italic">
       {lines.length > 0 && (
-        <ul className="m-0 flex w-full list-none flex-col gap-2 p-0">{lines}</ul>
+        <ul className="m-0 flex w-full list-none flex-col gap-2 p-0" role="list">
+          {lines}
+        </ul>
       )}
     </address>
   );

--- a/packages/ui/src/components/composites/Map/AdressContent.tsx
+++ b/packages/ui/src/components/composites/Map/AdressContent.tsx
@@ -6,7 +6,7 @@ type AdressContentProps = {
   poi: Poi;
 };
 
-// Les classes que chaque ligne portait en <p>, plus p-0 pour le padding que DSFR pose sur les li.
+// The classes each line carried as a <p>, plus p-0 for the padding DSFR sets on li.
 const LINE_CLASS =
   "text-default-grey text-corps-sm !m-0 flex w-full items-center justify-between gap-2 p-0";
 
@@ -16,8 +16,8 @@ export default function AdressContent({ poi }: AdressContentProps) {
     navigator.clipboard.writeText(address);
   };
 
-  // Informations du lieu : énumération structurée en ul/li (RGAA 9.3), rien de rendu si vide.
-  // Les rôles explicites sont justifiés sur la prop contentAs de MetaDataItem.
+  // Venue details: enumeration structured as ul/li (RGAA 9.3), nothing rendered when empty.
+  // The explicit roles are justified on the contentAs prop of MetaDataItem.
   const lines = [
     poi.address && poi.address.length > 1 ? (
       <li key="address" className={LINE_CLASS} role="listitem">

--- a/packages/ui/src/components/composites/Map/AdressContent.tsx
+++ b/packages/ui/src/components/composites/Map/AdressContent.tsx
@@ -6,11 +6,7 @@ type AdressContentProps = {
   poi: Poi;
 };
 
-// role="list" et role="listitem" : parade défensive. Un ul sans puce peut perdre sa nature
-// de liste sous Safari et VoiceOver, et les li sont en display:flex, ce qui leur retire leur
-// rôle natif. Les deux sautent si la mesure au lecteur d'écran conclut qu'ils sont inutiles.
-// Chaque ligne garde exactement les classes qu'elle portait en <p>, plus p-0 pour annuler
-// le padding bas que la base DSFR pose sur les li.
+// Les classes que chaque ligne portait en <p>, plus p-0 pour le padding que DSFR pose sur les li.
 const LINE_CLASS =
   "text-default-grey text-corps-sm !m-0 flex w-full items-center justify-between gap-2 p-0";
 
@@ -20,8 +16,8 @@ export default function AdressContent({ poi }: AdressContentProps) {
     navigator.clipboard.writeText(address);
   };
 
-  // Les informations du lieu sont une énumération : elles se structurent en ul/li (RGAA 9.3).
-  // On ne rend aucune liste quand il n'y a rien à lister.
+  // Informations du lieu : énumération structurée en ul/li (RGAA 9.3), rien de rendu si vide.
+  // Les rôles explicites sont justifiés sur la prop contentAs de MetaDataItem.
   const lines = [
     poi.address && poi.address.length > 1 ? (
       <li key="address" className={LINE_CLASS} role="listitem">

--- a/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
+++ b/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
@@ -11,15 +11,15 @@ type MetaDataItemProps = {
   onClick?: () => void;
   state?: "valid" | "invalid";
   /**
-   * Balise du conteneur d'enfants. "p" par défaut, "ul" quand les enfants sont une énumération
-   * (RGAA 9.3 : un <ul> ne peut pas vivre dans un <p>). En "ul" le conteneur perd puce, retrait
-   * et marges, et reçoit role="list" : sans ce rôle explicite, VoiceOver n'annonce plus la nature
-   * de liste ni le décompte dès que la puce est masquée (mesuré Safari + VoiceOver, 27/08).
-   * C'est la justification de tous les role="list" et role="listitem" posés sur les listes nues
-   * du dépôt.
+   * Tag of the children container. "p" by default, "ul" when the children are an enumeration
+   * (RGAA 9.3: a <ul> cannot live inside a <p>). As "ul" the container loses bullet, indent
+   * and margins, and receives role="list": without this explicit role, VoiceOver no longer
+   * announces the list nature nor the item count once the bullet is hidden (measured on
+   * Safari + VoiceOver, 27/08). This is the justification for every role="list" and
+   * role="listitem" set on the bare lists of the repository.
    */
   contentAs?: "p" | "ul";
-  /** Classes ajoutées au conteneur d'enfants, pour les cas où sa disposition doit changer. */
+  /** Classes added to the children container, for the cases where its layout must change. */
   contentClassName?: string;
 } & (
   | { icon: FrIconClassName | RiIconClassName; logoImage?: never }

--- a/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
+++ b/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
@@ -2,7 +2,7 @@ import type { FrIconClassName, RiIconClassName } from "@codegouvfr/react-dsfr";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { cn } from "@refugies-info/ui";
 import Image from "next/image";
-import type React from "react";
+import React from "react";
 
 type MetaDataItemProps = {
   className?: string;
@@ -10,6 +10,13 @@ type MetaDataItemProps = {
   children?: React.ReactNode;
   onClick?: () => void;
   state?: "valid" | "invalid";
+  /**
+   * Balise du conteneur d'enfants. "p" par défaut. Passer "ul" quand les enfants sont une
+   * énumération, ce qu'exige le critère RGAA 9.3 : un <ul> ne peut pas vivre dans un <p>.
+   */
+  contentAs?: "p" | "ul";
+  /** Classes ajoutées au conteneur d'enfants, pour les cas où sa disposition doit changer. */
+  contentClassName?: string;
 } & (
   | { icon: FrIconClassName | RiIconClassName; logoImage?: never }
   | { icon?: never; logoImage: { url: string; alt?: string } }
@@ -23,6 +30,8 @@ export const MetaDataItem = ({
   children,
   onClick,
   state,
+  contentAs = "p",
+  contentClassName,
 }: MetaDataItemProps) => {
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -54,18 +63,23 @@ export const MetaDataItem = ({
             {title}
           </h3>
         )}
-        {children && (
-          <p
-            className={cn(
-              "md:text-corps-sm relative mb-0 flex h-full flex-wrap gap-2 max-sm:inline [&_a]:inline",
-              "before:content-[''] before:bg-border-default-grey before:absolute before:block before:h-full lg:before:w-px ltr:before:-left-5.25 rtl:before:-right-5.25",
-              "md:[&_a]:text-sm",
-              onClick && "[&_a]:pointer-events-none",
-            )}
-          >
-            {children}
-          </p>
-        )}
+        {children &&
+          React.createElement(
+            contentAs,
+            {
+              className: cn(
+                "md:text-corps-sm relative mb-0 flex h-full flex-wrap gap-2 max-sm:inline [&_a]:inline",
+                "before:content-[''] before:bg-border-default-grey before:absolute before:block before:h-full lg:before:w-px ltr:before:-left-5.25 rtl:before:-right-5.25",
+                "md:[&_a]:text-sm",
+                onClick && "[&_a]:pointer-events-none",
+                // En ul, neutralise puce, retrait et marges de la base DSFR pour que le
+                // conteneur se comporte exactement comme le p qu'il remplace.
+                contentAs === "ul" && "m-0 list-none p-0 [&>li]:p-0",
+                contentClassName,
+              ),
+            },
+            children,
+          )}
       </div>
       {onClick && (
         <span className="ml-auto flex items-center">

--- a/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
+++ b/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
@@ -67,6 +67,9 @@ export const MetaDataItem = ({
           React.createElement(
             contentAs,
             {
+              // role="list" : parade défensive, un ul sans puce peut perdre sa nature de
+              // liste sous Safari et VoiceOver. Retiré si la mesure conclut qu'il est inutile.
+              role: contentAs === "ul" ? "list" : undefined,
               className: cn(
                 "md:text-corps-sm relative mb-0 flex h-full flex-wrap gap-2 max-sm:inline [&_a]:inline",
                 "before:content-[''] before:bg-border-default-grey before:absolute before:block before:h-full lg:before:w-px ltr:before:-left-5.25 rtl:before:-right-5.25",

--- a/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
+++ b/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
@@ -11,8 +11,12 @@ type MetaDataItemProps = {
   onClick?: () => void;
   state?: "valid" | "invalid";
   /**
-   * Balise du conteneur d'enfants. "p" par défaut. Passer "ul" quand les enfants sont une
-   * énumération, ce qu'exige le critère RGAA 9.3 : un <ul> ne peut pas vivre dans un <p>.
+   * Balise du conteneur d'enfants. "p" par défaut, "ul" quand les enfants sont une énumération
+   * (RGAA 9.3 : un <ul> ne peut pas vivre dans un <p>). En "ul" le conteneur perd puce, retrait
+   * et marges, et reçoit role="list" : sans ce rôle explicite, VoiceOver n'annonce plus la nature
+   * de liste ni le décompte dès que la puce est masquée (mesuré Safari + VoiceOver, 27/08).
+   * C'est la justification de tous les role="list" et role="listitem" posés sur les listes nues
+   * du dépôt.
    */
   contentAs?: "p" | "ul";
   /** Classes ajoutées au conteneur d'enfants, pour les cas où sa disposition doit changer. */
@@ -67,16 +71,12 @@ export const MetaDataItem = ({
           React.createElement(
             contentAs,
             {
-              // role="list" : parade défensive, un ul sans puce peut perdre sa nature de
-              // liste sous Safari et VoiceOver. Retiré si la mesure conclut qu'il est inutile.
               role: contentAs === "ul" ? "list" : undefined,
               className: cn(
                 "md:text-corps-sm relative mb-0 flex h-full flex-wrap gap-2 max-sm:inline [&_a]:inline",
                 "before:content-[''] before:bg-border-default-grey before:absolute before:block before:h-full lg:before:w-px ltr:before:-left-5.25 rtl:before:-right-5.25",
                 "md:[&_a]:text-sm",
                 onClick && "[&_a]:pointer-events-none",
-                // En ul, neutralise puce, retrait et marges de la base DSFR pour que le
-                // conteneur se comporte exactement comme le p qu'il remplace.
                 contentAs === "ul" && "m-0 list-none p-0 [&>li]:p-0",
                 contentClassName,
               ),


### PR DESCRIPTION
Audit RGAA Ideance, RGA-13. Les énumérations des fiches et formulaires (départements, publics, lieu d'accueil, filtres, langues) deviennent de vraies listes pour les lecteurs d'écran, et les témoignages de vraies citations.

Le commit « keep list semantics » pose des rôles indispensables sous Safari : sans eux, VoiceOver n'annonce plus du tout ces listes (mesuré).
