### PR TITLE
fix(a11y): messages de statut restants et contenus cachés à tort (RGAA 7.5, 8.9, 10.8)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -891,7 +891,9 @@
     "northStar_useful": "C'est utile ? ✨",
     "northStar_thanks": "Merci pour votre retour",
     "northStar_error": "Une erreur est survenue lors de la soumission de votre avis",
-    "northStar_vote_cancelled": "Votre vote a été retiré"
+    "northStar_vote_cancelled": "Votre vote a été retiré",
+    "themeBadge_one": "autre thème",
+    "themeBadge_other": "autres thèmes"
   },
   "ContentSources": {
     "RCO": {

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileAppSmsForm/MobileAppSmsForm.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileAppSmsForm/MobileAppSmsForm.tsx
@@ -4,7 +4,8 @@ import { Select } from "@codegouvfr/react-dsfr/SelectNext";
 import { useTranslation } from "next-i18next";
 import { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
-import Swal from "sweetalert2";
+import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
+import Toast from "~/components/UI/Toast";
 import { Event } from "~/lib/tracking";
 import { isValidPhone } from "~/lib/validateFields";
 import { allLanguesSelector, languei18nSelector } from "~/services/Langue/langue.selectors";
@@ -12,9 +13,11 @@ import API from "~/utils/API";
 
 const MobileAppSmsForm = () => {
   const { t } = useTranslation();
+  const announce = useAnnounce();
 
   const [phone, setPhone] = useState("");
   const [phoneError, setPhoneError] = useState("");
+  const [showToast, setShowToast] = useState(false);
   const [languageSelected, setLanguageSelected] = useState<string | undefined>(undefined);
   const languages = useSelector(allLanguesSelector);
   const locale = useSelector(languei18nSelector);
@@ -26,26 +29,30 @@ const MobileAppSmsForm = () => {
     }
   }, [languages, locale]);
 
+  // Le retour de soumission passe par le toast partagé plutôt que par une fenêtre
+  // SweetAlert2 : celle-ci déplaçait le focus, ce qui interdit de restituer le message
+  // sans déranger la navigation en cours (RGAA 7.5).
+  const failWith = (message: string) => {
+    setPhoneError(message);
+    announce(message, { priority: "interrupt" });
+  };
+
   const sendSMS = (e: any) => {
     setPhoneError("");
     e.preventDefault();
     if (isValidPhone(phone)) {
       API.smsDownloadApp({ phone, locale: languageSelected || "fr" })
         .then(() => {
-          Swal.fire({
-            title: "Yay...",
-            text: "SMS envoyé !",
-            icon: "success",
-            timer: 1500,
-          });
+          setShowToast(true);
+          announce(t("Dispositif.smsFormSent"));
           Event("SEND_SMS", "download app", "homepage");
           setPhone("");
         })
-        .catch((e) => {
-          setPhoneError("Une erreur s'est produite");
+        .catch(() => {
+          failWith(t("NewsletterForm.errorsSystemerror", "Une erreur s'est produite"));
         });
     } else {
-      setPhoneError(t("Register.invalid_phone_number"));
+      failWith(t("Register.invalid_phone_number"));
     }
   };
 
@@ -87,6 +94,10 @@ const MobileAppSmsForm = () => {
       >
         {t("MobileApp.buttonText", "Envoyer le lien")}
       </Button>
+
+      <Toast open={showToast} closeCallback={() => setShowToast(false)}>
+        {t("Dispositif.smsFormSent")}
+      </Toast>
     </form>
   );
 };

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
@@ -41,7 +41,6 @@ export const SectionUsers = () => {
                 aria-labelledby="users_legend_1"
               />
               <figcaption
-                aria-hidden="true"
                 id="users_legend_1"
                 className="text-small text-mention-grey text-center italic"
               >
@@ -77,7 +76,6 @@ export const SectionUsers = () => {
                 height={191}
               />
               <figcaption
-                aria-hidden="true"
                 id="users_legend_2"
                 className="text-small text-mention-grey text-center italic"
               >

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -129,10 +129,7 @@ const DispositifCard = (props: Props) => {
               <div className="mb-2 flex gap-2">
                 <NewThemeBadge theme={theme} />
                 {(props.dispositif.secondaryThemes?.length || 0) > 0 && (
-                  <NewThemeBadge
-                    aria-hidden="true"
-                    theme={props.dispositif.secondaryThemes?.length || 0}
-                  />
+                  <NewThemeBadge theme={props.dispositif.secondaryThemes?.length || 0} />
                 )}
               </div>
 

--- a/apps/client/src/components/UI/NewThemeBadge/NewThemeBadge.tsx
+++ b/apps/client/src/components/UI/NewThemeBadge/NewThemeBadge.tsx
@@ -1,6 +1,7 @@
 import type { GetThemeResponse } from "@refugies-info/api-types";
 import useLocale from "hooks/useLocale";
 import { cn } from "lib/classname";
+import { useTranslation } from "next-i18next";
 import type React from "react";
 import { useMemo } from "react";
 import styles from "./NewThemeBadge.module.scss";
@@ -11,6 +12,7 @@ interface Props extends React.HTMLAttributes<HTMLSpanElement> {
 
 export const NewThemeBadge = ({ theme, className, ...props }: Props) => {
   const locale = useLocale();
+  const { t } = useTranslation();
 
   const isPlusTag = useMemo(() => typeof theme === "number", [theme]);
   const themeText = useMemo(
@@ -29,6 +31,16 @@ export const NewThemeBadge = ({ theme, className, ...props }: Props) => {
       {...props}
     >
       {themeText}
+      {/* Le « +N » ne dit rien tout seul une fois vocalisé : on lui adjoint son unité,
+          visuellement masquée pour ne rien décaler (RGAA 10.8). */}
+      {isPlusTag && (
+        <>
+          {" "}
+          <span className="sr-only">
+            {t("ui.themeBadge", { count: theme as number, defaultValue: "autres thèmes" })}
+          </span>
+        </>
+      )}
     </span>
   );
 };

--- a/apps/client/src/components/UI/Toast/Toast.tsx
+++ b/apps/client/src/components/UI/Toast/Toast.tsx
@@ -2,6 +2,7 @@ import { ToastClose, ToastDescription, Toast as ToastRoot } from "@radix-ui/reac
 import type React from "react";
 import { cn } from "~/lib/classname";
 import styles from "./Toast.module.scss";
+import { useDeclareToast } from "./ToastPresence";
 
 interface Props {
   open: boolean;
@@ -11,6 +12,9 @@ interface Props {
 }
 
 const Toast = ({ open, children, type = "success", closeCallback }: Props) => {
+  // Le viewport n'est monté que si un toast est à afficher (RGAA 8.9).
+  useDeclareToast(open);
+
   const onOpenChange = (open: boolean) => {
     if (!open) closeCallback();
   };

--- a/apps/client/src/components/UI/Toast/Toast.tsx
+++ b/apps/client/src/components/UI/Toast/Toast.tsx
@@ -12,7 +12,7 @@ interface Props {
 }
 
 const Toast = ({ open, children, type = "success", closeCallback }: Props) => {
-  // Le viewport n'est monté que si un toast est à afficher (RGAA 8.9).
+  // The viewport is mounted only while a toast is shown (RGAA 8.9).
   useDeclareToast(open);
 
   const onOpenChange = (open: boolean) => {

--- a/apps/client/src/components/UI/Toast/ToastPresence.tsx
+++ b/apps/client/src/components/UI/Toast/ToastPresence.tsx
@@ -9,6 +9,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 
@@ -26,7 +27,14 @@ import {
  * puis se replace tout seul dans le portail dès qu'il est monté.
  */
 
-/** Laisse l'animation de fermeture se terminer avant de démonter le viewport. */
+/**
+ * Délai entre la fermeture d'un toast et le démontage du viewport, pour laisser
+ * l'animation de sortie se dérouler (`hide 100ms` dans `Toast.module.scss`).
+ *
+ * Le retrait de la clé est porté par la branche « fermé » de l'effet, jamais par
+ * son nettoyage : un nettoyage retirerait la clé dès le changement d'état et le
+ * délai n'existerait pas. Seul le démontage du composant retire immédiatement.
+ */
 const DUREE_SORTIE_MS = 300;
 
 /**
@@ -79,16 +87,49 @@ export const useDeclareToast = (open: boolean) => {
   useEffect(() => {
     if (open) {
       setToastOpen(cle, true);
-      return () => setToastOpen(cle, false);
+      return;
     }
     const timer = setTimeout(() => setToastOpen(cle, false), DUREE_SORTIE_MS);
     return () => clearTimeout(timer);
   }, [cle, open, setToastOpen]);
+
+  // Le démontage du composant, lui, retire la clé sans délai : il n'y a plus
+  // rien à animer. Cet effet est séparé pour que son nettoyage ne se déclenche
+  // pas au simple changement de `open`.
+  useEffect(() => () => setToastOpen(cle, false), [cle, setToastOpen]);
 };
 
-/** Viewport Radix, monté seulement quand au moins un toast est à afficher. */
+/**
+ * Viewport Radix, monté seulement quand au moins un toast est à afficher.
+ *
+ * Exception : on le garde monté tant qu'il porte le focus. À la fermeture d'un
+ * toast au clavier, Radix exécute `viewport?.focus()` ; démonter derrière lui
+ * ferait tomber le focus sur `<body>`. On attend donc que le focus soit sorti
+ * de la zone. C'est le comportement actuel de production dans ce seul cas, et
+ * la zone n'est alors pas un repère vide puisqu'elle porte le focus.
+ */
 export const ToastViewportWhenNeeded = (props: ComponentProps<typeof ToastViewport>) => {
   const { hasToasts } = useContext(ToastPresenceContext);
-  if (!hasToasts) return null;
-  return <ToastViewport {...props} />;
+  const [monte, setMonte] = useState(false);
+  const ref = useRef<HTMLOListElement>(null);
+
+  useEffect(() => {
+    if (hasToasts) {
+      setMonte(true);
+      return;
+    }
+    const zone = ref.current?.parentElement ?? ref.current;
+    if (!zone?.contains(document.activeElement)) {
+      setMonte(false);
+      return;
+    }
+    const surSortieDuFocus = (event: FocusEvent) => {
+      if (!zone.contains(event.relatedTarget as Node | null)) setMonte(false);
+    };
+    zone.addEventListener("focusout", surSortieDuFocus);
+    return () => zone.removeEventListener("focusout", surSortieDuFocus);
+  }, [hasToasts]);
+
+  if (!monte) return null;
+  return <ToastViewport ref={ref} {...props} />;
 };

--- a/apps/client/src/components/UI/Toast/ToastPresence.tsx
+++ b/apps/client/src/components/UI/Toast/ToastPresence.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { ToastViewport } from "@radix-ui/react-toast";
+import {
+  type ComponentProps,
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+/**
+ * Suivi des toasts ouverts, pour ne monter le viewport Radix que lorsqu'il sert.
+ *
+ * Sans ce garde-fou, `<ToastViewport>` rend en permanence un conteneur
+ * `<div role="region" aria-label="Notifications (F8)">` vide en fin de page.
+ * Les lecteurs d'écran l'annoncent comme un repère de navigation qui ne mène
+ * nulle part (RGAA 8.9, relevé Ideance sur la page d'accueil).
+ *
+ * Radix ne publie pas son compteur de toasts, on le tient donc nous-mêmes :
+ * chaque `<Toast>` déclare sa présence, et le viewport apparaît puis disparaît
+ * avec elle. `ToastImpl` de Radix rend `null` tant que le viewport n'existe pas,
+ * puis se replace tout seul dans le portail dès qu'il est monté.
+ */
+
+/** Laisse l'animation de fermeture se terminer avant de démonter le viewport. */
+const DUREE_SORTIE_MS = 300;
+
+/**
+ * L'identité d'un toast est un objet vide propre à l'instance, pas un `useId`.
+ * `useId` consommerait un créneau du compteur d'identifiants de React et
+ * décalerait ceux que DSFR génère en aval, ce qui change des identifiants
+ * rendus sans rien apporter.
+ */
+type CleToast = Record<string, never>;
+
+type ToastPresence = {
+  hasToasts: boolean;
+  setToastOpen: (cle: CleToast, open: boolean) => void;
+};
+
+/**
+ * Repli neutre hors provider : le harnais de test monte son propre viewport
+ * sans passer par `_app`, et ne doit pas casser pour autant.
+ */
+const REPLI: ToastPresence = { hasToasts: false, setToastOpen: () => {} };
+
+const ToastPresenceContext = createContext<ToastPresence>(REPLI);
+
+export const ToastPresenceProvider = ({ children }: { children: ReactNode }) => {
+  const [ouverts, setOuverts] = useState<ReadonlySet<CleToast>>(() => new Set());
+
+  const setToastOpen = useCallback((cle: CleToast, open: boolean) => {
+    setOuverts((prev) => {
+      if (open === prev.has(cle)) return prev;
+      const suivant = new Set(prev);
+      if (open) suivant.add(cle);
+      else suivant.delete(cle);
+      return suivant;
+    });
+  }, []);
+
+  const value = useMemo(
+    () => ({ hasToasts: ouverts.size > 0, setToastOpen }),
+    [ouverts, setToastOpen],
+  );
+
+  return <ToastPresenceContext.Provider value={value}>{children}</ToastPresenceContext.Provider>;
+};
+
+/** Déclare l'état d'un toast auprès du provider. */
+export const useDeclareToast = (open: boolean) => {
+  const { setToastOpen } = useContext(ToastPresenceContext);
+  const [cle] = useState<CleToast>(() => ({}));
+
+  useEffect(() => {
+    if (open) {
+      setToastOpen(cle, true);
+      return () => setToastOpen(cle, false);
+    }
+    const timer = setTimeout(() => setToastOpen(cle, false), DUREE_SORTIE_MS);
+    return () => clearTimeout(timer);
+  }, [cle, open, setToastOpen]);
+};
+
+/** Viewport Radix, monté seulement quand au moins un toast est à afficher. */
+export const ToastViewportWhenNeeded = (props: ComponentProps<typeof ToastViewport>) => {
+  const { hasToasts } = useContext(ToastPresenceContext);
+  if (!hasToasts) return null;
+  return <ToastViewport {...props} />;
+};

--- a/apps/client/src/components/UI/Toast/ToastPresence.tsx
+++ b/apps/client/src/components/UI/Toast/ToastPresence.tsx
@@ -14,122 +14,91 @@ import {
 } from "react";
 
 /**
- * Suivi des toasts ouverts, pour ne monter le viewport Radix que lorsqu'il sert.
- *
- * Sans ce garde-fou, `<ToastViewport>` rend en permanence un conteneur
- * `<div role="region" aria-label="Notifications (F8)">` vide en fin de page.
- * Les lecteurs d'écran l'annoncent comme un repère de navigation qui ne mène
- * nulle part (RGAA 8.9, relevé Ideance sur la page d'accueil).
- *
- * Radix ne publie pas son compteur de toasts, on le tient donc nous-mêmes :
- * chaque `<Toast>` déclare sa présence, et le viewport apparaît puis disparaît
- * avec elle. `ToastImpl` de Radix rend `null` tant que le viewport n'existe pas,
- * puis se replace tout seul dans le portail dès qu'il est monté.
+ * Radix renders an empty `<div role="region" aria-label="Notifications (F8)">` at all times.
+ * Screen readers announce it as a landmark leading nowhere (RGAA 8.9, Ideance audit).
+ * Radix exposes no toast count, so we track open toasts and mount the viewport only when needed.
  */
 
-/**
- * Délai entre la fermeture d'un toast et le démontage du viewport, pour laisser
- * l'animation de sortie se dérouler (`hide 100ms` dans `Toast.module.scss`).
- *
- * Le retrait de la clé est porté par la branche « fermé » de l'effet, jamais par
- * son nettoyage : un nettoyage retirerait la clé dès le changement d'état et le
- * délai n'existerait pas. Seul le démontage du composant retire immédiatement.
- */
-const DUREE_SORTIE_MS = 300;
+/** Leaves room for the `hide 100ms` exit animation in `Toast.module.scss`. */
+const EXIT_ANIMATION_MS = 300;
 
-/**
- * L'identité d'un toast est un objet vide propre à l'instance, pas un `useId`.
- * `useId` consommerait un créneau du compteur d'identifiants de React et
- * décalerait ceux que DSFR génère en aval, ce qui change des identifiants
- * rendus sans rien apporter.
- */
-type CleToast = Record<string, never>;
+/** An empty object, not `useId`: that would shift the ids DSFR generates downstream. */
+type ToastKey = Record<string, never>;
 
 type ToastPresence = {
   hasToasts: boolean;
-  setToastOpen: (cle: CleToast, open: boolean) => void;
+  setToastOpen: (key: ToastKey, open: boolean) => void;
 };
 
-/**
- * Repli neutre hors provider : le harnais de test monte son propre viewport
- * sans passer par `_app`, et ne doit pas casser pour autant.
- */
-const REPLI: ToastPresence = { hasToasts: false, setToastOpen: () => {} };
+/** Neutral fallback: the test harness mounts its own viewport without going through `_app`. */
+const FALLBACK: ToastPresence = { hasToasts: false, setToastOpen: () => {} };
 
-const ToastPresenceContext = createContext<ToastPresence>(REPLI);
+const ToastPresenceContext = createContext<ToastPresence>(FALLBACK);
 
 export const ToastPresenceProvider = ({ children }: { children: ReactNode }) => {
-  const [ouverts, setOuverts] = useState<ReadonlySet<CleToast>>(() => new Set());
+  const [openToasts, setOpenToasts] = useState<ReadonlySet<ToastKey>>(() => new Set());
 
-  const setToastOpen = useCallback((cle: CleToast, open: boolean) => {
-    setOuverts((prev) => {
-      if (open === prev.has(cle)) return prev;
-      const suivant = new Set(prev);
-      if (open) suivant.add(cle);
-      else suivant.delete(cle);
-      return suivant;
+  const setToastOpen = useCallback((key: ToastKey, open: boolean) => {
+    setOpenToasts((prev) => {
+      if (open === prev.has(key)) return prev;
+      const next = new Set(prev);
+      if (open) next.add(key);
+      else next.delete(key);
+      return next;
     });
   }, []);
 
   const value = useMemo(
-    () => ({ hasToasts: ouverts.size > 0, setToastOpen }),
-    [ouverts, setToastOpen],
+    () => ({ hasToasts: openToasts.size > 0, setToastOpen }),
+    [openToasts, setToastOpen],
   );
 
   return <ToastPresenceContext.Provider value={value}>{children}</ToastPresenceContext.Provider>;
 };
 
-/** Déclare l'état d'un toast auprès du provider. */
 export const useDeclareToast = (open: boolean) => {
   const { setToastOpen } = useContext(ToastPresenceContext);
-  const [cle] = useState<CleToast>(() => ({}));
+  const [key] = useState<ToastKey>(() => ({}));
 
   useEffect(() => {
     if (open) {
-      setToastOpen(cle, true);
+      setToastOpen(key, true);
       return;
     }
-    const timer = setTimeout(() => setToastOpen(cle, false), DUREE_SORTIE_MS);
+    const timer = setTimeout(() => setToastOpen(key, false), EXIT_ANIMATION_MS);
     return () => clearTimeout(timer);
-  }, [cle, open, setToastOpen]);
+  }, [key, open, setToastOpen]);
 
-  // Le démontage du composant, lui, retire la clé sans délai : il n'y a plus
-  // rien à animer. Cet effet est séparé pour que son nettoyage ne se déclenche
-  // pas au simple changement de `open`.
-  useEffect(() => () => setToastOpen(cle, false), [cle, setToastOpen]);
+  // Separate effect: unmount drops the key at once, and its cleanup must not run on `open` changes.
+  useEffect(() => () => setToastOpen(key, false), [key, setToastOpen]);
 };
 
 /**
- * Viewport Radix, monté seulement quand au moins un toast est à afficher.
- *
- * Exception : on le garde monté tant qu'il porte le focus. À la fermeture d'un
- * toast au clavier, Radix exécute `viewport?.focus()` ; démonter derrière lui
- * ferait tomber le focus sur `<body>`. On attend donc que le focus soit sorti
- * de la zone. C'est le comportement actuel de production dans ce seul cas, et
- * la zone n'est alors pas un repère vide puisqu'elle porte le focus.
+ * Stays mounted while it holds focus: Radix calls `viewport.focus()` when a toast is closed with
+ * the keyboard, and unmounting behind it would drop focus on `<body>`.
  */
 export const ToastViewportWhenNeeded = (props: ComponentProps<typeof ToastViewport>) => {
   const { hasToasts } = useContext(ToastPresenceContext);
-  const [monte, setMonte] = useState(false);
+  const [mounted, setMounted] = useState(false);
   const ref = useRef<HTMLOListElement>(null);
 
   useEffect(() => {
     if (hasToasts) {
-      setMonte(true);
+      setMounted(true);
       return;
     }
-    const zone = ref.current?.parentElement ?? ref.current;
-    if (!zone?.contains(document.activeElement)) {
-      setMonte(false);
+    const region = ref.current?.parentElement ?? ref.current;
+    if (!region?.contains(document.activeElement)) {
+      setMounted(false);
       return;
     }
-    const surSortieDuFocus = (event: FocusEvent) => {
-      if (!zone.contains(event.relatedTarget as Node | null)) setMonte(false);
+    const handleFocusOut = (event: FocusEvent) => {
+      if (!region.contains(event.relatedTarget as Node | null)) setMounted(false);
     };
-    zone.addEventListener("focusout", surSortieDuFocus);
-    return () => zone.removeEventListener("focusout", surSortieDuFocus);
+    region.addEventListener("focusout", handleFocusOut);
+    return () => region.removeEventListener("focusout", handleFocusOut);
   }, [hasToasts]);
 
-  if (!monte) return null;
+  if (!mounted) return null;
   return <ToastViewport ref={ref} {...props} />;
 };

--- a/apps/client/src/components/UI/Toast/__tests__/ToastPresence.test.tsx
+++ b/apps/client/src/components/UI/Toast/__tests__/ToastPresence.test.tsx
@@ -1,0 +1,86 @@
+import { ToastProvider } from "@radix-ui/react-toast";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import Toast from "../Toast";
+import { ToastPresenceProvider, ToastViewportWhenNeeded } from "../ToastPresence";
+
+/**
+ * Le harnais global (`jest/lib/wrapWithProvidersAndRender`) monte son propre
+ * `ToastViewport` sans le contexte de présence : il n'exerce jamais cette
+ * logique. Ces tests montent donc le vrai `ToastPresence`.
+ */
+
+const zoneDeNotifications = () =>
+  document.querySelector('[role="region"][aria-label^="Notifications"]');
+
+const attendre = (ms: number) =>
+  act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
+  });
+
+const Harnais = ({ ouvertAuDepart }: { ouvertAuDepart: boolean }) => {
+  const [open, setOpen] = useState(ouvertAuDepart);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Envoyer le lien
+      </button>
+      <ToastProvider swipeDirection="down">
+        <ToastPresenceProvider>
+          <Toast open={open} closeCallback={() => setOpen(false)}>
+            SMS envoyé !
+          </Toast>
+          <ToastViewportWhenNeeded />
+        </ToastPresenceProvider>
+      </ToastProvider>
+    </>
+  );
+};
+
+describe("ToastViewportWhenNeeded", () => {
+  it("ne monte pas la zone de notifications au repos", () => {
+    render(<Harnais ouvertAuDepart={false} />);
+    expect(zoneDeNotifications()).toBeNull();
+  });
+
+  it("monte la zone pendant l'affichage d'un toast", async () => {
+    render(<Harnais ouvertAuDepart={false} />);
+    fireEvent.click(screen.getByRole("button", { name: "Envoyer le lien" }));
+    await attendre(0);
+
+    expect(zoneDeNotifications()).not.toBeNull();
+    // getByText lève si le toast n'est pas rendu dans le portail du viewport.
+    expect(screen.getByText("SMS envoyé !")).toBeTruthy();
+  });
+
+  it("laisse l'animation de sortie se dérouler avant de démonter la zone", async () => {
+    render(<Harnais ouvertAuDepart={true} />);
+    await attendre(0);
+    expect(zoneDeNotifications()).not.toBeNull();
+
+    // Fermeture programmée, sans que le focus soit entré dans le toast.
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+
+    await attendre(100);
+    expect(zoneDeNotifications()).not.toBeNull(); // S1 : encore là à t+100
+
+    await attendre(350);
+    expect(zoneDeNotifications()).toBeNull(); // puis démontée
+  });
+
+  it("ne laisse pas tomber le focus sur body à la fermeture au clavier", async () => {
+    render(<Harnais ouvertAuDepart={true} />);
+    await attendre(0);
+
+    const fermer = screen.getByRole("button", { name: "Close" });
+    fermer.focus();
+    expect(document.activeElement).toBe(fermer);
+
+    fireEvent.click(fermer);
+    await attendre(450);
+
+    // S2 : Radix repose le focus sur le viewport, on ne démonte pas sous ses pieds.
+    expect(document.activeElement).not.toBe(document.body);
+    expect(zoneDeNotifications()).not.toBeNull();
+  });
+});

--- a/apps/client/src/components/UI/Toast/__tests__/ToastPresence.test.tsx
+++ b/apps/client/src/components/UI/Toast/__tests__/ToastPresence.test.tsx
@@ -5,21 +5,20 @@ import Toast from "../Toast";
 import { ToastPresenceProvider, ToastViewportWhenNeeded } from "../ToastPresence";
 
 /**
- * Le harnais global (`jest/lib/wrapWithProvidersAndRender`) monte son propre
- * `ToastViewport` sans le contexte de présence : il n'exerce jamais cette
- * logique. Ces tests montent donc le vrai `ToastPresence`.
+ * The global harness (`jest/lib/wrapWithProvidersAndRender`) mounts its own `ToastViewport` without
+ * the presence context, so it never exercises this logic. These tests mount the real one.
  */
 
-const zoneDeNotifications = () =>
+const notificationRegion = () =>
   document.querySelector('[role="region"][aria-label^="Notifications"]');
 
-const attendre = (ms: number) =>
+const advanceTime = (ms: number) =>
   act(async () => {
     await new Promise((resolve) => setTimeout(resolve, ms));
   });
 
-const Harnais = ({ ouvertAuDepart }: { ouvertAuDepart: boolean }) => {
-  const [open, setOpen] = useState(ouvertAuDepart);
+const Harness = ({ openAtStart }: { openAtStart: boolean }) => {
+  const [open, setOpen] = useState(openAtStart);
   return (
     <>
       <button type="button" onClick={() => setOpen(true)}>
@@ -38,49 +37,49 @@ const Harnais = ({ ouvertAuDepart }: { ouvertAuDepart: boolean }) => {
 };
 
 describe("ToastViewportWhenNeeded", () => {
-  it("ne monte pas la zone de notifications au repos", () => {
-    render(<Harnais ouvertAuDepart={false} />);
-    expect(zoneDeNotifications()).toBeNull();
+  it("should not mount the notification region at rest", () => {
+    render(<Harness openAtStart={false} />);
+    expect(notificationRegion()).toBeNull();
   });
 
-  it("monte la zone pendant l'affichage d'un toast", async () => {
-    render(<Harnais ouvertAuDepart={false} />);
+  it("should mount the region while a toast is shown", async () => {
+    render(<Harness openAtStart={false} />);
     fireEvent.click(screen.getByRole("button", { name: "Envoyer le lien" }));
-    await attendre(0);
+    await advanceTime(0);
 
-    expect(zoneDeNotifications()).not.toBeNull();
-    // getByText lève si le toast n'est pas rendu dans le portail du viewport.
+    expect(notificationRegion()).not.toBeNull();
+    // getByText throws if the toast is not rendered inside the viewport portal.
     expect(screen.getByText("SMS envoyé !")).toBeTruthy();
   });
 
-  it("laisse l'animation de sortie se dérouler avant de démonter la zone", async () => {
-    render(<Harnais ouvertAuDepart={true} />);
-    await attendre(0);
-    expect(zoneDeNotifications()).not.toBeNull();
+  it("should let the exit animation run before unmounting the region", async () => {
+    render(<Harness openAtStart={true} />);
+    await advanceTime(0);
+    expect(notificationRegion()).not.toBeNull();
 
-    // Fermeture programmée, sans que le focus soit entré dans le toast.
+    // Programmatic close, with focus never having entered the toast.
     fireEvent.click(screen.getByRole("button", { name: "Close" }));
 
-    await attendre(100);
-    expect(zoneDeNotifications()).not.toBeNull(); // S1 : encore là à t+100
+    await advanceTime(100);
+    expect(notificationRegion()).not.toBeNull(); // S1: still there at t+100
 
-    await attendre(350);
-    expect(zoneDeNotifications()).toBeNull(); // puis démontée
+    await advanceTime(350);
+    expect(notificationRegion()).toBeNull(); // then unmounted
   });
 
-  it("ne laisse pas tomber le focus sur body à la fermeture au clavier", async () => {
-    render(<Harnais ouvertAuDepart={true} />);
-    await attendre(0);
+  it("should not drop focus on body when closing with the keyboard", async () => {
+    render(<Harness openAtStart={true} />);
+    await advanceTime(0);
 
-    const fermer = screen.getByRole("button", { name: "Close" });
-    fermer.focus();
-    expect(document.activeElement).toBe(fermer);
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    closeButton.focus();
+    expect(document.activeElement).toBe(closeButton);
 
-    fireEvent.click(fermer);
-    await attendre(450);
+    fireEvent.click(closeButton);
+    await advanceTime(450);
 
-    // S2 : Radix repose le focus sur le viewport, on ne démonte pas sous ses pieds.
+    // S2: Radix puts focus back on the viewport, we do not unmount under its feet.
     expect(document.activeElement).not.toBe(document.body);
-    expect(zoneDeNotifications()).not.toBeNull();
+    expect(notificationRegion()).not.toBeNull();
   });
 });

--- a/apps/client/src/pages/_app.tsx
+++ b/apps/client/src/pages/_app.tsx
@@ -4,7 +4,7 @@ import "scss/index.scss";
 
 import { createNextDsfrIntegrationApi } from "@codegouvfr/react-dsfr/next-pagesdir";
 import { DirectionProvider } from "@radix-ui/react-direction";
-import { ToastProvider, ToastViewport } from "@radix-ui/react-toast";
+import { ToastProvider } from "@radix-ui/react-toast";
 import { TooltipProvider } from "@radix-ui/react-tooltip";
 import type { NextPage } from "next";
 import type { AppProps } from "next/app";
@@ -19,6 +19,10 @@ import { useEffectOnce } from "react-use";
 import toastStyles from "scss/components/toast.module.scss";
 import { ScreenReaderAnnouncerProvider } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import Layout from "~/components/Layout/Layout";
+import {
+  ToastPresenceProvider,
+  ToastViewportWhenNeeded,
+} from "~/components/UI/Toast/ToastPresence";
 import { useRTL, useScrollToAnchor } from "~/hooks";
 import { useConsent } from "~/hooks/useConsentContext";
 import { isContentPage } from "~/lib/isContentPage";
@@ -117,18 +121,19 @@ const App = ({ Component, ...pageProps }: AppPropsWithLayout) => {
   return (
     <DirectionProvider dir={isRTL ? "rtl" : "ltr"}>
       <ToastProvider swipeDirection="down">
-        <TooltipProvider delayDuration={250}>
-          <ScreenReaderAnnouncerProvider>
-            <Provider store={store}>
-              {getLayout(<Component history={history} {...props.pageProps} />)}
-            </Provider>
+        <ToastPresenceProvider>
+          <TooltipProvider delayDuration={250}>
+            <ScreenReaderAnnouncerProvider>
+              <Provider store={store}>
+                {getLayout(<Component history={history} {...props.pageProps} />)}
+              </Provider>
 
-            {options.supportModule && (
-              <Script
-                id="crisp-widget"
-                strategy="lazyOnload"
-                dangerouslySetInnerHTML={{
-                  __html: `
+              {options.supportModule && (
+                <Script
+                  id="crisp-widget"
+                  strategy="lazyOnload"
+                  dangerouslySetInnerHTML={{
+                    __html: `
         window.$crisp=[["safe", true]];
         window.CRISP_WEBSITE_ID="74e04b98-ef6b-4cb0-9daf-f8a2b643e121";
         (function(){
@@ -138,12 +143,13 @@ const App = ({ Component, ...pageProps }: AppPropsWithLayout) => {
           s.async = 1;
           d.getElementsByTagName("head")[0].appendChild(s);
         })();`,
-                }}
-              />
-            )}
-          </ScreenReaderAnnouncerProvider>
-        </TooltipProvider>
-        <ToastViewport className={toastStyles.viewport} dir={isRTL ? "rtl" : "ltr"} />
+                  }}
+                />
+              )}
+            </ScreenReaderAnnouncerProvider>
+          </TooltipProvider>
+          <ToastViewportWhenNeeded className={toastStyles.viewport} dir={isRTL ? "rtl" : "ltr"} />
+        </ToastPresenceProvider>
       </ToastProvider>
     </DirectionProvider>
   );


### PR DESCRIPTION
Audit RGAA Ideance, RGA-16. Le formulaire « Envoyez un lien de téléchargement » annonce maintenant son résultat aux lecteurs d'écran, les badges « +N » des cartes sont restitués, et les légendes des images de mission-et-impact redeviennent percevables. Seul changement visuel : la popup de confirmation SweetAlert2 est remplacée par le toast commun du site, qui ne vole pas le focus.

Deux clés nouvelles à verser au flux de traduction : `ui.themeBadge_one` et `ui.themeBadge_other` (français seulement, les autres clés utilisées existaient déjà en 8 langues).
