### PR TITLE
fix(a11y): annonce de changement de page et repositionnement du focus (RGAA 12.7, 12.8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ This document provides comprehensive guidance for AI agents (including Claude, C
 - Verify ARIA labels and roles are correct
 - Ensure every live page update is vocalised for assistive technologies
 - Always use the `useAnnounce` hook for centralized vocalisation of dynamic updates
+- Route change announcements and focus repositioning go through the route announcer paragraph (`useRouteAnnouncement` hook, `#route-announcer` in `_document.tsx`, RGAA 12.8 audit prescription); `useAnnounce` remains the rule for every other dynamic vocalisation
 
 ### II. Multilingual by Design
 

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -277,6 +277,7 @@
     "mapCopyAddress": "Copier l'adresse",
     "mapCopyPhone": "Copier le numéro de téléphone",
     "mapCopyEmail": "Copier l'adresse email",
+    "skipMap": "Passer la carte",
     "react": "Faire une suggestion d'amélioration",
     "reactFeedbackMessage": "Votre réaction a bien été enregistrée, merci !",
     "suggestionTitle": "Vous avez une suggestion ?",

--- a/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserFavorites/__tests__/__snapshots__/UserFavorites.component.test.tsx.snap
@@ -466,6 +466,7 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
         <article
           aria-labelledby="id1"
           class="[object Object]"
+          tabindex="-1"
         >
           <p
             class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
@@ -577,6 +578,7 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
         <article
           aria-labelledby="id2"
           class="[object Object]"
+          tabindex="-1"
         >
           <p
             class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"
@@ -688,6 +690,7 @@ exports[`UserFavorites should render correctly when 3 favorites 1`] = `
         <article
           aria-labelledby="id3"
           class="[object Object]"
+          tabindex="-1"
         >
           <p
             class="fr-badge fr-badge--sm fr-badge--no-icon $$typeof type props _owner _store"

--- a/apps/client/src/components/Content/Dispositif/Dispositif.tsx
+++ b/apps/client/src/components/Content/Dispositif/Dispositif.tsx
@@ -88,7 +88,18 @@ const Dispositif = (props: Props) => {
             ))}
             {/* TODO: adapt the Map component to be used in edit mode */}
             {isViewMode ? (
-              (dispositif?.map || []).length > 0 && <MapNew data={dispositif?.map || []} />
+              (dispositif?.map || []).length > 0 && (
+                <>
+                  <a
+                    href="#after-map"
+                    className="sr-only focus:not-sr-only focus:mb-4 focus:inline-block focus:underline"
+                  >
+                    {t("Dispositif.skipMap", "Passer la carte")}
+                  </a>
+                  <MapNew data={dispositif?.map || []} />
+                  <div id="after-map" tabIndex={-1} />
+                </>
+              )
             ) : (
               <MapEdit />
             )}

--- a/apps/client/src/components/Pages/auth/Layout/Layout.tsx
+++ b/apps/client/src/components/Pages/auth/Layout/Layout.tsx
@@ -63,6 +63,7 @@ const Layout = (props: Props) => {
       )}
       <div className={cls(!props.fullWidth && "flex max-lg:flex-col")}>
         <main
+          id="contenu"
           className={cls(
             styles.main,
             props.fullWidth && styles.full_width,

--- a/apps/client/src/components/Pages/dispositif/ShareButtons/ShareButtons.tsx
+++ b/apps/client/src/components/Pages/dispositif/ShareButtons/ShareButtons.tsx
@@ -97,7 +97,10 @@ const ShareButtons = ({ className }: { className?: string }) => {
       >
         <Button
           priority="tertiary no outline"
-          onClick={() => setShowSMS(false)}
+          onClick={() => {
+            setShowSMS(false);
+            closeButtonRef.current?.focus();
+          }}
           iconId="ri-close-line"
           className={cn("z-10 ml-auto", !showSMS && "!hidden")}
           size="small"

--- a/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
@@ -86,6 +86,10 @@ const Newsletter = () => {
           </div>
           <form
             onSubmit={sendMail}
+            // RGAA 12.8: once the success message replaced it, the collapsed form must not stay
+            // reachable by keyboard or screen reader. `inert` does that without killing the
+            // collapse transition that `display: none` would cut short.
+            inert={newsletterFormState === "success"}
             className={cls(
               "col-start-1 row-start-1 overflow-y-clip transition-all duration-200 ease-in",
               newsletterFormState === "success"

--- a/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchResults/SearchResults.tsx
@@ -1,7 +1,7 @@
 import Button from "@codegouvfr/react-dsfr/Button";
 import { useWindowSize } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
-import { memo, useEffect, useMemo, useRef } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { Container } from "reactstrap";
 import {
@@ -77,7 +77,18 @@ const SearchResults = (props: Props) => {
     }
   }, [pagination.page, remainingItems, announce, t]);
 
+  // RGAA 12.8 : after loading more results, move the focus to the first new card.
+  const firstNewCardRef = useRef<HTMLElement | null>(null);
+  const [focusIndex, setFocusIndex] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (focusIndex === null || dispositifs.length <= focusIndex) return;
+    firstNewCardRef.current?.focus();
+    setFocusIndex(null);
+  }, [focusIndex, dispositifs.length]);
+
   const handleSeeMore = () => {
+    setFocusIndex(dispositifs.length);
     announce(
       t("Recherche.loadingResults", "Chargement de {{count}} résultats...", {
         count: seeMoreCount,
@@ -149,10 +160,11 @@ const SearchResults = (props: Props) => {
             </h2>
 
             <div className={styles.results} id="resultats-liste">
-              {dispositifs.map((d) => (
+              {dispositifs.map((d, index) => (
                 <DispositifCard
                   className={styles.dispositifCard}
                   key={d._id.toString()}
+                  ref={index === focusIndex ? firstNewCardRef : undefined}
                   dispositif={d}
                   selectedDepartment={selectedDepartment}
                   targetBlank

--- a/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
+++ b/apps/client/src/components/UI/DispositifCard/DispositifCard.tsx
@@ -3,7 +3,7 @@ import { ContentType, type SimpleDispositif } from "@refugies-info/api-types";
 import { cn } from "@refugies-info/ui";
 import Link from "next/link";
 import { useTranslation } from "next-i18next";
-import { memo, useMemo } from "react";
+import { forwardRef, memo, useMemo } from "react";
 import { useSelector } from "react-redux";
 import defaultStructureImage from "~/assets/recherche/default-structure-image.svg";
 import demarcheIcon from "~/assets/recherche/illu-demarche.svg";
@@ -27,7 +27,7 @@ interface Props {
   className?: string;
 }
 
-const DispositifCard = (props: Props) => {
+const DispositifCard = forwardRef<HTMLElement, Props>((props, ref) => {
   const { t } = useTranslation();
   const locale = useLocale();
   const themes = useSelector(allThemesSelector);
@@ -80,6 +80,8 @@ const DispositifCard = (props: Props) => {
 
   return (
     <article
+      ref={ref}
+      tabIndex={-1}
       aria-labelledby={props.dispositif._id.toString()}
       className={cn(styles.wrapper, props.className, "fr-card fr-card--sm fr-enlarge-link")}
     >
@@ -205,7 +207,9 @@ const DispositifCard = (props: Props) => {
       </div>
     </article>
   );
-};
+});
+
+DispositifCard.displayName = "DispositifCard";
 
 const propsAreEqual = (prevProps: Props, nextProps: Props): boolean => {
   const prevDisp = prevProps.dispositif;

--- a/apps/client/src/components/UI/SkipLinksNavigation/SkipLinksNavigation.tsx
+++ b/apps/client/src/components/UI/SkipLinksNavigation/SkipLinksNavigation.tsx
@@ -1,7 +1,12 @@
 import { SkipLinks } from "@codegouvfr/react-dsfr/SkipLinks";
 import { useTranslation } from "next-i18next";
 
-const SkipLinksNavigation = () => {
+type Props = {
+  /** Screens without the main navigation and the footer (auth tunnel) must not offer those links. */
+  hasNavigationAndFooter?: boolean;
+};
+
+const SkipLinksNavigation = ({ hasNavigationAndFooter = true }: Props) => {
   const { t } = useTranslation();
   return (
     <SkipLinks
@@ -10,14 +15,18 @@ const SkipLinksNavigation = () => {
           anchor: "#contenu",
           label: t("SkipLinks.Contenu", "Aller au contenu"),
         },
-        {
-          anchor: "#main-navigation",
-          label: t("SkipLinks.Menu", "Menu"),
-        },
-        {
-          anchor: "#fr-footer",
-          label: t("SkipLinks.PiedDePage", "Pied de page"),
-        },
+        ...(hasNavigationAndFooter
+          ? [
+              {
+                anchor: "#main-navigation",
+                label: t("SkipLinks.Menu", "Menu"),
+              },
+              {
+                anchor: "#fr-footer",
+                label: t("SkipLinks.PiedDePage", "Pied de page"),
+              },
+            ]
+          : []),
       ]}
     />
   );

--- a/apps/client/src/hooks/index.ts
+++ b/apps/client/src/hooks/index.ts
@@ -11,6 +11,7 @@ export { default as useLogin } from "./useLogin";
 export { default as useOutsideClick } from "./useOutsideClick";
 export { default as useParamsFromHistory } from "./useParamsFromHistory";
 export { default as useRegisterFlow } from "./useRegisterFlow";
+export { default as useRouteAnnouncement } from "./useRouteAnnouncement";
 export { default as useRouterLocale } from "./useRouterLocale";
 export { default as useRTL } from "./useRTL";
 export { useRtriLinks } from "./useRtriLinks";

--- a/apps/client/src/hooks/useRouteAnnouncement.test.tsx
+++ b/apps/client/src/hooks/useRouteAnnouncement.test.tsx
@@ -1,6 +1,12 @@
 import { act, renderHook } from "@testing-library/react";
 import mockRouter from "next-router-mock";
-import useRouteAnnouncement, { ROUTE_ANNOUNCER_ID } from "./useRouteAnnouncement";
+import { createDynamicRouteParser } from "next-router-mock/dynamic-routes";
+import useRouteAnnouncement, {
+  clearAnchorNavigation,
+  markAnchorNavigation,
+  ROUTE_ANNOUNCER_ID,
+} from "./useRouteAnnouncement";
+import useScrollToAnchor from "./useScrollToAnchor";
 
 jest.mock("next/router", () => require("next-router-mock"));
 
@@ -35,8 +41,14 @@ describe("useRouteAnnouncement", () => {
     document.body.innerHTML = "";
     document.title = "";
     frameQueue = [];
+    clearAnchorNavigation();
+    window.history.pushState({}, "", "/");
     mockRouter.setCurrentUrl("/");
     mockRouter.locale = "fr";
+    // Sans ce parser, `router.pathname` vaudrait l'URL résolue et la
+    // comparaison au motif de route ne prouverait rien.
+    mockRouter.useParser(createDynamicRouteParser(["/demarche/[id]", "/dispositif/[id]"]));
+    window.scrollTo = jest.fn();
     jest.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
       frameQueue.push(callback);
       return frameQueue.length;
@@ -61,7 +73,9 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("AGIR pour les personnes réfugiées - Réfugiés.info");
     });
 
-    it("n'écrit rien au montage, sans navigation", () => {
+    it("n'écrit rien et ne déplace pas le focus au montage, sans navigation", () => {
+      // Couvre aussi la première visite où la modale de langue s'ouvre seule :
+      // aucune navigation n'a lieu, le hook ne touche à rien.
       const paragraph = addAnnouncer();
       document.title = "Réfugiés.info";
 
@@ -69,6 +83,7 @@ describe("useRouteAnnouncement", () => {
       flushFrames();
 
       expect(paragraph.textContent).toBe("");
+      expect(document.activeElement).not.toBe(paragraph);
     });
 
     it("restitue le contenu à chaque navigation, même vers un titre identique", async () => {
@@ -167,6 +182,7 @@ describe("useRouteAnnouncement", () => {
       flushFrames();
 
       expect(paragraph.textContent).toBe("");
+      expect(document.activeElement).not.toBe(paragraph);
     });
 
     it("annonce une navigation qui change de page et de locale à la fois", async () => {
@@ -248,6 +264,151 @@ describe("useRouteAnnouncement", () => {
       });
       flushFrames();
 
+      expect(paragraph.textContent).toBe("AGIR pour les personnes réfugiées - Réfugiés.info");
+    });
+  });
+
+  describe("repositionnement du focus", () => {
+    it("pose le focus sur le paragraphe après une navigation ordinaire, sans défilement", async () => {
+      const paragraph = addAnnouncer();
+      const focusSpy = jest.spyOn(paragraph, "focus");
+      renderHook(() => useRouteAnnouncement());
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      flushFrames();
+
+      expect(document.activeElement).toBe(paragraph);
+      // preventScroll : sans lui, le focus ferait remonter la page et
+      // détruirait la restauration de position au retour arrière (R16).
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+    });
+
+    it("ne déplace pas le focus sur une route à autofocus, mais synchronise le texte", async () => {
+      // Verdict VoiceOver du 26/08 : sur ces pages l'annonce du champ fait
+      // foi. Couvre aussi le cas du champ pas encore monté au moment du
+      // routeChangeComplete : le hook ne prend jamais le focus sur ces routes.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "Bienvenue - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/auth");
+      });
+      flushFrames();
+
+      expect(document.activeElement).not.toBe(paragraph);
+      expect(paragraph.textContent).toBe("Bienvenue - Réfugiés.info");
+    });
+
+    it("compare le motif de route, pas l'URL résolue, sur une route dynamique", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "Demander l'asile - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/demarche/63528e00976acb4f7bcd37ad");
+      });
+      flushFrames();
+
+      expect(mockRouter.pathname).toBe("/demarche/[id]");
+      expect(document.activeElement).toBe(paragraph);
+    });
+
+    it("refocalise le paragraphe à chaque navigation, même à titre identique", async () => {
+      // Geste de forçage : focus() sur un élément déjà focalisé n'émet rien.
+      // Le hook sort le focus puis le remet, un événement focus par navigation.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      const focusEvents = jest.fn();
+      paragraph.addEventListener("focus", focusEvents);
+      document.title = "Bienvenue - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/plan-du-site");
+      });
+      flushFrames();
+      expect(document.activeElement).toBe(paragraph);
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      flushFrames();
+
+      expect(document.activeElement).toBe(paragraph);
+      expect(focusEvents).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("drapeau d'ancre, partagé avec useScrollToAnchor", () => {
+    it("laisse le focus à la cible d'une ancre inter-pages, pas au paragraphe", async () => {
+      // Cas réel : lien newsletter du pied de page depuis /agir (R9).
+      window.history.pushState({}, "", "/agir");
+      const paragraph = addAnnouncer();
+      const target = document.createElement("div");
+      target.id = "newsletter";
+      document.body.appendChild(target);
+      renderHook(() => {
+        useScrollToAnchor();
+        useRouteAnnouncement();
+      });
+      document.title = "Réfugiés.info";
+
+      const anchor = document.createElement("a");
+      anchor.setAttribute("href", "/#newsletter");
+      document.body.appendChild(anchor);
+      await act(async () => {
+        anchor.click();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      flushFrames();
+
+      expect(document.activeElement).toBe(target);
+      expect(paragraph.textContent).toBe("");
+    });
+
+    it("consomme le drapeau : la navigation suivante retrouve le paragraphe", async () => {
+      // Sans remise à zéro, un drapeau collé éteindrait l'annonce du reste de
+      // la session.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+
+      markAnchorNavigation();
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      flushFrames();
+      expect(document.activeElement).not.toBe(paragraph);
+      expect(paragraph.textContent).toBe("");
+
+      await act(async () => {
+        await mockRouter.push("/plan-du-site");
+      });
+      document.title = "Plan du site - Réfugiés.info";
+      flushFrames();
+
+      expect(document.activeElement).toBe(paragraph);
+      expect(paragraph.textContent).toBe("Plan du site - Réfugiés.info");
+    });
+
+    it("un drapeau remis à zéro après un push rejeté n'affecte pas la navigation suivante", async () => {
+      // Le finally de useScrollToAnchor remet le drapeau à zéro même quand le
+      // push est annulé par une navigation concurrente.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+
+      markAnchorNavigation();
+      clearAnchorNavigation();
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      flushFrames();
+
+      expect(document.activeElement).toBe(paragraph);
       expect(paragraph.textContent).toBe("AGIR pour les personnes réfugiées - Réfugiés.info");
     });
   });

--- a/apps/client/src/hooks/useRouteAnnouncement.test.tsx
+++ b/apps/client/src/hooks/useRouteAnnouncement.test.tsx
@@ -11,9 +11,9 @@ import useScrollToAnchor from "./useScrollToAnchor";
 jest.mock("next/router", () => require("next-router-mock"));
 
 /**
- * Le hook attend le titre par `requestAnimationFrame`. On contrôle les trames
- * à la main pour pouvoir jouer les scénarios de chevauchement : chaque appel à
- * `flushFrames(1)` rejoue une trame, `flushFrames()` épuise la file.
+ * The hook waits for the title through `requestAnimationFrame`. Frames are
+ * driven by hand so the overlap scenarios can be replayed: each call to
+ * `flushFrames(1)` plays one frame, `flushFrames()` drains the queue.
  */
 let frameQueue: FrameRequestCallback[] = [];
 const flushFrames = (count = Number.POSITIVE_INFINITY) => {
@@ -45,8 +45,8 @@ describe("useRouteAnnouncement", () => {
     window.history.pushState({}, "", "/");
     mockRouter.setCurrentUrl("/");
     mockRouter.locale = "fr";
-    // Sans ce parser, `router.pathname` vaudrait l'URL résolue et la
-    // comparaison au motif de route ne prouverait rien.
+    // Without this parser, `router.pathname` would hold the resolved URL and
+    // comparing it to the route pattern would prove nothing.
     mockRouter.useParser(createDynamicRouteParser(["/demarche/[id]", "/dispositif/[id]"]));
     window.scrollTo = jest.fn();
     jest.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
@@ -59,8 +59,8 @@ describe("useRouteAnnouncement", () => {
     jest.restoreAllMocks();
   });
 
-  describe("annonce du titre", () => {
-    it("recopie exactement le document.title d'arrivée après une navigation", async () => {
+  describe("title announcement", () => {
+    it("copies the incoming document.title verbatim after a navigation", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -73,9 +73,9 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("AGIR pour les personnes réfugiées - Réfugiés.info");
     });
 
-    it("n'écrit rien et ne déplace pas le focus au montage, sans navigation", () => {
-      // Couvre aussi la première visite où la modale de langue s'ouvre seule :
-      // aucune navigation n'a lieu, le hook ne touche à rien.
+    it("writes nothing and does not move the focus on mount, without a navigation", () => {
+      // Also covers the first visit, where the language modal opens on its own:
+      // no navigation happens, the hook touches nothing.
       const paragraph = addAnnouncer();
       document.title = "Réfugiés.info";
 
@@ -86,9 +86,9 @@ describe("useRouteAnnouncement", () => {
       expect(document.activeElement).not.toBe(paragraph);
     });
 
-    it("restitue le contenu à chaque navigation, même vers un titre identique", async () => {
-      // Couple réel : /auth et /auth/inscription déclarent le même
-      // title="Bienvenue". Le paragraphe doit être réécrit à chaque fois.
+    it("re-announces the content on every navigation, even towards an identical title", async () => {
+      // Real pair: /auth and /auth/inscription both declare the same
+      // title="Bienvenue". The paragraph must be rewritten every time.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -106,14 +106,14 @@ describe("useRouteAnnouncement", () => {
       flushFrames();
 
       expect(paragraph.textContent).toBe("Bienvenue - Réfugiés.info");
-      // Le nœud texte a été posé à neuf : preuve du geste de forçage,
-      // sans lequel React/DOM ne restituerait rien sur un texte identique.
+      // The text node was set afresh: proof of the forcing gesture, without
+      // which React/DOM would announce nothing on an identical text.
       expect(paragraph.firstChild).not.toBe(firstTextNode);
     });
   });
 
-  describe("titre vide et routes sans <title>", () => {
-    it("n'écrit jamais un chemin d'URL, même quand le titre reste vide", async () => {
+  describe("empty title and routes without a <title>", () => {
+    it("never writes a URL path, even when the title stays empty", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -127,7 +127,7 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).not.toContain("/");
     });
 
-    it("écrit un repli humanisé tiré du motif de route quand le titre reste vide", async () => {
+    it("writes a humanized fallback derived from the route pattern when the title stays empty", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -139,7 +139,7 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("Download app");
     });
 
-    it("écrit le titre dès qu'il est posé, même s'il était momentanément vide", async () => {
+    it("writes the title as soon as it is set, even if it was momentarily empty", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -155,8 +155,8 @@ describe("useRouteAnnouncement", () => {
     });
   });
 
-  describe("gardes", () => {
-    it("ne fait rien sur une navigation superficielle (saisie dans la recherche)", async () => {
+  describe("guards", () => {
+    it("does nothing on a shallow navigation (typing in the search field)", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "Recherche - Réfugiés.info";
@@ -169,9 +169,9 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("");
     });
 
-    it("ne fait rien quand seule la locale change sur la même page", async () => {
-      // Cas réel : redirection de langue du premier chargement et validation
-      // de la modale de langue, un router.replace non superficiel.
+    it("does nothing when only the locale changes on the same page", async () => {
+      // Real case: first-load language redirect and language modal validation,
+      // a non-shallow router.replace.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "Réfugiés.info";
@@ -185,7 +185,7 @@ describe("useRouteAnnouncement", () => {
       expect(document.activeElement).not.toBe(paragraph);
     });
 
-    it("annonce une navigation qui change de page et de locale à la fois", async () => {
+    it("announces a navigation that changes both the page and the locale", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "Пландусайту - Réfugiés.info";
@@ -199,18 +199,18 @@ describe("useRouteAnnouncement", () => {
     });
   });
 
-  describe("navigations chevauchées", () => {
-    it("n'écrit pas après coup quand une navigation en chasse une autre", async () => {
-      // La première navigation attend son titre ; une seconde démarre avant la
-      // fin de l'attente. L'attente périmée ne doit plus rien écrire.
+  describe("overlapping navigations", () => {
+    it("does not write afterwards when a navigation supersedes another", async () => {
+      // The first navigation waits for its title; a second one starts before
+      // the wait ends. The stale wait must not write anything anymore.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
       await act(async () => {
         await mockRouter.push("/agir");
       });
-      // L'attente de /agir est en file, titre encore vide. Une seconde
-      // navigation démarre : le jeton de génération invalide l'attente.
+      // The /agir wait is queued, title still empty. A second navigation
+      // starts: the generation token invalidates the wait.
       mockRouter.events.emit("routeChangeStart", "/plan-du-site", { shallow: false });
       document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
       flushFrames();
@@ -218,7 +218,7 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("");
     });
 
-    it("seule la dernière de deux navigations rapprochées écrit", async () => {
+    it("only the last of two back-to-back navigations writes", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -235,8 +235,8 @@ describe("useRouteAnnouncement", () => {
     });
   });
 
-  describe("chemins d'erreur", () => {
-    it("ne lève pas quand le paragraphe est absent du DOM", async () => {
+  describe("error paths", () => {
+    it("does not throw when the paragraph is missing from the DOM", async () => {
       renderHook(() => useRouteAnnouncement());
       document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
 
@@ -247,7 +247,7 @@ describe("useRouteAnnouncement", () => {
       expect(() => flushFrames()).not.toThrow();
     });
 
-    it("garde le titre de la dernière navigation aboutie après un routeChangeError", async () => {
+    it("keeps the title of the last completed navigation after a routeChangeError", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
 
@@ -257,7 +257,7 @@ describe("useRouteAnnouncement", () => {
       });
       flushFrames();
 
-      // Une navigation démarre puis échoue : rien ne doit être réécrit.
+      // A navigation starts then fails: nothing must be rewritten.
       mockRouter.events.emit("routeChangeStart", "/plan-du-site", { shallow: false });
       mockRouter.events.emit("routeChangeError", new Error("cancelled"), "/plan-du-site", {
         shallow: false,
@@ -268,8 +268,8 @@ describe("useRouteAnnouncement", () => {
     });
   });
 
-  describe("repositionnement du focus", () => {
-    it("pose le focus sur le paragraphe après une navigation ordinaire, sans défilement", async () => {
+  describe("focus repositioning", () => {
+    it("focuses the paragraph after an ordinary navigation, without scrolling", async () => {
       const paragraph = addAnnouncer();
       const focusSpy = jest.spyOn(paragraph, "focus");
       renderHook(() => useRouteAnnouncement());
@@ -281,15 +281,15 @@ describe("useRouteAnnouncement", () => {
       flushFrames();
 
       expect(document.activeElement).toBe(paragraph);
-      // preventScroll : sans lui, le focus ferait remonter la page et
-      // détruirait la restauration de position au retour arrière (R16).
+      // preventScroll: without it, the focus would scroll the page back to the
+      // top and break the position restoration on browser back (R16).
       expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
     });
 
-    it("ne déplace pas le focus sur une route à autofocus, mais synchronise le texte", async () => {
-      // Verdict VoiceOver du 26/08 : sur ces pages l'annonce du champ fait
-      // foi. Couvre aussi le cas du champ pas encore monté au moment du
-      // routeChangeComplete : le hook ne prend jamais le focus sur ces routes.
+    it("does not move the focus on an autofocus route, but syncs the text", async () => {
+      // VoiceOver verdict of 26/08: on these pages the field announcement is
+      // authoritative. Also covers the case of a field not mounted yet at
+      // routeChangeComplete time: the hook never takes the focus on these routes.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "Bienvenue - Réfugiés.info";
@@ -303,7 +303,7 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("Bienvenue - Réfugiés.info");
     });
 
-    it("compare le motif de route, pas l'URL résolue, sur une route dynamique", async () => {
+    it("compares the route pattern, not the resolved URL, on a dynamic route", async () => {
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "Demander l'asile - Réfugiés.info";
@@ -317,9 +317,9 @@ describe("useRouteAnnouncement", () => {
       expect(document.activeElement).toBe(paragraph);
     });
 
-    it("refocalise le paragraphe à chaque navigation, même à titre identique", async () => {
-      // Geste de forçage : focus() sur un élément déjà focalisé n'émet rien.
-      // Le hook sort le focus puis le remet, un événement focus par navigation.
+    it("refocuses the paragraph on every navigation, even with an identical title", async () => {
+      // Forcing gesture: focus() on an already focused element emits nothing.
+      // The hook blurs then refocuses, one focus event per navigation.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       const focusEvents = jest.fn();
@@ -342,9 +342,9 @@ describe("useRouteAnnouncement", () => {
     });
   });
 
-  describe("drapeau d'ancre, partagé avec useScrollToAnchor", () => {
-    it("laisse le focus à la cible d'une ancre inter-pages, pas au paragraphe", async () => {
-      // Cas réel : lien newsletter du pied de page depuis /agir (R9).
+  describe("anchor flag, shared with useScrollToAnchor", () => {
+    it("leaves the focus on the target of an inter-page anchor, not on the paragraph", async () => {
+      // Real case: footer newsletter link from /agir (R9).
       window.history.pushState({}, "", "/agir");
       const paragraph = addAnnouncer();
       const target = document.createElement("div");
@@ -369,9 +369,9 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("");
     });
 
-    it("consomme le drapeau : la navigation suivante retrouve le paragraphe", async () => {
-      // Sans remise à zéro, un drapeau collé éteindrait l'annonce du reste de
-      // la session.
+    it("consumes the flag: the next navigation gets the paragraph back", async () => {
+      // Without the reset, a stuck flag would silence the announcement for the
+      // rest of the session.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
@@ -394,9 +394,9 @@ describe("useRouteAnnouncement", () => {
       expect(paragraph.textContent).toBe("Plan du site - Réfugiés.info");
     });
 
-    it("un drapeau remis à zéro après un push rejeté n'affecte pas la navigation suivante", async () => {
-      // Le finally de useScrollToAnchor remet le drapeau à zéro même quand le
-      // push est annulé par une navigation concurrente.
+    it("a flag cleared after a rejected push does not affect the next navigation", async () => {
+      // The finally in useScrollToAnchor clears the flag even when the push is
+      // cancelled by a concurrent navigation.
       const paragraph = addAnnouncer();
       renderHook(() => useRouteAnnouncement());
       document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
@@ -413,8 +413,8 @@ describe("useRouteAnnouncement", () => {
     });
   });
 
-  describe("nettoyage", () => {
-    it("retire l'abonnement au démontage", async () => {
+  describe("cleanup", () => {
+    it("removes the subscription on unmount", async () => {
       const paragraph = addAnnouncer();
       const { unmount } = renderHook(() => useRouteAnnouncement());
       unmount();

--- a/apps/client/src/hooks/useRouteAnnouncement.test.tsx
+++ b/apps/client/src/hooks/useRouteAnnouncement.test.tsx
@@ -2,9 +2,9 @@ import { act, renderHook } from "@testing-library/react";
 import mockRouter from "next-router-mock";
 import { createDynamicRouteParser } from "next-router-mock/dynamic-routes";
 import useRouteAnnouncement, {
-  clearAnchorNavigation,
   markAnchorNavigation,
   ROUTE_ANNOUNCER_ID,
+  unmarkAnchorNavigation,
 } from "./useRouteAnnouncement";
 import useScrollToAnchor from "./useScrollToAnchor";
 
@@ -41,7 +41,7 @@ describe("useRouteAnnouncement", () => {
     document.body.innerHTML = "";
     document.title = "";
     frameQueue = [];
-    clearAnchorNavigation();
+    unmarkAnchorNavigation();
     window.history.pushState({}, "", "/");
     mockRouter.setCurrentUrl("/");
     mockRouter.locale = "fr";
@@ -402,7 +402,7 @@ describe("useRouteAnnouncement", () => {
       document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
 
       markAnchorNavigation();
-      clearAnchorNavigation();
+      unmarkAnchorNavigation();
       await act(async () => {
         await mockRouter.push("/agir");
       });

--- a/apps/client/src/hooks/useRouteAnnouncement.test.tsx
+++ b/apps/client/src/hooks/useRouteAnnouncement.test.tsx
@@ -1,0 +1,270 @@
+import { act, renderHook } from "@testing-library/react";
+import mockRouter from "next-router-mock";
+import useRouteAnnouncement, { ROUTE_ANNOUNCER_ID } from "./useRouteAnnouncement";
+
+jest.mock("next/router", () => require("next-router-mock"));
+
+/**
+ * Le hook attend le titre par `requestAnimationFrame`. On contrôle les trames
+ * à la main pour pouvoir jouer les scénarios de chevauchement : chaque appel à
+ * `flushFrames(1)` rejoue une trame, `flushFrames()` épuise la file.
+ */
+let frameQueue: FrameRequestCallback[] = [];
+const flushFrames = (count = Number.POSITIVE_INFINITY) => {
+  let played = 0;
+  while (frameQueue.length > 0 && played < count) {
+    const callbacks = frameQueue;
+    frameQueue = [];
+    for (const callback of callbacks) callback(0);
+    played += 1;
+  }
+};
+
+const addAnnouncer = () => {
+  const paragraph = document.createElement("p");
+  paragraph.id = ROUTE_ANNOUNCER_ID;
+  paragraph.tabIndex = -1;
+  paragraph.className = "sr-only";
+  document.body.prepend(paragraph);
+  return paragraph;
+};
+
+describe("useRouteAnnouncement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+    document.title = "";
+    frameQueue = [];
+    mockRouter.setCurrentUrl("/");
+    mockRouter.locale = "fr";
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((callback) => {
+      frameQueue.push(callback);
+      return frameQueue.length;
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("annonce du titre", () => {
+    it("recopie exactement le document.title d'arrivée après une navigation", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("AGIR pour les personnes réfugiées - Réfugiés.info");
+    });
+
+    it("n'écrit rien au montage, sans navigation", () => {
+      const paragraph = addAnnouncer();
+      document.title = "Réfugiés.info";
+
+      renderHook(() => useRouteAnnouncement());
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("");
+    });
+
+    it("restitue le contenu à chaque navigation, même vers un titre identique", async () => {
+      // Couple réel : /auth et /auth/inscription déclarent le même
+      // title="Bienvenue". Le paragraphe doit être réécrit à chaque fois.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      document.title = "Bienvenue - Réfugiés.info";
+      await act(async () => {
+        await mockRouter.push("/auth");
+      });
+      flushFrames();
+      const firstTextNode = paragraph.firstChild;
+      expect(paragraph.textContent).toBe("Bienvenue - Réfugiés.info");
+
+      await act(async () => {
+        await mockRouter.push("/auth/inscription");
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("Bienvenue - Réfugiés.info");
+      // Le nœud texte a été posé à neuf : preuve du geste de forçage,
+      // sans lequel React/DOM ne restituerait rien sur un texte identique.
+      expect(paragraph.firstChild).not.toBe(firstTextNode);
+    });
+  });
+
+  describe("titre vide et routes sans <title>", () => {
+    it("n'écrit jamais un chemin d'URL, même quand le titre reste vide", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      await act(async () => {
+        await mockRouter.push("/download-app");
+      });
+      flushFrames(5);
+      expect(paragraph.textContent).not.toContain("/download-app");
+      flushFrames();
+
+      expect(paragraph.textContent).not.toContain("/");
+    });
+
+    it("écrit un repli humanisé tiré du motif de route quand le titre reste vide", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      await act(async () => {
+        await mockRouter.push("/download-app");
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("Download app");
+    });
+
+    it("écrit le titre dès qu'il est posé, même s'il était momentanément vide", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      await act(async () => {
+        await mockRouter.push("/plan-du-site");
+      });
+      flushFrames(2);
+      expect(paragraph.textContent).toBe("");
+      document.title = "Plan du site - Réfugiés.info";
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("Plan du site - Réfugiés.info");
+    });
+  });
+
+  describe("gardes", () => {
+    it("ne fait rien sur une navigation superficielle (saisie dans la recherche)", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "Recherche - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/recherche?search=logement", undefined, { shallow: true });
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("");
+    });
+
+    it("ne fait rien quand seule la locale change sur la même page", async () => {
+      // Cas réel : redirection de langue du premier chargement et validation
+      // de la modale de langue, un router.replace non superficiel.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/", undefined, { locale: "uk" });
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("");
+    });
+
+    it("annonce une navigation qui change de page et de locale à la fois", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+      document.title = "Пландусайту - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/plan-du-site", undefined, { locale: "uk" });
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("Пландусайту - Réfugiés.info");
+    });
+  });
+
+  describe("navigations chevauchées", () => {
+    it("n'écrit pas après coup quand une navigation en chasse une autre", async () => {
+      // La première navigation attend son titre ; une seconde démarre avant la
+      // fin de l'attente. L'attente périmée ne doit plus rien écrire.
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      // L'attente de /agir est en file, titre encore vide. Une seconde
+      // navigation démarre : le jeton de génération invalide l'attente.
+      mockRouter.events.emit("routeChangeStart", "/plan-du-site", { shallow: false });
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("");
+    });
+
+    it("seule la dernière de deux navigations rapprochées écrit", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      await act(async () => {
+        await mockRouter.push("/plan-du-site");
+      });
+      document.title = "Plan du site - Réfugiés.info";
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("Plan du site - Réfugiés.info");
+    });
+  });
+
+  describe("chemins d'erreur", () => {
+    it("ne lève pas quand le paragraphe est absent du DOM", async () => {
+      renderHook(() => useRouteAnnouncement());
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+
+      expect(() => flushFrames()).not.toThrow();
+    });
+
+    it("garde le titre de la dernière navigation aboutie après un routeChangeError", async () => {
+      const paragraph = addAnnouncer();
+      renderHook(() => useRouteAnnouncement());
+
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      flushFrames();
+
+      // Une navigation démarre puis échoue : rien ne doit être réécrit.
+      mockRouter.events.emit("routeChangeStart", "/plan-du-site", { shallow: false });
+      mockRouter.events.emit("routeChangeError", new Error("cancelled"), "/plan-du-site", {
+        shallow: false,
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("AGIR pour les personnes réfugiées - Réfugiés.info");
+    });
+  });
+
+  describe("nettoyage", () => {
+    it("retire l'abonnement au démontage", async () => {
+      const paragraph = addAnnouncer();
+      const { unmount } = renderHook(() => useRouteAnnouncement());
+      unmount();
+      document.title = "AGIR pour les personnes réfugiées - Réfugiés.info";
+
+      await act(async () => {
+        await mockRouter.push("/agir");
+      });
+      flushFrames();
+
+      expect(paragraph.textContent).toBe("");
+    });
+  });
+});

--- a/apps/client/src/hooks/useRouteAnnouncement.ts
+++ b/apps/client/src/hooks/useRouteAnnouncement.ts
@@ -47,7 +47,7 @@ export const markAnchorNavigation = () => {
   anchorNavigationInProgress = true;
 };
 
-export const clearAnchorNavigation = () => {
+export const unmarkAnchorNavigation = () => {
   anchorNavigationInProgress = false;
 };
 

--- a/apps/client/src/hooks/useRouteAnnouncement.ts
+++ b/apps/client/src/hooks/useRouteAnnouncement.ts
@@ -18,6 +18,52 @@ export const ROUTE_ANNOUNCER_ID = "route-announcer";
 const TITLE_WAIT_MAX_FRAMES = 30;
 
 /**
+ * Routes disposant d'un autofocus de page. Verdict de la mesure VoiceOver du
+ * 26/08 : sur ces pages, poser le focus sur le paragraphe le vole au champ
+ * autofocalisé ; l'annonce du champ fait foi, le paragraphe est synchronisé
+ * mais ne reçoit ni focus ni annonce. Liste centralisée, exprimée en
+ * `router.pathname`, un commentaire par entrée citant la déclaration
+ * d'autofocus et son statut de mesure (mesuré ou seulement déclaré).
+ * Procédure de mise à jour : documentation/client/accessibility/voiceover.md.
+ */
+const AUTOFOCUS_ROUTE_PATTERNS = new Set([
+  // src/pages/auth/index.tsx l.162 — mesuré le 25/08 (focus posé sur le champ email)
+  "/auth",
+  // src/pages/auth/connexion.tsx l.97 — déclaré, non mesuré (redirige vers /fr/auth sans session)
+  "/auth/connexion",
+  // src/pages/auth/inscription/index.tsx l.112 — déclaré, non mesuré (redirige sans session)
+  "/auth/inscription",
+  // src/components/User/EditPseudo/EditPseudo.tsx l.62 — déclaré, non mesuré (redirige sans session)
+  "/auth/inscription/pseudo",
+  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 — déclaré, non mesuré (redirige sans session)
+  "/auth/code-connexion",
+  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 — déclaré, non mesuré (redirige sans session)
+  "/auth/code-securite",
+  // src/components/User/ForgotPassword/ForgotPassword.tsx l.44 — mesuré le 25/08 (focus posé)
+  "/auth/reinitialiser-mot-de-passe",
+  // src/pages/auth/reinitialiser-mot-de-passe/nouveau.tsx l.122 et l.134 — déclaré ;
+  // mesuré le 25/08 SANS focus posé, conservé par prudence tant que l'écart n'est pas expliqué
+  "/auth/reinitialiser-mot-de-passe/nouveau",
+]);
+
+/**
+ * Drapeau de navigation par ancre, partagé avec `useScrollToAnchor` : quand une
+ * ancre inter-pages déclenche un `router.push`, la cible de l'ancre garde le
+ * focus et le paragraphe ne s'en mêle pas. Posé avant le `push`, consommé au
+ * `routeChangeComplete`, remis à zéro dans un `finally` sur la promesse du
+ * `push` pour qu'une navigation annulée ne laisse pas un drapeau collé.
+ */
+let anchorNavigationInProgress = false;
+
+export const markAnchorNavigation = () => {
+  anchorNavigationInProgress = true;
+};
+
+export const clearAnchorNavigation = () => {
+  anchorNavigationInProgress = false;
+};
+
+/**
  * Repli lisible pour les routes servies sans `<title>` (mesurées :
  * `/download-app`, `/embed`, `/dispositif`, `/demarche`). On humanise le motif
  * de route plutôt que d'annoncer un chemin d'URL brut ou de focaliser un
@@ -36,32 +82,44 @@ const humanizeRoutePattern = (pathname: string): string => {
   return label.charAt(0).toUpperCase() + label.slice(1);
 };
 
-const writeAnnouncement = (text: string) => {
+const writeAnnouncement = (text: string, moveFocus: boolean) => {
   const paragraph = document.getElementById(ROUTE_ANNOUNCER_ID);
   if (!paragraph) return;
   // Geste de forçage : deux navigations de suite vers un titre identique
   // (`/auth` puis `/auth/inscription`, deux pages en `title="Bienvenue"`)
-  // doivent être restituées toutes les deux. On vide puis on réécrit pour que
-  // le contenu soit posé à neuf à chaque navigation.
+  // doivent être restituées toutes les deux. Or `focus()` sur un élément déjà
+  // focalisé n'émet rien : on sort le focus et on vide le paragraphe avant de
+  // réécrire puis refocaliser, pour que la restitution reparte à neuf.
+  if (document.activeElement === paragraph) paragraph.blur();
   paragraph.textContent = "";
   paragraph.textContent = text;
+  // `preventScroll` : la classe sr-only ne fixant ni top ni left, un focus
+  // défilant ferait remonter la page et détruirait la restauration de position
+  // au retour arrière navigateur. Motif maison de useScrollToAnchor.
+  if (moveFocus) paragraph.focus({ preventScroll: true });
 };
 
 /**
- * Annonce le changement de page lors des navigations client (RGAA 12.8).
+ * Annonce le changement de page et repositionne le focus lors des navigations
+ * client (RGAA 12.8).
  *
  * Mécanique prescrite par l'audit Ideance : un paragraphe `sr-only` avec
  * `tabindex="-1"` en tête de `<body>` (posé par `_document.tsx`), synchronisé
- * avec le `<title>` de la page d'arrivée. L'annonceur natif de Next
- * (`<next-route-announcer>`) est neutralisé par CSS dans `_dsfr-fix.scss`.
+ * avec le `<title>` de la page d'arrivée et focalisé à chaque navigation.
+ * L'annonceur natif de Next (`<next-route-announcer>`) est neutralisé par CSS
+ * dans `_dsfr-fix.scss`.
  *
  * Gardes :
  * - navigations superficielles ignorées (saisie dans le champ de recherche) ;
  * - changement de locale seul ignoré (redirection de langue du premier
  *   chargement, validation de la modale de langue) ;
  * - attente du titre annulée si une autre navigation démarre (jeton de
- *   génération) : seule la dernière navigation écrit ;
+ *   génération) : seule la dernière navigation écrit et focalise ;
  * - route sans `<title>` : repli humanisé tiré du motif de route.
+ *
+ * Le focus ne se dispute jamais avec un autre mécanisme : la modale de langue
+ * du premier chargement, l'autofocus de page (liste centralisée ci-dessus) et
+ * la cible d'une ancre (`useScrollToAnchor`, drapeau partagé) le gardent.
  *
  * @example
  * // Use inside _app.tsx
@@ -88,15 +146,18 @@ const useRouteAnnouncement = () => {
       let frames = 0;
       const tick = () => {
         if (generationRef.current !== generation) return; // attente périmée
+        // Le focus ne se dispute jamais avec l'autofocus d'une page : sur ces
+        // routes, le paragraphe est synchronisé sans être focalisé.
+        const moveFocus = !AUTOFOCUS_ROUTE_PATTERNS.has(Router.pathname);
         const title = document.title;
         if (title) {
-          writeAnnouncement(title);
+          writeAnnouncement(title, moveFocus);
           return;
         }
         frames += 1;
         if (frames >= TITLE_WAIT_MAX_FRAMES) {
           const fallback = humanizeRoutePattern(Router.pathname);
-          if (fallback) writeAnnouncement(fallback);
+          if (fallback) writeAnnouncement(fallback, moveFocus);
           return;
         }
         window.requestAnimationFrame(tick);
@@ -111,6 +172,14 @@ const useRouteAnnouncement = () => {
       // Navigation superficielle : la recherche pousse une navigation shallow
       // débouncée à chaque frappe, qui ne change pas de page.
       if (shallow) return;
+
+      // Navigation issue d'une ancre inter-pages (`/#newsletter` depuis le pied
+      // de page) : la cible de l'ancre garde le focus, rien à annoncer ici.
+      // Le drapeau est consommé, la navigation suivante redevient ordinaire.
+      if (anchorNavigationInProgress) {
+        anchorNavigationInProgress = false;
+        return;
+      }
 
       // Seule la locale change sur la même page : redirection de langue du
       // premier chargement (Layout.tsx), validation de la modale de langue.

--- a/apps/client/src/hooks/useRouteAnnouncement.ts
+++ b/apps/client/src/hooks/useRouteAnnouncement.ts
@@ -13,26 +13,29 @@ const TITLE_WAIT_MAX_FRAMES = 30;
 
 /**
  * Routes whose page sets its own autofocus: the paragraph stays in sync but is
- * never focused, otherwise it steals the focus from the field. Update procedure
- * in documentation/client/accessibility/voiceover.md.
+ * never focused, otherwise it steals the focus from the field. Each entry
+ * carries the file:line (under src/) that declares the autofocus and whether
+ * the focus was measured in a browser or is only declared in the code (the
+ * "declared only" routes redirect to /fr/auth without a session). A route
+ * measured with no focus set is kept as a precaution until the gap is
+ * explained. Update procedure in documentation/client/accessibility/voiceover.md.
  */
 const AUTOFOCUS_ROUTE_PATTERNS = new Set([
-  // src/pages/auth/index.tsx l.162 - measured 25/08 (focus set on the email field)
+  // pages/auth/index.tsx:162, measured 25/08
   "/auth",
-  // src/pages/auth/connexion.tsx l.97 - declared, not measured (redirects to /fr/auth without a session)
+  // pages/auth/connexion.tsx:97, declared only
   "/auth/connexion",
-  // src/pages/auth/inscription/index.tsx l.112 - declared, not measured (redirects without a session)
+  // pages/auth/inscription/index.tsx:112, declared only
   "/auth/inscription",
-  // src/components/User/EditPseudo/EditPseudo.tsx l.62 - declared, not measured (redirects without a session)
+  // components/User/EditPseudo/EditPseudo.tsx:62, declared only
   "/auth/inscription/pseudo",
-  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 - declared, not measured (redirects without a session)
+  // components/Pages/auth/CheckCode/CheckCode.tsx:128, declared only
   "/auth/code-connexion",
-  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 - declared, not measured (redirects without a session)
+  // components/Pages/auth/CheckCode/CheckCode.tsx:128, declared only
   "/auth/code-securite",
-  // src/components/User/ForgotPassword/ForgotPassword.tsx l.44 - measured 25/08 (focus set)
+  // components/User/ForgotPassword/ForgotPassword.tsx:44, measured 25/08
   "/auth/reinitialiser-mot-de-passe",
-  // src/pages/auth/reinitialiser-mot-de-passe/nouveau.tsx l.122 and l.134 - declared;
-  // measured 25/08 with NO focus set, kept as a precaution until the gap is explained
+  // pages/auth/reinitialiser-mot-de-passe/nouveau.tsx:122 and :134, measured 25/08, no focus set
   "/auth/reinitialiser-mot-de-passe/nouveau",
 ]);
 

--- a/apps/client/src/hooks/useRouteAnnouncement.ts
+++ b/apps/client/src/hooks/useRouteAnnouncement.ts
@@ -1,5 +1,6 @@
 import Router, { useRouter } from "next/router";
 import { useEffect, useRef } from "react";
+import { humanizeRoutePattern } from "~/lib/humanizeRoutePattern";
 
 /**
  * Identifiant du paragraphe d'annonce posé tout en haut du `<body>` par
@@ -61,25 +62,6 @@ export const markAnchorNavigation = () => {
 
 export const clearAnchorNavigation = () => {
   anchorNavigationInProgress = false;
-};
-
-/**
- * Repli lisible pour les routes servies sans `<title>` (mesurées :
- * `/download-app`, `/embed`, `/dispositif`, `/demarche`). On humanise le motif
- * de route plutôt que d'annoncer un chemin d'URL brut ou de focaliser un
- * paragraphe vide (RGAA 12.8, R14/D13). Aucune clé i18n : le motif de route
- * est le seul libellé disponible sans traduction.
- */
-const humanizeRoutePattern = (pathname: string): string => {
-  const label = pathname
-    .replace(/[[\]]|\.{3}/g, "")
-    .split("/")
-    .filter(Boolean)
-    .join(" ")
-    .replace(/-/g, " ")
-    .trim();
-  if (!label) return "";
-  return label.charAt(0).toUpperCase() + label.slice(1);
 };
 
 const writeAnnouncement = (text: string, moveFocus: boolean) => {

--- a/apps/client/src/hooks/useRouteAnnouncement.ts
+++ b/apps/client/src/hooks/useRouteAnnouncement.ts
@@ -1,0 +1,134 @@
+import Router, { useRouter } from "next/router";
+import { useEffect, useRef } from "react";
+
+/**
+ * Identifiant du paragraphe d'annonce posé tout en haut du `<body>` par
+ * `_document.tsx`. Partagé pour que le hook et le document restent alignés.
+ */
+export const ROUTE_ANNOUNCER_ID = "route-announcer";
+
+/**
+ * Nombre maximal de trames d'attente du `<title>` après `routeChangeComplete`.
+ * Le titre est posé par `next/head` dans le même cycle de rendu, mais il peut
+ * être momentanément vide pendant une transition (mesuré sur les redirections
+ * du parcours auth). À 60 Hz cela laisse ~500 ms, à 120 Hz ~250 ms : dans les
+ * deux cas plus que les 128 ms mesurées avant qu'une redirection chasse la
+ * navigation en cours et invalide l'attente.
+ */
+const TITLE_WAIT_MAX_FRAMES = 30;
+
+/**
+ * Repli lisible pour les routes servies sans `<title>` (mesurées :
+ * `/download-app`, `/embed`, `/dispositif`, `/demarche`). On humanise le motif
+ * de route plutôt que d'annoncer un chemin d'URL brut ou de focaliser un
+ * paragraphe vide (RGAA 12.8, R14/D13). Aucune clé i18n : le motif de route
+ * est le seul libellé disponible sans traduction.
+ */
+const humanizeRoutePattern = (pathname: string): string => {
+  const label = pathname
+    .replace(/[[\]]|\.{3}/g, "")
+    .split("/")
+    .filter(Boolean)
+    .join(" ")
+    .replace(/-/g, " ")
+    .trim();
+  if (!label) return "";
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+const writeAnnouncement = (text: string) => {
+  const paragraph = document.getElementById(ROUTE_ANNOUNCER_ID);
+  if (!paragraph) return;
+  // Geste de forçage : deux navigations de suite vers un titre identique
+  // (`/auth` puis `/auth/inscription`, deux pages en `title="Bienvenue"`)
+  // doivent être restituées toutes les deux. On vide puis on réécrit pour que
+  // le contenu soit posé à neuf à chaque navigation.
+  paragraph.textContent = "";
+  paragraph.textContent = text;
+};
+
+/**
+ * Annonce le changement de page lors des navigations client (RGAA 12.8).
+ *
+ * Mécanique prescrite par l'audit Ideance : un paragraphe `sr-only` avec
+ * `tabindex="-1"` en tête de `<body>` (posé par `_document.tsx`), synchronisé
+ * avec le `<title>` de la page d'arrivée. L'annonceur natif de Next
+ * (`<next-route-announcer>`) est neutralisé par CSS dans `_dsfr-fix.scss`.
+ *
+ * Gardes :
+ * - navigations superficielles ignorées (saisie dans le champ de recherche) ;
+ * - changement de locale seul ignoré (redirection de langue du premier
+ *   chargement, validation de la modale de langue) ;
+ * - attente du titre annulée si une autre navigation démarre (jeton de
+ *   génération) : seule la dernière navigation écrit ;
+ * - route sans `<title>` : repli humanisé tiré du motif de route.
+ *
+ * @example
+ * // Use inside _app.tsx
+ * useRouteAnnouncement();
+ */
+const useRouteAnnouncement = () => {
+  const router = useRouter();
+  const generationRef = useRef(0);
+  const lastRouteRef = useRef<{ pathname: string; locale?: string }>({
+    pathname: "",
+    locale: undefined,
+  });
+
+  useEffect(() => {
+    lastRouteRef.current = { pathname: Router.pathname, locale: Router.locale };
+
+    // Jeton de génération : toute navigation qui en chasse une autre rend
+    // l'attente de titre de la précédente périmée, sans écriture après coup.
+    const handleRouteChangeStart = () => {
+      generationRef.current += 1;
+    };
+
+    const waitForTitle = (generation: number) => {
+      let frames = 0;
+      const tick = () => {
+        if (generationRef.current !== generation) return; // attente périmée
+        const title = document.title;
+        if (title) {
+          writeAnnouncement(title);
+          return;
+        }
+        frames += 1;
+        if (frames >= TITLE_WAIT_MAX_FRAMES) {
+          const fallback = humanizeRoutePattern(Router.pathname);
+          if (fallback) writeAnnouncement(fallback);
+          return;
+        }
+        window.requestAnimationFrame(tick);
+      };
+      window.requestAnimationFrame(tick);
+    };
+
+    const handleRouteChangeComplete = (_url: string, { shallow }: { shallow: boolean }) => {
+      const previous = lastRouteRef.current;
+      lastRouteRef.current = { pathname: Router.pathname, locale: Router.locale };
+
+      // Navigation superficielle : la recherche pousse une navigation shallow
+      // débouncée à chaque frappe, qui ne change pas de page.
+      if (shallow) return;
+
+      // Seule la locale change sur la même page : redirection de langue du
+      // premier chargement (Layout.tsx), validation de la modale de langue.
+      // Ce n'est pas un changement de page, rien à annoncer.
+      if (Router.locale !== previous.locale && Router.pathname === previous.pathname) return;
+
+      waitForTitle(generationRef.current);
+    };
+
+    router.events.on("routeChangeStart", handleRouteChangeStart);
+    router.events.on("routeChangeComplete", handleRouteChangeComplete);
+    return () => {
+      router.events.off("routeChangeStart", handleRouteChangeStart);
+      router.events.off("routeChangeComplete", handleRouteChangeComplete);
+    };
+    // Abonnement unique au montage, même motif que les abonnements de _app.tsx.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+};
+
+export default useRouteAnnouncement;

--- a/apps/client/src/hooks/useRouteAnnouncement.ts
+++ b/apps/client/src/hooks/useRouteAnnouncement.ts
@@ -2,57 +2,44 @@ import Router, { useRouter } from "next/router";
 import { useEffect, useRef } from "react";
 import { humanizeRoutePattern } from "~/lib/humanizeRoutePattern";
 
-/**
- * Identifiant du paragraphe d'annonce posé tout en haut du `<body>` par
- * `_document.tsx`. Partagé pour que le hook et le document restent alignés.
- */
+/** Id of the announcer paragraph, shared with `_document.tsx` which renders it. */
 export const ROUTE_ANNOUNCER_ID = "route-announcer";
 
 /**
- * Nombre maximal de trames d'attente du `<title>` après `routeChangeComplete`.
- * Le titre est posé par `next/head` dans le même cycle de rendu, mais il peut
- * être momentanément vide pendant une transition (mesuré sur les redirections
- * du parcours auth). À 60 Hz cela laisse ~500 ms, à 120 Hz ~250 ms : dans les
- * deux cas plus que les 128 ms mesurées avant qu'une redirection chasse la
- * navigation en cours et invalide l'attente.
+ * Frame budget for the `<title>` wait. Frames, not a timer: the title lands
+ * with the render cycle. See voiceover.md for the measured values.
  */
 const TITLE_WAIT_MAX_FRAMES = 30;
 
 /**
- * Routes disposant d'un autofocus de page. Verdict de la mesure VoiceOver du
- * 26/08 : sur ces pages, poser le focus sur le paragraphe le vole au champ
- * autofocalisé ; l'annonce du champ fait foi, le paragraphe est synchronisé
- * mais ne reçoit ni focus ni annonce. Liste centralisée, exprimée en
- * `router.pathname`, un commentaire par entrée citant la déclaration
- * d'autofocus et son statut de mesure (mesuré ou seulement déclaré).
- * Procédure de mise à jour : documentation/client/accessibility/voiceover.md.
+ * Routes whose page sets its own autofocus: the paragraph stays in sync but is
+ * never focused, otherwise it steals the focus from the field. Update procedure
+ * in documentation/client/accessibility/voiceover.md.
  */
 const AUTOFOCUS_ROUTE_PATTERNS = new Set([
-  // src/pages/auth/index.tsx l.162 — mesuré le 25/08 (focus posé sur le champ email)
+  // src/pages/auth/index.tsx l.162 - measured 25/08 (focus set on the email field)
   "/auth",
-  // src/pages/auth/connexion.tsx l.97 — déclaré, non mesuré (redirige vers /fr/auth sans session)
+  // src/pages/auth/connexion.tsx l.97 - declared, not measured (redirects to /fr/auth without a session)
   "/auth/connexion",
-  // src/pages/auth/inscription/index.tsx l.112 — déclaré, non mesuré (redirige sans session)
+  // src/pages/auth/inscription/index.tsx l.112 - declared, not measured (redirects without a session)
   "/auth/inscription",
-  // src/components/User/EditPseudo/EditPseudo.tsx l.62 — déclaré, non mesuré (redirige sans session)
+  // src/components/User/EditPseudo/EditPseudo.tsx l.62 - declared, not measured (redirects without a session)
   "/auth/inscription/pseudo",
-  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 — déclaré, non mesuré (redirige sans session)
+  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 - declared, not measured (redirects without a session)
   "/auth/code-connexion",
-  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 — déclaré, non mesuré (redirige sans session)
+  // src/components/Pages/auth/CheckCode/CheckCode.tsx l.128 - declared, not measured (redirects without a session)
   "/auth/code-securite",
-  // src/components/User/ForgotPassword/ForgotPassword.tsx l.44 — mesuré le 25/08 (focus posé)
+  // src/components/User/ForgotPassword/ForgotPassword.tsx l.44 - measured 25/08 (focus set)
   "/auth/reinitialiser-mot-de-passe",
-  // src/pages/auth/reinitialiser-mot-de-passe/nouveau.tsx l.122 et l.134 — déclaré ;
-  // mesuré le 25/08 SANS focus posé, conservé par prudence tant que l'écart n'est pas expliqué
+  // src/pages/auth/reinitialiser-mot-de-passe/nouveau.tsx l.122 and l.134 - declared;
+  // measured 25/08 with NO focus set, kept as a precaution until the gap is explained
   "/auth/reinitialiser-mot-de-passe/nouveau",
 ]);
 
 /**
- * Drapeau de navigation par ancre, partagé avec `useScrollToAnchor` : quand une
- * ancre inter-pages déclenche un `router.push`, la cible de l'ancre garde le
- * focus et le paragraphe ne s'en mêle pas. Posé avant le `push`, consommé au
- * `routeChangeComplete`, remis à zéro dans un `finally` sur la promesse du
- * `push` pour qu'une navigation annulée ne laisse pas un drapeau collé.
+ * Anchor navigation flag, shared with `useScrollToAnchor`: the anchor target
+ * keeps the focus, so the paragraph stays out of that navigation. Set before
+ * the `push`, consumed on `routeChangeComplete`, cleared in a `finally`.
  */
 let anchorNavigationInProgress = false;
 
@@ -67,41 +54,24 @@ export const clearAnchorNavigation = () => {
 const writeAnnouncement = (text: string, moveFocus: boolean) => {
   const paragraph = document.getElementById(ROUTE_ANNOUNCER_ID);
   if (!paragraph) return;
-  // Geste de forçage : deux navigations de suite vers un titre identique
-  // (`/auth` puis `/auth/inscription`, deux pages en `title="Bienvenue"`)
-  // doivent être restituées toutes les deux. Or `focus()` sur un élément déjà
-  // focalisé n'émet rien : on sort le focus et on vide le paragraphe avant de
-  // réécrire puis refocaliser, pour que la restitution reparte à neuf.
+  // `focus()` on an already focused element emits nothing, so two navigations
+  // in a row to the same title would only be announced once: blur and clear
+  // first, so the restitution starts fresh.
   if (document.activeElement === paragraph) paragraph.blur();
   paragraph.textContent = "";
   paragraph.textContent = text;
-  // `preventScroll` : la classe sr-only ne fixant ni top ni left, un focus
-  // défilant ferait remonter la page et détruirait la restauration de position
-  // au retour arrière navigateur. Motif maison de useScrollToAnchor.
+  // `preventScroll`: sr-only pins neither top nor left, a scrolling focus would
+  // jump the page and break browser back position restoration.
   if (moveFocus) paragraph.focus({ preventScroll: true });
 };
 
 /**
- * Annonce le changement de page et repositionne le focus lors des navigations
- * client (RGAA 12.8).
+ * Announces page changes and repositions the focus on client navigations
+ * (RGAA 12.8).
  *
- * Mécanique prescrite par l'audit Ideance : un paragraphe `sr-only` avec
- * `tabindex="-1"` en tête de `<body>` (posé par `_document.tsx`), synchronisé
- * avec le `<title>` de la page d'arrivée et focalisé à chaque navigation.
- * L'annonceur natif de Next (`<next-route-announcer>`) est neutralisé par CSS
- * dans `_dsfr-fix.scss`.
- *
- * Gardes :
- * - navigations superficielles ignorées (saisie dans le champ de recherche) ;
- * - changement de locale seul ignoré (redirection de langue du premier
- *   chargement, validation de la modale de langue) ;
- * - attente du titre annulée si une autre navigation démarre (jeton de
- *   génération) : seule la dernière navigation écrit et focalise ;
- * - route sans `<title>` : repli humanisé tiré du motif de route.
- *
- * Le focus ne se dispute jamais avec un autre mécanisme : la modale de langue
- * du premier chargement, l'autofocus de page (liste centralisée ci-dessus) et
- * la cible d'une ancre (`useScrollToAnchor`, drapeau partagé) le gardent.
+ * Syncs the `sr-only` paragraph rendered by `_document.tsx` with the incoming
+ * `<title>` and focuses it. Guards, autofocus exceptions and the measurements
+ * behind them: documentation/client/accessibility/voiceover.md.
  *
  * @example
  * // Use inside _app.tsx
@@ -118,8 +88,8 @@ const useRouteAnnouncement = () => {
   useEffect(() => {
     lastRouteRef.current = { pathname: Router.pathname, locale: Router.locale };
 
-    // Jeton de génération : toute navigation qui en chasse une autre rend
-    // l'attente de titre de la précédente périmée, sans écriture après coup.
+    // Generation token: a navigation that supersedes another makes the pending
+    // title wait stale, so only the last one writes.
     const handleRouteChangeStart = () => {
       generationRef.current += 1;
     };
@@ -127,9 +97,8 @@ const useRouteAnnouncement = () => {
     const waitForTitle = (generation: number) => {
       let frames = 0;
       const tick = () => {
-        if (generationRef.current !== generation) return; // attente périmée
-        // Le focus ne se dispute jamais avec l'autofocus d'une page : sur ces
-        // routes, le paragraphe est synchronisé sans être focalisé.
+        if (generationRef.current !== generation) return; // stale wait
+        // Never compete with a page autofocus: sync without focusing.
         const moveFocus = !AUTOFOCUS_ROUTE_PATTERNS.has(Router.pathname);
         const title = document.title;
         if (title) {
@@ -151,21 +120,19 @@ const useRouteAnnouncement = () => {
       const previous = lastRouteRef.current;
       lastRouteRef.current = { pathname: Router.pathname, locale: Router.locale };
 
-      // Navigation superficielle : la recherche pousse une navigation shallow
-      // débouncée à chaque frappe, qui ne change pas de page.
+      // The search page pushes a debounced shallow navigation on every
+      // keystroke, which is not a page change.
       if (shallow) return;
 
-      // Navigation issue d'une ancre inter-pages (`/#newsletter` depuis le pied
-      // de page) : la cible de l'ancre garde le focus, rien à annoncer ici.
-      // Le drapeau est consommé, la navigation suivante redevient ordinaire.
+      // Inter-page anchor (`/#newsletter` from the footer): the anchor target
+      // keeps the focus. Consuming the flag restores ordinary behavior next time.
       if (anchorNavigationInProgress) {
         anchorNavigationInProgress = false;
         return;
       }
 
-      // Seule la locale change sur la même page : redirection de langue du
-      // premier chargement (Layout.tsx), validation de la modale de langue.
-      // Ce n'est pas un changement de page, rien à annoncer.
+      // Only the locale changed on the same route: first-load language redirect
+      // (Layout.tsx) or language modal validation, not a page change.
       if (Router.locale !== previous.locale && Router.pathname === previous.pathname) return;
 
       waitForTitle(generationRef.current);
@@ -177,7 +144,7 @@ const useRouteAnnouncement = () => {
       router.events.off("routeChangeStart", handleRouteChangeStart);
       router.events.off("routeChangeComplete", handleRouteChangeComplete);
     };
-    // Abonnement unique au montage, même motif que les abonnements de _app.tsx.
+    // Subscribe once on mount, same pattern as the _app.tsx subscriptions.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 };

--- a/apps/client/src/hooks/useScrollToAnchor.test.tsx
+++ b/apps/client/src/hooks/useScrollToAnchor.test.tsx
@@ -7,10 +7,10 @@ jest.mock("next/router", () => require("next-router-mock"));
 // on the announcement is covered by useRouteAnnouncement.test.tsx.
 jest.mock("./useRouteAnnouncement", () => ({
   markAnchorNavigation: jest.fn(),
-  clearAnchorNavigation: jest.fn(),
+  unmarkAnchorNavigation: jest.fn(),
 }));
 
-const { markAnchorNavigation, clearAnchorNavigation } = require("./useRouteAnnouncement");
+const { markAnchorNavigation, unmarkAnchorNavigation } = require("./useRouteAnnouncement");
 
 /**
  * Test trap, do not remove: the hook compares `window.location.pathname`, not
@@ -171,7 +171,7 @@ describe("useScrollToAnchor", () => {
       });
 
       expect(markAnchorNavigation).toHaveBeenCalledTimes(1);
-      expect(clearAnchorNavigation).toHaveBeenCalledTimes(1);
+      expect(unmarkAnchorNavigation).toHaveBeenCalledTimes(1);
       expect(callOrder(markAnchorNavigation)).toBeLessThan(callOrder(mockRouter.push));
     });
 
@@ -211,7 +211,7 @@ describe("useScrollToAnchor", () => {
       clickAnchor("/#newsletter");
 
       expect(markAnchorNavigation).toHaveBeenCalledTimes(1);
-      expect(clearAnchorNavigation).toHaveBeenCalledTimes(1);
+      expect(unmarkAnchorNavigation).toHaveBeenCalledTimes(1);
       // The navigation failed, so the scroll to the target does not happen.
       expect(document.activeElement).not.toBe(target);
       expect(window.scrollTo).not.toHaveBeenCalled();

--- a/apps/client/src/hooks/useScrollToAnchor.test.tsx
+++ b/apps/client/src/hooks/useScrollToAnchor.test.tsx
@@ -3,6 +3,14 @@ import mockRouter from "next-router-mock";
 import useScrollToAnchor from "./useScrollToAnchor";
 
 jest.mock("next/router", () => require("next-router-mock"));
+// Le drapeau d'ancre partagé est vérifié ici au niveau des appels ; son effet
+// réel sur l'annonce est couvert par useRouteAnnouncement.test.tsx.
+jest.mock("./useRouteAnnouncement", () => ({
+  markAnchorNavigation: jest.fn(),
+  clearAnchorNavigation: jest.fn(),
+}));
+
+const { markAnchorNavigation, clearAnchorNavigation } = require("./useRouteAnnouncement");
 
 /**
  * Piège de test, à ne pas retirer : le hook compare `window.location.pathname`,
@@ -148,6 +156,65 @@ describe("useScrollToAnchor", () => {
       });
       expect(document.activeElement).toBe(target);
       expect(callOrder(mockRouter.push)).toBeLessThan(callOrder(window.scrollTo));
+    });
+  });
+
+  describe("drapeau d'ancre, RGAA 12.8", () => {
+    it("pose le drapeau avant le push inter-pages et le remet à zéro après", async () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      addTarget("newsletter");
+
+      await act(async () => {
+        clickAnchor("/#newsletter");
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(markAnchorNavigation).toHaveBeenCalledTimes(1);
+      expect(clearAnchorNavigation).toHaveBeenCalledTimes(1);
+      expect(callOrder(markAnchorNavigation)).toBeLessThan(callOrder(mockRouter.push));
+    });
+
+    it("ne pose pas le drapeau sur une ancre de même page, qui ne navigue pas", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      addTarget("contenu");
+
+      clickAnchor("#contenu");
+
+      expect(markAnchorNavigation).not.toHaveBeenCalled();
+    });
+
+    it("remet le drapeau à zéro même quand le push est rejeté", () => {
+      // Une navigation annulée par une autre rejette la promesse du push. Sans
+      // le finally, le drapeau resterait collé et éteindrait l'annonce de la
+      // navigation suivante. Le push n'a aucun catch (défaut préexistant
+      // consigné) : une vraie promesse rejetée ferait échouer la suite en
+      // rejet non géré. Ce thenable factice rejoue le chemin de rejet, le
+      // callback de then est sauté, celui de finally s'exécute.
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      const target = addTarget("newsletter");
+      const rejectedPush = {
+        then() {
+          return this;
+        },
+        finally(callback: () => void) {
+          callback();
+          return Promise.resolve(true);
+        },
+      };
+      (mockRouter.push as jest.Mock).mockImplementation(
+        () => rejectedPush as unknown as Promise<boolean>,
+      );
+
+      clickAnchor("/#newsletter");
+
+      expect(markAnchorNavigation).toHaveBeenCalledTimes(1);
+      expect(clearAnchorNavigation).toHaveBeenCalledTimes(1);
+      // La navigation ayant échoué, le défilement vers la cible n'a pas lieu.
+      expect(document.activeElement).not.toBe(target);
+      expect(window.scrollTo).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/client/src/hooks/useScrollToAnchor.test.tsx
+++ b/apps/client/src/hooks/useScrollToAnchor.test.tsx
@@ -1,0 +1,183 @@
+import { act, renderHook } from "@testing-library/react";
+import mockRouter from "next-router-mock";
+import useScrollToAnchor from "./useScrollToAnchor";
+
+jest.mock("next/router", () => require("next-router-mock"));
+
+/**
+ * Piège de test, à ne pas retirer : le hook compare `window.location.pathname`,
+ * pas `router.pathname`. `next-router-mock` ne touche jamais l'objet `location`
+ * de jsdom. Sans `window.history.pushState`, tous les cas verraient "/" et
+ * prendraient la branche même-page, donc les tests passeraient au vert en
+ * prouvant l'inverse de ce qu'ils visent.
+ */
+const setLocation = (url: string) => window.history.pushState({}, "", url);
+
+/** Le hook écoute au niveau `document` : il faut un vrai lien dans le DOM. */
+const clickAnchor = (href: string) => {
+  const anchor = document.createElement("a");
+  anchor.setAttribute("href", href);
+  anchor.textContent = "lien";
+  document.body.appendChild(anchor);
+  anchor.click();
+  return anchor;
+};
+
+const addTarget = (id: string, tabIndex?: string) => {
+  const target = document.createElement("div");
+  target.id = id;
+  if (tabIndex !== undefined) target.setAttribute("tabIndex", tabIndex);
+  document.body.appendChild(target);
+  return target;
+};
+
+const callOrder = (fn: unknown) => (fn as jest.Mock).mock.invocationCallOrder[0];
+
+describe("useScrollToAnchor", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = "";
+    mockRouter.setCurrentUrl("/");
+    setLocation("/");
+    window.scrollTo = jest.fn();
+    // Le hook diffère la mesure d'une trame pour laisser la barre d'évitement du
+    // DSFR se replier. On la rend synchrone pour pouvoir assertionner le défilement.
+    jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      cb(0);
+      return 0;
+    });
+    jest.spyOn(mockRouter, "push");
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe("ancre de même page, liens d'évitement, RGAA 12.7", () => {
+    it("ne navigue pas depuis une route dynamique, pose le focus et défile vers la cible", () => {
+      setLocation("/demarche/63528e00976acb4f7bcd37ad");
+      renderHook(() => useScrollToAnchor());
+      const target = addTarget("contenu");
+
+      clickAnchor("#contenu");
+
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(target.getAttribute("tabIndex")).toBe("-1");
+      expect(document.activeElement).toBe(target);
+      expect(window.scrollTo).toHaveBeenCalledWith({
+        top: expect.any(Number),
+        behavior: "smooth",
+      });
+    });
+
+    it("pose le focus avant de mesurer, pour que la barre d'évitement soit repliée", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      const target = addTarget("contenu");
+      const focusSpy = jest.spyOn(target, "focus");
+
+      clickAnchor("#contenu");
+
+      expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true });
+      expect(callOrder(focusSpy)).toBeLessThan(callOrder(window.scrollTo));
+    });
+
+    it("ne navigue pas depuis une route statique", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      addTarget("contenu");
+
+      clickAnchor("#contenu");
+
+      expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+
+    it("n'écrase pas un tabindex déjà porté par la cible et lui donne quand même le focus", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      const target = addTarget("contenu", "0");
+
+      clickAnchor("#contenu");
+
+      expect(target.getAttribute("tabIndex")).toBe("0");
+      expect(document.activeElement).toBe(target);
+    });
+
+    it("ne demande aucune navigation, donc laisse l'URL de recherche intacte", () => {
+      setLocation("/recherche?search=logement&sort=default");
+      renderHook(() => useScrollToAnchor());
+      addTarget("contenu");
+
+      clickAnchor("#contenu");
+
+      // C'est cette assertion qui prouve la conservation de la chaîne de requête :
+      // le défaut corrigé venait d'un `router.push("")` que Next résolvait en motif
+      // de route, ce qui effaçait la query. L'assertion sur `window.location.search`
+      // ci-dessous est documentaire : `next-router-mock` ne touche jamais `location`,
+      // elle ne pourrait donc pas échouer. La preuve réelle est la mesure navigateur.
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(window.location.search).toBe("?search=logement&sort=default");
+    });
+
+    it("ne navigue pas quand le chemin de l'ancre est déjà le chemin courant", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      addTarget("contenu");
+
+      clickAnchor("/agir#contenu");
+
+      expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ancre inter-pages", () => {
+    it("navigue vers la page cible avant de défiler vers l'ancre", async () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+      const target = addTarget("newsletter");
+
+      await act(async () => {
+        clickAnchor("/#newsletter");
+      });
+
+      expect(mockRouter.push).toHaveBeenCalledTimes(1);
+      expect(mockRouter.push).toHaveBeenCalledWith("/", undefined, { scroll: false });
+      expect(window.scrollTo).toHaveBeenCalledWith({
+        top: expect.any(Number),
+        behavior: "smooth",
+      });
+      expect(document.activeElement).toBe(target);
+      expect(callOrder(mockRouter.push)).toBeLessThan(callOrder(window.scrollTo));
+    });
+  });
+
+  describe("cas limites", () => {
+    it("ne lève pas et ne navigue pas sur un href réduit à un dièse", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+
+      expect(() => clickAnchor("#")).not.toThrow();
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("ne lève pas, ne navigue pas et ne défile pas quand la cible n'existe pas", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+
+      expect(() => clickAnchor("#cible-absente")).not.toThrow();
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+
+    it("ignore les liens sans ancre", () => {
+      setLocation("/agir");
+      renderHook(() => useScrollToAnchor());
+
+      clickAnchor("/recherche");
+
+      expect(mockRouter.push).not.toHaveBeenCalled();
+      expect(window.scrollTo).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/client/src/hooks/useScrollToAnchor.test.tsx
+++ b/apps/client/src/hooks/useScrollToAnchor.test.tsx
@@ -3,8 +3,8 @@ import mockRouter from "next-router-mock";
 import useScrollToAnchor from "./useScrollToAnchor";
 
 jest.mock("next/router", () => require("next-router-mock"));
-// Le drapeau d'ancre partagé est vérifié ici au niveau des appels ; son effet
-// réel sur l'annonce est couvert par useRouteAnnouncement.test.tsx.
+// The shared anchor flag is checked here at the call level; its actual effect
+// on the announcement is covered by useRouteAnnouncement.test.tsx.
 jest.mock("./useRouteAnnouncement", () => ({
   markAnchorNavigation: jest.fn(),
   clearAnchorNavigation: jest.fn(),
@@ -13,15 +13,15 @@ jest.mock("./useRouteAnnouncement", () => ({
 const { markAnchorNavigation, clearAnchorNavigation } = require("./useRouteAnnouncement");
 
 /**
- * Piège de test, à ne pas retirer : le hook compare `window.location.pathname`,
- * pas `router.pathname`. `next-router-mock` ne touche jamais l'objet `location`
- * de jsdom. Sans `window.history.pushState`, tous les cas verraient "/" et
- * prendraient la branche même-page, donc les tests passeraient au vert en
- * prouvant l'inverse de ce qu'ils visent.
+ * Test trap, do not remove: the hook compares `window.location.pathname`, not
+ * `router.pathname`. `next-router-mock` never touches the jsdom `location`
+ * object. Without `window.history.pushState`, every case would see "/" and take
+ * the same-page branch, so the tests would pass while proving the opposite of
+ * what they target.
  */
 const setLocation = (url: string) => window.history.pushState({}, "", url);
 
-/** Le hook écoute au niveau `document` : il faut un vrai lien dans le DOM. */
+/** The hook listens at the `document` level: a real link in the DOM is needed. */
 const clickAnchor = (href: string) => {
   const anchor = document.createElement("a");
   anchor.setAttribute("href", href);
@@ -48,8 +48,8 @@ describe("useScrollToAnchor", () => {
     mockRouter.setCurrentUrl("/");
     setLocation("/");
     window.scrollTo = jest.fn();
-    // Le hook diffère la mesure d'une trame pour laisser la barre d'évitement du
-    // DSFR se replier. On la rend synchrone pour pouvoir assertionner le défilement.
+    // The hook defers the measurement by one frame to let the DSFR skip link
+    // bar collapse. It is made synchronous here so the scroll can be asserted.
     jest.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
       cb(0);
       return 0;
@@ -61,8 +61,8 @@ describe("useScrollToAnchor", () => {
     jest.restoreAllMocks();
   });
 
-  describe("ancre de même page, liens d'évitement, RGAA 12.7", () => {
-    it("ne navigue pas depuis une route dynamique, pose le focus et défile vers la cible", () => {
+  describe("same-page anchor, skip links, RGAA 12.7", () => {
+    it("does not navigate from a dynamic route, focuses and scrolls to the target", () => {
       setLocation("/demarche/63528e00976acb4f7bcd37ad");
       renderHook(() => useScrollToAnchor());
       const target = addTarget("contenu");
@@ -78,7 +78,7 @@ describe("useScrollToAnchor", () => {
       });
     });
 
-    it("pose le focus avant de mesurer, pour que la barre d'évitement soit repliée", () => {
+    it("focuses before measuring, so that the skip link bar is collapsed", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       const target = addTarget("contenu");
@@ -90,7 +90,7 @@ describe("useScrollToAnchor", () => {
       expect(callOrder(focusSpy)).toBeLessThan(callOrder(window.scrollTo));
     });
 
-    it("ne navigue pas depuis une route statique", () => {
+    it("does not navigate from a static route", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       addTarget("contenu");
@@ -100,7 +100,7 @@ describe("useScrollToAnchor", () => {
       expect(mockRouter.push).not.toHaveBeenCalled();
     });
 
-    it("n'écrase pas un tabindex déjà porté par la cible et lui donne quand même le focus", () => {
+    it("does not overwrite a tabindex already carried by the target and still focuses it", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       const target = addTarget("contenu", "0");
@@ -111,23 +111,23 @@ describe("useScrollToAnchor", () => {
       expect(document.activeElement).toBe(target);
     });
 
-    it("ne demande aucune navigation, donc laisse l'URL de recherche intacte", () => {
+    it("requests no navigation, hence leaves the search URL untouched", () => {
       setLocation("/recherche?search=logement&sort=default");
       renderHook(() => useScrollToAnchor());
       addTarget("contenu");
 
       clickAnchor("#contenu");
 
-      // C'est cette assertion qui prouve la conservation de la chaîne de requête :
-      // le défaut corrigé venait d'un `router.push("")` que Next résolvait en motif
-      // de route, ce qui effaçait la query. L'assertion sur `window.location.search`
-      // ci-dessous est documentaire : `next-router-mock` ne touche jamais `location`,
-      // elle ne pourrait donc pas échouer. La preuve réelle est la mesure navigateur.
+      // This assertion is what proves the query string is preserved: the fixed
+      // defect came from a `router.push("")` that Next resolved to the route
+      // pattern, which wiped the query. The assertion on `window.location.search`
+      // below is documentary: `next-router-mock` never touches `location`, so it
+      // could not fail. The real proof is the browser measurement.
       expect(mockRouter.push).not.toHaveBeenCalled();
       expect(window.location.search).toBe("?search=logement&sort=default");
     });
 
-    it("ne navigue pas quand le chemin de l'ancre est déjà le chemin courant", () => {
+    it("does not navigate when the anchor path is already the current path", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       addTarget("contenu");
@@ -138,8 +138,8 @@ describe("useScrollToAnchor", () => {
     });
   });
 
-  describe("ancre inter-pages", () => {
-    it("navigue vers la page cible avant de défiler vers l'ancre", async () => {
+  describe("inter-page anchor", () => {
+    it("navigates to the target page before scrolling to the anchor", async () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       const target = addTarget("newsletter");
@@ -159,8 +159,8 @@ describe("useScrollToAnchor", () => {
     });
   });
 
-  describe("drapeau d'ancre, RGAA 12.8", () => {
-    it("pose le drapeau avant le push inter-pages et le remet à zéro après", async () => {
+  describe("anchor flag, RGAA 12.8", () => {
+    it("sets the flag before the inter-page push and clears it afterwards", async () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       addTarget("newsletter");
@@ -175,7 +175,7 @@ describe("useScrollToAnchor", () => {
       expect(callOrder(markAnchorNavigation)).toBeLessThan(callOrder(mockRouter.push));
     });
 
-    it("ne pose pas le drapeau sur une ancre de même page, qui ne navigue pas", () => {
+    it("does not set the flag on a same-page anchor, which does not navigate", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       addTarget("contenu");
@@ -185,13 +185,13 @@ describe("useScrollToAnchor", () => {
       expect(markAnchorNavigation).not.toHaveBeenCalled();
     });
 
-    it("remet le drapeau à zéro même quand le push est rejeté", () => {
-      // Une navigation annulée par une autre rejette la promesse du push. Sans
-      // le finally, le drapeau resterait collé et éteindrait l'annonce de la
-      // navigation suivante. Le push n'a aucun catch (défaut préexistant
-      // consigné) : une vraie promesse rejetée ferait échouer la suite en
-      // rejet non géré. Ce thenable factice rejoue le chemin de rejet, le
-      // callback de then est sauté, celui de finally s'exécute.
+    it("clears the flag even when the push is rejected", () => {
+      // A navigation cancelled by another one rejects the push promise. Without
+      // the finally, the flag would stay stuck and silence the announcement of
+      // the next navigation. The push has no catch (pre-existing defect,
+      // recorded): a real rejected promise would fail the suite with an
+      // unhandled rejection. This fake thenable replays the rejection path: the
+      // then callback is skipped, the finally one runs.
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
       const target = addTarget("newsletter");
@@ -212,14 +212,14 @@ describe("useScrollToAnchor", () => {
 
       expect(markAnchorNavigation).toHaveBeenCalledTimes(1);
       expect(clearAnchorNavigation).toHaveBeenCalledTimes(1);
-      // La navigation ayant échoué, le défilement vers la cible n'a pas lieu.
+      // The navigation failed, so the scroll to the target does not happen.
       expect(document.activeElement).not.toBe(target);
       expect(window.scrollTo).not.toHaveBeenCalled();
     });
   });
 
-  describe("cas limites", () => {
-    it("ne lève pas et ne navigue pas sur un href réduit à un dièse", () => {
+  describe("edge cases", () => {
+    it("does not throw and does not navigate on an href reduced to a bare hash", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
 
@@ -228,7 +228,7 @@ describe("useScrollToAnchor", () => {
       expect(window.scrollTo).not.toHaveBeenCalled();
     });
 
-    it("ne lève pas, ne navigue pas et ne défile pas quand la cible n'existe pas", () => {
+    it("does not throw, navigate or scroll when the target does not exist", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
 
@@ -237,7 +237,7 @@ describe("useScrollToAnchor", () => {
       expect(window.scrollTo).not.toHaveBeenCalled();
     });
 
-    it("ignore les liens sans ancre", () => {
+    it("ignores links without an anchor", () => {
       setLocation("/agir");
       renderHook(() => useScrollToAnchor());
 

--- a/apps/client/src/hooks/useScrollToAnchor.ts
+++ b/apps/client/src/hooks/useScrollToAnchor.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "next/router";
 import { useCallback, useEffect } from "react";
+import { clearAnchorNavigation, markAnchorNavigation } from "./useRouteAnnouncement";
 
 /**
  * Custom hook to enable smooth scrolling for anchor links.
@@ -81,9 +82,19 @@ const useScrollToAnchor = () => {
         if (isSamePage) {
           scrollToHash(hash);
         } else {
-          router.push(path, undefined, { scroll: false }).then(() => {
-            scrollToHash(hash);
-          });
+          // La cible de l'ancre garde le focus : le drapeau empêche
+          // useRouteAnnouncement de le disputer sur cette navigation (RGAA
+          // 12.8). Remis à zéro dans un finally pour qu'un push rejeté
+          // (navigation annulée par une autre) ne laisse pas un drapeau collé.
+          markAnchorNavigation();
+          router
+            .push(path, undefined, { scroll: false })
+            .then(() => {
+              scrollToHash(hash);
+            })
+            .finally(() => {
+              clearAnchorNavigation();
+            });
         }
       }
     },

--- a/apps/client/src/hooks/useScrollToAnchor.ts
+++ b/apps/client/src/hooks/useScrollToAnchor.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "next/router";
 import { useCallback, useEffect } from "react";
-import { clearAnchorNavigation, markAnchorNavigation } from "./useRouteAnnouncement";
+import { markAnchorNavigation, unmarkAnchorNavigation } from "./useRouteAnnouncement";
 
 /**
  * Custom hook to enable smooth scrolling for anchor links.
@@ -87,7 +87,7 @@ const useScrollToAnchor = () => {
               scrollToHash(hash);
             })
             .finally(() => {
-              clearAnchorNavigation();
+              unmarkAnchorNavigation();
             });
         }
       }

--- a/apps/client/src/hooks/useScrollToAnchor.ts
+++ b/apps/client/src/hooks/useScrollToAnchor.ts
@@ -23,21 +23,30 @@ const useScrollToAnchor = () => {
   const scrollToHash = useCallback((hash: string) => {
     const element = document.getElementById(hash);
     if (element) {
-      // Calculate position with offset for header
-      const headerOffset = 0;
-      const elementPosition = element.getBoundingClientRect().top;
-      const offsetPosition = elementPosition + window.scrollY - headerOffset;
-
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: "smooth",
-      });
-
       // Manage focus
       if (!element.hasAttribute("tabIndex")) {
         element.setAttribute("tabIndex", "-1");
       }
+      // Le focus est posé AVANT la mesure. La barre d'évitement du DSFR passe de
+      // `position: absolute` à `position: relative` tant qu'elle garde le focus
+      // (`.fr-skiplinks:focus-within`, dsfr.css) et pousse la page de sa hauteur.
+      // Mesurer dans cet état puis sortir le focus de la barre la fait se replier
+      // pendant l'animation : le défilement atterrit 48 px trop bas et le haut de
+      // la cible passe au-dessus de la fenêtre. Mesuré sur /, /agir et une fiche.
       element.focus({ preventScroll: true });
+
+      // La mesure attend la trame suivante, une fois la barre repliée.
+      requestAnimationFrame(() => {
+        // Calculate position with offset for header
+        const headerOffset = 0;
+        const elementPosition = element.getBoundingClientRect().top;
+        const offsetPosition = elementPosition + window.scrollY - headerOffset;
+
+        window.scrollTo({
+          top: offsetPosition,
+          behavior: "smooth",
+        });
+      });
     }
   }, []);
 
@@ -63,12 +72,18 @@ const useScrollToAnchor = () => {
         event.preventDefault(); // Prevent full page reload
         const [path, hash] = href.split("#");
 
-        if (path !== window.location.pathname) {
+        // Une ancre de même page (`href="#contenu"`) donne un `path` vide après le
+        // découpage. La traiter comme une navigation appelle `router.push("")`, que
+        // Next résout en motif de route : 404 sur les routes dynamiques et perte de
+        // la chaîne de requête ailleurs. Liens d'évitement, RGAA 12.7.
+        const isSamePage = !path || path === window.location.pathname;
+
+        if (isSamePage) {
+          scrollToHash(hash);
+        } else {
           router.push(path, undefined, { scroll: false }).then(() => {
             scrollToHash(hash);
           });
-        } else {
-          scrollToHash(hash);
         }
       }
     },

--- a/apps/client/src/hooks/useScrollToAnchor.ts
+++ b/apps/client/src/hooks/useScrollToAnchor.ts
@@ -28,15 +28,11 @@ const useScrollToAnchor = () => {
       if (!element.hasAttribute("tabIndex")) {
         element.setAttribute("tabIndex", "-1");
       }
-      // Le focus est posé AVANT la mesure. La barre d'évitement du DSFR passe de
-      // `position: absolute` à `position: relative` tant qu'elle garde le focus
-      // (`.fr-skiplinks:focus-within`, dsfr.css) et pousse la page de sa hauteur.
-      // Mesurer dans cet état puis sortir le focus de la barre la fait se replier
-      // pendant l'animation : le défilement atterrit 48 px trop bas et le haut de
-      // la cible passe au-dessus de la fenêtre. Mesuré sur /, /agir et une fiche.
+      // Focus BEFORE measuring: the DSFR skip link bar shifts the page while it
+      // holds the focus, so measuring first lands the scroll off. See voiceover.md.
       element.focus({ preventScroll: true });
 
-      // La mesure attend la trame suivante, une fois la barre repliée.
+      // Measure on the next frame, once the bar has collapsed.
       requestAnimationFrame(() => {
         // Calculate position with offset for header
         const headerOffset = 0;
@@ -73,19 +69,17 @@ const useScrollToAnchor = () => {
         event.preventDefault(); // Prevent full page reload
         const [path, hash] = href.split("#");
 
-        // Une ancre de même page (`href="#contenu"`) donne un `path` vide après le
-        // découpage. La traiter comme une navigation appelle `router.push("")`, que
-        // Next résout en motif de route : 404 sur les routes dynamiques et perte de
-        // la chaîne de requête ailleurs. Liens d'évitement, RGAA 12.7.
+        // A same-page anchor (`href="#contenu"`) yields an empty `path`. Treating
+        // it as a navigation calls `router.push("")`, which Next resolves to the
+        // route pattern: 404 on dynamic routes. Skip links, RGAA 12.7.
         const isSamePage = !path || path === window.location.pathname;
 
         if (isSamePage) {
           scrollToHash(hash);
         } else {
-          // La cible de l'ancre garde le focus : le drapeau empêche
-          // useRouteAnnouncement de le disputer sur cette navigation (RGAA
-          // 12.8). Remis à zéro dans un finally pour qu'un push rejeté
-          // (navigation annulée par une autre) ne laisse pas un drapeau collé.
+          // The anchor target keeps the focus: the flag stops useRouteAnnouncement
+          // from competing on this navigation (RGAA 12.8). Cleared in a finally so
+          // a rejected push does not leave the flag stuck.
           markAnchorNavigation();
           router
             .push(path, undefined, { scroll: false })

--- a/apps/client/src/lib/humanizeRoutePattern.test.ts
+++ b/apps/client/src/lib/humanizeRoutePattern.test.ts
@@ -1,0 +1,23 @@
+import { humanizeRoutePattern } from "./humanizeRoutePattern";
+
+describe("humanizeRoutePattern", () => {
+  it("should capitalize the segment and turn hyphens into spaces", () => {
+    const res = humanizeRoutePattern("/download-app");
+    expect(res).toEqual("Download app");
+  });
+
+  it("should join several segments", () => {
+    const res = humanizeRoutePattern("/dispositif/test-preview");
+    expect(res).toEqual("Dispositif test preview");
+  });
+
+  it("should strip the brackets of a dynamic segment", () => {
+    const res = humanizeRoutePattern("/dispositif/[id]");
+    expect(res).toEqual("Dispositif id");
+  });
+
+  it("should return an empty string when there is no readable segment", () => {
+    const res = humanizeRoutePattern("/");
+    expect(res).toEqual("");
+  });
+});

--- a/apps/client/src/lib/humanizeRoutePattern.ts
+++ b/apps/client/src/lib/humanizeRoutePattern.ts
@@ -1,0 +1,21 @@
+/**
+ * Turns a Next.js route pattern into a readable label.
+ *
+ * Used as the announced fallback when a route is served without a `<title>`
+ * (RGAA 12.8): announcing a raw URL path or focusing an empty paragraph would
+ * be worse than a humanized route pattern. Dynamic segments lose their
+ * brackets, so `/dispositif/[id]` gives "Dispositif id".
+ *
+ * Returns an empty string when the pattern carries no readable segment.
+ */
+export const humanizeRoutePattern = (pathname: string): string => {
+  const label = pathname
+    .replace(/[[\]]|\.{3}/g, "")
+    .split("/")
+    .filter(Boolean)
+    .join(" ")
+    .replace(/-/g, " ")
+    .trim();
+  if (!label) return "";
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};

--- a/apps/client/src/pages/_app.tsx
+++ b/apps/client/src/pages/_app.tsx
@@ -19,7 +19,7 @@ import { useEffectOnce } from "react-use";
 import toastStyles from "scss/components/toast.module.scss";
 import { ScreenReaderAnnouncerProvider } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import Layout from "~/components/Layout/Layout";
-import { useRTL, useScrollToAnchor } from "~/hooks";
+import { useRouteAnnouncement, useRTL, useScrollToAnchor } from "~/hooks";
 import { useConsent } from "~/hooks/useConsentContext";
 import { isContentPage } from "~/lib/isContentPage";
 import { Event, initGA } from "~/lib/tracking";
@@ -64,6 +64,7 @@ const App = ({ Component, ...pageProps }: AppPropsWithLayout) => {
   const router = useRouter();
 
   useScrollToAnchor();
+  useRouteAnnouncement();
 
   const options: PageOptions = Component.options || {
     cookiesModule: true,

--- a/apps/client/src/pages/_document.tsx
+++ b/apps/client/src/pages/_document.tsx
@@ -1,8 +1,20 @@
 import { type DocumentProps, Head, Html, Main, NextScript } from "next/document";
 import SkipLinksNavigation from "~/components/UI/SkipLinksNavigation/SkipLinksNavigation";
+import { ROUTE_ANNOUNCER_ID } from "~/hooks/useRouteAnnouncement";
 import { caveat, dsfrDocumentApi } from "./_app";
 
 const { getColorSchemeHtmlAttributes, augmentDocumentForDsfr } = dsfrDocumentApi;
+
+// Le <title> produit par next/head est disponible dans props.head : on le
+// recopie pour que le paragraphe d'annonce porte le titre dès le HTML source,
+// comme le demande l'audit Ideance (RGAA 12.8).
+const getServerTitle = (props: DocumentProps): string => {
+  const titleElement = props.head?.find((element) => element?.type === "title");
+  const children = titleElement?.props?.children;
+  if (typeof children === "string") return children;
+  if (Array.isArray(children)) return children.join("");
+  return "";
+};
 
 export default function Document(props: DocumentProps) {
   return (
@@ -16,6 +28,12 @@ export default function Document(props: DocumentProps) {
         )}
       </Head>
       <body>
+        {/* Annonce de changement de page (RGAA 12.8) : paragraphe sr-only
+            synchronisé avec le <title> et focalisé à chaque navigation client
+            par useRouteAnnouncement, posé avant les liens d'évitement. */}
+        <p id={ROUTE_ANNOUNCER_ID} tabIndex={-1} className="sr-only">
+          {getServerTitle(props)}
+        </p>
         <SkipLinksNavigation />
         <Main />
         <NextScript />

--- a/apps/client/src/pages/_document.tsx
+++ b/apps/client/src/pages/_document.tsx
@@ -17,6 +17,8 @@ const getServerTitle = (props: DocumentProps): string => {
 };
 
 export default function Document(props: DocumentProps) {
+  // The auth tunnel renders neither the main navigation nor the footer (RGAA 6.1).
+  const hasNavigationAndFooter = !(props.__NEXT_DATA__?.page ?? "").startsWith("/auth");
   return (
     <Html {...getColorSchemeHtmlAttributes(props)} className={caveat.variable}>
       <Head>
@@ -34,7 +36,7 @@ export default function Document(props: DocumentProps) {
         <p id={ROUTE_ANNOUNCER_ID} tabIndex={-1} className="sr-only">
           {getServerTitle(props)}
         </p>
-        <SkipLinksNavigation />
+        <SkipLinksNavigation hasNavigationAndFooter={hasNavigationAndFooter} />
         <Main />
         <NextScript />
       </body>

--- a/apps/client/src/pages/_document.tsx
+++ b/apps/client/src/pages/_document.tsx
@@ -5,9 +5,9 @@ import { caveat, dsfrDocumentApi } from "./_app";
 
 const { getColorSchemeHtmlAttributes, augmentDocumentForDsfr } = dsfrDocumentApi;
 
-// Le <title> produit par next/head est disponible dans props.head : on le
-// recopie pour que le paragraphe d'annonce porte le titre dès le HTML source,
-// comme le demande l'audit Ideance (RGAA 12.8).
+// The <title> produced by next/head is available in props.head: copying it here
+// gives the announcer paragraph its title straight from the source HTML
+// (RGAA 12.8).
 const getServerTitle = (props: DocumentProps): string => {
   const titleElement = props.head?.find((element) => element?.type === "title");
   const children = titleElement?.props?.children;
@@ -28,9 +28,9 @@ export default function Document(props: DocumentProps) {
         )}
       </Head>
       <body>
-        {/* Annonce de changement de page (RGAA 12.8) : paragraphe sr-only
-            synchronisé avec le <title> et focalisé à chaque navigation client
-            par useRouteAnnouncement, posé avant les liens d'évitement. */}
+        {/* Route change announcement (RGAA 12.8): sr-only paragraph synced with
+            the <title> and focused on every client navigation by
+            useRouteAnnouncement, placed before the skip links. */}
         <p id={ROUTE_ANNOUNCER_ID} tabIndex={-1} className="sr-only">
           {getServerTitle(props)}
         </p>

--- a/apps/client/src/scss/_dsfr-fix.scss
+++ b/apps/client/src/scss/_dsfr-fix.scss
@@ -100,17 +100,14 @@ a:not(.underline):not(.fr-default) {
   }
 }
 
-// Annonce de changement de page (RGAA 12.8) : elle passe par le paragraphe
-// sr-only de _document.tsx, synchronisé et focalisé par useRouteAnnouncement.
-// L'annonceur natif de Next est éteint pour supprimer la double vocalisation
-// (mesure VoiceOver du 26/08 : display none suffit, plus aucune annonce).
-// Attention : `next-route-announcer` n'est pas une API publique. C'est le type
-// du portail créé par node_modules/next/dist/client/index.js (Next 15.5.18) ;
-// une montée de version peut le renommer et rendre cette règle muette sans
-// qu'aucun test ne rougisse. Garde-fou : le scénario navigateur vérifie que
-// l'élément existe et que son style calculé est bien display none. Cette règle
-// doit rester ici, hors de tout @layer (les règles couchées perdent la cascade
-// face au DSFR) et hors de tout @media.
+// Route change announcements go through the sr-only paragraph of _document.tsx
+// (RGAA 12.8), so the native Next announcer is turned off to remove the double
+// vocalisation. See documentation/client/accessibility/voiceover.md.
+// Careful: `next-route-announcer` is not a public API, it is the portal type
+// created by next/dist/client/index.js (Next 15.5.18). A version bump can rename
+// it and silence this rule without any test turning red.
+// This rule must stay out of any @layer (layered rules lose the cascade against
+// the DSFR) and out of any @media.
 next-route-announcer {
   display: none;
 }

--- a/apps/client/src/scss/_dsfr-fix.scss
+++ b/apps/client/src/scss/_dsfr-fix.scss
@@ -99,3 +99,18 @@ a:not(.underline):not(.fr-default) {
     }
   }
 }
+
+// Annonce de changement de page (RGAA 12.8) : elle passe par le paragraphe
+// sr-only de _document.tsx, synchronisé et focalisé par useRouteAnnouncement.
+// L'annonceur natif de Next est éteint pour supprimer la double vocalisation
+// (mesure VoiceOver du 26/08 : display none suffit, plus aucune annonce).
+// Attention : `next-route-announcer` n'est pas une API publique. C'est le type
+// du portail créé par node_modules/next/dist/client/index.js (Next 15.5.18) ;
+// une montée de version peut le renommer et rendre cette règle muette sans
+// qu'aucun test ne rougisse. Garde-fou : le scénario navigateur vérifie que
+// l'élément existe et que son style calculé est bien display none. Cette règle
+// doit rester ici, hors de tout @layer (les règles couchées perdent la cascade
+// face au DSFR) et hors de tout @media.
+next-route-announcer {
+  display: none;
+}

--- a/documentation/client/accessibility/voiceover.md
+++ b/documentation/client/accessibility/voiceover.md
@@ -56,9 +56,40 @@ announce(message: string, options?: {
 
 ### Examples
 
-- After navigation: `announce(t("page.loaded"), { priority: "interrupt" })`
 - On lazy content ready: `announce(t("content.ready"), { delay: 300 })`
 - On form error focus: `announce(t("form.error"), { priority: "interrupt" })`
+
+Do not use `announce()` for page navigation: route changes have their own mechanism, see "Route change announcements" below.
+
+## Route change announcements (RGAA 12.8)
+
+Page navigation is NOT announced through `useAnnounce`. It uses a separate mechanism, prescribed by the Ideance accessibility audit:
+
+- `_document.tsx` renders a `<p id="route-announcer" tabindex="-1" class="sr-only">` as the first child of `<body>`, before the skip links. On the server it is filled with the page `<title>` extracted from `props.head`.
+- `useRouteAnnouncement` (mounted in `_app.tsx`) listens to `routeChangeComplete`. On every client navigation it waits for the new `<title>`, copies it into the paragraph and moves keyboard focus onto it with `focus({ preventScroll: true })`. Receiving focus is what makes screen readers read the title: the paragraph is not a live region.
+- The native `<next-route-announcer>` is disabled with `display: none` in `_dsfr-fix.scss`. Keeping both would produce a double vocalisation (measured with VoiceOver on 26/08/2026). Consequence: this paragraph is the only channel that announces the page title. A `document.title` change outside the routing cycle is not announced by anything.
+
+### Why not `useAnnounce`
+
+`useAnnounce` renders an `aria-live` region. The audit prescribes a focusable paragraph, which is a different restitution channel: the announcement comes from the focus move, and the focus repositioning is itself half of the 12.8 requirement. Cumulating both channels (focus plus live region) was measured on 26/08/2026 and brings nothing over the focused paragraph alone, while reintroducing a double vocalisation risk. `useAnnounce` remains the single channel for dynamic component updates (results counts, form errors, background tasks).
+
+### Guards built into the hook
+
+- Shallow navigations are ignored (the search page pushes a debounced shallow navigation on every keystroke; stealing focus from the search field would be a severe regression).
+- A navigation where only the locale changes on the same route is ignored (first-load language redirect, language modal validation).
+- A navigation triggered by an inter-page anchor (`useScrollToAnchor`) is ignored: the anchor target keeps the focus. The two hooks share a flag, set before the anchor `push` and cleared in a `finally`.
+- When one navigation supersedes another, a generation token cancels the pending title wait: only the last navigation writes and focuses.
+- Routes served without a `<title>` get a humanized fallback derived from the route pattern, never a raw URL path.
+
+### Pages with an autofocus
+
+On routes where the page sets its own autofocus (the auth funnel), the paragraph is kept in sync but never focused: the focused field is the announcement. The centralized list lives in `useRouteAnnouncement.ts` (`AUTOFOCUS_ROUTE_PATTERNS`), expressed as `router.pathname` patterns.
+
+To update the list:
+
+1. Add the route pattern with a comment giving the `file:line` that declares the autofocus.
+2. State in the comment whether the autofocus behavior was actually measured in a browser (with an authenticated session when the route requires one; without a session most auth sub-routes redirect to `/fr/auth` and any measurement is wrong) or only declared in the code.
+3. Never add a route on the sole basis of an `autofocus` attribute in the DOM: two routes were measured with a declared autofocus that poses no focus at all.
 
 ## Debugging announcements (visual overlay)
 

--- a/documentation/client/accessibility/voiceover.md
+++ b/documentation/client/accessibility/voiceover.md
@@ -102,8 +102,8 @@ On routes where the page sets its own autofocus (the auth funnel), the paragraph
 
 To update the list:
 
-1. Add the route pattern with a comment giving the `file:line` that declares the autofocus.
-2. State in the comment whether the autofocus behavior was actually measured in a browser (with an authenticated session when the route requires one; without a session most auth sub-routes redirect to `/fr/auth` and any measurement is wrong) or only declared in the code.
+1. Add the route pattern with a one-line comment of the form `// <file>:<line>, measured <date>` or `// <file>:<line>, declared only`, where `file:line` (relative to `apps/client/src`) is the declaration of the autofocus.
+2. `measured` means the autofocus behavior was actually observed in a browser (with an authenticated session when the route requires one; without a session most auth sub-routes redirect to `/fr/auth` and any measurement is wrong). `declared only` means the autofocus was found in the code but not measured. A route measured with no focus set says so on its line and is kept as a precaution until the gap is explained.
 3. Never add a route on the sole basis of an `autofocus` attribute in the DOM: two routes were measured with a declared autofocus that poses no focus at all.
 
 ### Skip links and anchor landing (RGAA 12.7)

--- a/documentation/client/accessibility/voiceover.md
+++ b/documentation/client/accessibility/voiceover.md
@@ -79,7 +79,22 @@ Page navigation is NOT announced through `useAnnounce`. It uses a separate mecha
 - A navigation where only the locale changes on the same route is ignored (first-load language redirect, language modal validation).
 - A navigation triggered by an inter-page anchor (`useScrollToAnchor`) is ignored: the anchor target keeps the focus. The two hooks share a flag, set before the anchor `push` and cleared in a `finally`.
 - When one navigation supersedes another, a generation token cancels the pending title wait: only the last navigation writes and focuses.
-- Routes served without a `<title>` get a humanized fallback derived from the route pattern, never a raw URL path.
+- Routes served without a `<title>` get a humanized fallback derived from the route pattern, never a raw URL path. See "Routes without a page title" below.
+
+### Title wait budget
+
+The `<title>` is set by `next/head` in the same render cycle as `routeChangeComplete`, but it can be momentarily empty during a transition (measured on the auth funnel redirections). The hook therefore waits for it across animation frames rather than on a timer: a frame budget follows the render cycle on any refresh rate, a millisecond timer does not.
+
+`TITLE_WAIT_MAX_FRAMES` is 30. At 60 Hz that is roughly 500 ms, at 120 Hz roughly 250 ms. Both are well above the 128 ms measured before a redirection supersedes the pending navigation and invalidates the wait. Once the budget is spent the hook writes the humanized fallback instead of leaving the paragraph empty.
+
+### Routes without a page title
+
+The application produces a `<title>` from two places only: `components/Seo.tsx` and `pages/sitemap.tsx`. `<SEO>` always emits a title; without a `title` prop it emits the bare site name `Réfugiés.info`. Two different defects follow:
+
+- A route that never mounts `<SEO>` leaves `document.title` empty. The fallback fires and the paragraph gets a humanized route pattern. Concerned: `/download-app`, `/embed`, `/dispositif/test-preview`, `/_error`.
+- A route that mounts `<SEO>` with an empty title announces `Réfugiés.info` on every navigation. The fallback never fires. Concerned: `/dispositif` and `/demarche` in creation mode, both through `components/Content/Dispositif/Dispositif.tsx`.
+
+The fallback lives in `~/lib/humanizeRoutePattern`. It is a safety net, not a substitute for real titles: without it the focus would land on an empty paragraph and nothing at all would be announced, which is a plain 12.8 regression. Giving these routes a real title is a separate task for the refugies.info team; the fallback simply becomes unreachable once they have one.
 
 ### Pages with an autofocus
 
@@ -90,6 +105,14 @@ To update the list:
 1. Add the route pattern with a comment giving the `file:line` that declares the autofocus.
 2. State in the comment whether the autofocus behavior was actually measured in a browser (with an authenticated session when the route requires one; without a session most auth sub-routes redirect to `/fr/auth` and any measurement is wrong) or only declared in the code.
 3. Never add a route on the sole basis of an `autofocus` attribute in the DOM: two routes were measured with a declared autofocus that poses no focus at all.
+
+### Skip links and anchor landing (RGAA 12.7)
+
+`useScrollToAnchor` focuses the anchor target **before** measuring where to scroll, then measures on the next animation frame. The order is not cosmetic.
+
+The DSFR skip link bar switches from `position: absolute` to `position: relative` while it holds the focus (`.fr-skiplinks:focus-within`, `dsfr.css`) and pushes the page down by its own height. Measuring in that state and then moving the focus out of the bar makes it collapse mid-animation: the scroll lands 48 px too low and the top of the target ends up above the viewport. Measured on `/`, `/agir` and a content page. Focusing first, then measuring one frame later, measures a page that has already settled.
+
+An anchor that targets the current page (`href="#contenu"`) yields an empty `path` once split on `#`. Treating it as a navigation calls `router.push("")`, which Next resolves to the route pattern: a 404 on dynamic routes and a lost query string elsewhere.
 
 ## Debugging announcements (visual overlay)
 


### PR DESCRIPTION
Audit RGAA Ideance, RGA-8.

À chaque changement de page, le lecteur d'écran annonce maintenant le titre de la nouvelle page et le focus est repositionné en tête de contenu. Au passage, la navigation vers une ancre de la même page (12.7) fonctionne à nouveau et amène bien au bon endroit.

À savoir : comme convenu avec Jérémy sur le ticket Linear RGA-8, ce mécanisme d'annonce de route est une exception documentée à la règle `useAnnounce` du fichier AGENTS.md, la ligne est ajoutée dans cette PR.

À savoir aussi : les pages qui placent déjà le focus sur un champ à l'arrivée ne déclenchent aucune annonce, c'est l'exception écrite dans la grille Ideance.

Types et tests verts (375 tests dont 34 nouveaux), aucun instantané modifié. Branche rebasée sur dev à jour.
