### PR TITLE
fix(a11y): combobox département selon le motif ARIA APG (RGAA 7.1, 8.9)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -224,9 +224,9 @@
     "invalid_phone_number": "Ceci n'est pas un numéro de téléphone valide, vérifiez votre saisie."
   },
   "EditDepartments": {
-    "suggestions_found_zero": "Aucune suggestion trouvée, modifiez votre recherche",
-    "suggestions_found_one": "{{count}} suggestion trouvée, utilisez les flèches haut et bas pour la parcourir",
-    "suggestions_found_other": "{{count}} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir",
+    "suggestions_found_zero": "Aucune suggestion, modifiez votre recherche",
+    "suggestions_found_one": "{{count}} suggestion",
+    "suggestions_found_other": "{{count}} suggestions",
     "department_removed": "Département {{department}} retiré.",
     "last_department_removed": "Département {{department}} retiré. Vous devez sélectionner au moins un département.",
     "remove_department": "Retirer le département {{department}}",

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -223,6 +223,15 @@
     "check_mail": "vérifiez l'orthographe.",
     "invalid_phone_number": "Ceci n'est pas un numéro de téléphone valide, vérifiez votre saisie."
   },
+  "EditDepartments": {
+    "suggestions_found_zero": "Aucune suggestion trouvée, modifiez votre recherche",
+    "suggestions_found_one": "{{count}} suggestion trouvée, utilisez les flèches haut et bas pour la parcourir",
+    "suggestions_found_other": "{{count}} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir",
+    "department_removed": "Département {{department}} retiré.",
+    "last_department_removed": "Département {{department}} retiré. Vous devez sélectionner au moins un département.",
+    "remove_department": "Retirer le département {{department}}",
+    "suggestions_label": "Suggestions de départements"
+  },
   "UnauthorizedAccess": {
     "access_denied": "Accès refusé",
     "back_home": "Revenir à l'accueil"

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -230,7 +230,11 @@
     "department_removed": "Département {{department}} retiré.",
     "last_department_removed": "Département {{department}} retiré. Vous devez sélectionner au moins un département.",
     "remove_department": "Retirer le département {{department}}",
-    "suggestions_label": "Suggestions de départements"
+    "suggestions_label": "Suggestions de départements",
+    "label": "Nom ou numéro du département",
+    "hint": "Plusieurs choix possibles",
+    "error_required": "Vous devez sélectionner au moins un département",
+    "error_generic": "Une erreur s'est produite, veuillez réessayer ou contacter un administrateur."
   },
   "UnauthorizedAccess": {
     "access_denied": "Accès refusé",

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.module.scss
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.module.scss
@@ -18,6 +18,12 @@
     text-align: left;
     padding: u(2) u(3);
   }
+
+  // Visual focus of the option pointed at by aria-activedescendant.
+  // Only shows in a state that did not exist before: arrow key navigation.
+  & > button.active {
+    background: var(--background-action-low-blue-france);
+  }
 }
 
 .option {

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -234,7 +234,7 @@ const EditDepartments = (props: Props) => {
 
   return (
     <form onSubmit={submit}>
-      <label htmlFor="location" className="fr-label mb-2">
+      <label htmlFor={INPUT_ID} className="fr-label mb-2">
         Nom ou numéro du département
         <span className="fr-hint-text">Plusieurs choix possibles</span>
       </label>

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -16,6 +16,8 @@ import styles from "./EditDepartments.module.scss";
  * or user profile modal), so fixed ids stay deterministic between server and client.
  */
 const INPUT_ID = "departments-search";
+const LISTBOX_ID = "departments-suggestions";
+const getOptionId = (code: string) => `departments-option-${code}`;
 
 interface Props {
   successCallback: () => void;
@@ -118,6 +120,17 @@ const EditDepartments = (props: Props) => {
               id={INPUT_ID}
               placeholder="Rechercher"
               type="search"
+              // Browser autofill would cover the suggestion list, and a department
+              // search maps to no HTML autofill token.
+              autoComplete="off"
+              role="combobox"
+              aria-expanded={isListboxOpen}
+              aria-controls={LISTBOX_ID}
+              // "list" and not "both": the suggestion engine scores by inclusion and
+              // Levenshtein distance, so the first suggestion often does not start
+              // with what was typed. Inline completion would overwrite the input
+              // with unrelated text. Documented gap to the APG example.
+              aria-autocomplete="list"
               value={search}
               onChange={handleChange}
               onFocus={() => setIsInputFocused(true)}
@@ -141,11 +154,22 @@ const EditDepartments = (props: Props) => {
             )}
           </div>
           {isListboxOpen && (
-            <div className={styles.suggestions}>
+            <div
+              className={styles.suggestions}
+              id={LISTBOX_ID}
+              role="listbox"
+              aria-label="Suggestions de départements"
+            >
               {predictions.map((p) => (
+                // `role="option"` on a <button> is allowed by ARIA in HTML, and it
+                // keeps the existing `.suggestions > button` styling untouched.
                 <button
                   key={p.id}
                   type="button"
+                  role="option"
+                  id={getOptionId(p.id)}
+                  aria-selected={false}
+                  tabIndex={-1}
                   onClick={(e: any) => {
                     e.preventDefault();
                     onPlaceSelected(p.id);

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -59,7 +59,12 @@ const EditDepartments = (props: Props) => {
       } catch (e: any) {
         props.setIsLoading?.(false);
         logger.error(e);
-        setError("Une erreur s'est produite, veuillez réessayer ou contacter un administrateur.");
+        setError(
+          t(
+            "EditDepartments.error_generic",
+            "Une erreur s'est produite, veuillez réessayer ou contacter un administrateur.",
+          ),
+        );
       }
     },
     [userDetails, selectedDepartments, props.successCallback],
@@ -235,19 +240,23 @@ const EditDepartments = (props: Props) => {
 
   useEffect(() => {
     if (selectedDepartments.length === 0 && isDirty) {
-      setError("Vous devez sélectionner au moins un département");
+      setError(
+        t("EditDepartments.error_required", "Vous devez sélectionner au moins un département"),
+      );
     } else {
       setError("");
     }
-  }, [selectedDepartments, isDirty]);
+  }, [selectedDepartments, isDirty, t]);
 
   if (!userDetails) return null;
 
   return (
     <form onSubmit={submit}>
       <label htmlFor={INPUT_ID} className="fr-label mb-2">
-        Nom ou numéro du département
-        <span className="fr-hint-text">Plusieurs choix possibles</span>
+        {t("EditDepartments.label", "Nom ou numéro du département")}
+        <span className="fr-hint-text">
+          {t("EditDepartments.hint", "Plusieurs choix possibles")}
+        </span>
       </label>
       <div className="relative">
         <div ref={suggestionsRef}>
@@ -359,7 +368,7 @@ const EditDepartments = (props: Props) => {
           nativeButtonProps={{ type: "submit" }}
           disabled={loading || selectedDepartments.length === 0}
         >
-          Valider
+          {t("Valider", "Valider")}
         </Button>
       </div>
     </form>

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -89,20 +89,34 @@ const EditDepartments = (props: Props) => {
   useEffect(() => {
     if (hidePredictions || search.length < 2) {
       announcedCountRef.current = null;
-      return;
+      return undefined;
     }
     const count = predictions.length;
-    if (announcedCountRef.current === count) return;
+
+    if (count === 0) {
+      // Timed from the LAST keystroke, not from the change of count: the effect
+      // cleanup restarts this timer on every keystroke (search is a dependency),
+      // so the message always lands ~1.5 s after typing stops, clear of the
+      // keyboard echo window where VoiceOver loses it. Once said, it is not
+      // repeated while the count stays at 0; a non-zero count re-arms it.
+      if (announcedCountRef.current === count) return undefined;
+      const timer = setTimeout(() => {
+        announcedCountRef.current = 0;
+        announce("Aucune suggestion trouvée, modifiez votre recherche");
+      }, 1500);
+      return () => clearTimeout(timer);
+    }
+
+    if (announcedCountRef.current === count) return undefined;
     announcedCountRef.current = count;
 
-    let message: string;
-    if (count === 0) message = "Aucune suggestion trouvée, modifiez votre recherche";
-    else if (count === 1)
-      message = "1 suggestion trouvée, utilisez les flèches haut et bas pour la parcourir";
-    else
-      message = `${count} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir`;
+    const message =
+      count === 1
+        ? "1 suggestion trouvée, utilisez les flèches haut et bas pour la parcourir"
+        : `${count} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir`;
 
     announce(message, { delay: 1500 });
+    return undefined;
   }, [predictions, hidePredictions, search, announce]);
 
   const handleChange = (e: any) => setSearch(e.target.value);

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -1,5 +1,4 @@
 import { Button } from "@codegouvfr/react-dsfr/Button";
-import { SearchBar } from "@codegouvfr/react-dsfr/SearchBar";
 import { logger } from "logger";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
@@ -11,6 +10,12 @@ import { formatDepartment } from "~/lib/departments";
 import { userDetailsSelector } from "~/services/User/user.selectors";
 import API from "~/utils/API";
 import styles from "./EditDepartments.module.scss";
+
+/**
+ * Fixed ids: this combobox is rendered at most once per page (registration step
+ * or user profile modal), so fixed ids stay deterministic between server and client.
+ */
+const INPUT_ID = "departments-search";
 
 interface Props {
   successCallback: () => void;
@@ -58,17 +63,24 @@ const EditDepartments = (props: Props) => {
   const suggestionsRef = useRef<HTMLDivElement | null>(null);
   useOutsideClick(suggestionsRef, () => setHidePredictions(true));
 
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [isInputFocused, setIsInputFocused] = useState(false);
+
+  const isListboxOpen = !hidePredictions && predictions.length > 0;
+
   const handleChange = (e: any) => setSearch(e.target.value);
   const onPlaceSelected = async (id: string) => {
     if (!isDirty) setIsDirty(true);
     const place = await getPlaceSelected(id);
     if (!place) return;
     if (!selectedDepartments.includes(place)) {
-      const newDeps = [...(selectedDepartments || []), place];
-      setSelectedDepartments(newDeps);
-      setHidePredictions(true);
-      setSearch("");
+      setSelectedDepartments([...(selectedDepartments || []), place]);
     }
+    // The combobox always closes and clears after a selection, and focus never
+    // leaves the text field: this is what makes Enter usable on an option.
+    setHidePredictions(true);
+    setSearch("");
+    inputRef.current?.focus();
   };
 
   useEffect(() => {
@@ -89,29 +101,51 @@ const EditDepartments = (props: Props) => {
       </label>
       <div className="relative">
         <div ref={suggestionsRef}>
-          <SearchBar
-            renderInput={({ className, id, placeholder, type }) => (
-              <input
-                className={className}
-                name="location"
-                id={id}
-                placeholder={placeholder}
-                type={type}
-                value={search}
-                onChange={handleChange}
-                onKeyDown={(event) => {
-                  if (event.key === "Escape") {
-                    setHidePredictions(true);
-                  }
-                }}
-              />
+          {/*
+            Hand-rolled equivalent of the DSFR `SearchBar`, kept class for class so
+            the rendering does not move. `SearchBar` hard-codes `role="search"` on
+            its wrapper, which RGAA 8.9 asks us to drop here, and it renders a
+            submit-typed button inside our form.
+          */}
+          <div className="fr-search-bar">
+            <label className="fr-label" htmlFor={INPUT_ID}>
+              Rechercher
+            </label>
+            <input
+              ref={inputRef}
+              className="fr-input"
+              name="location"
+              id={INPUT_ID}
+              placeholder="Rechercher"
+              type="search"
+              value={search}
+              onChange={handleChange}
+              onFocus={() => setIsInputFocused(true)}
+              onBlur={() => setIsInputFocused(false)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setHidePredictions(true);
+                }
+              }}
+            />
+            {!isInputFocused && search === "" && (
+              <button
+                type="button"
+                className="fr-btn"
+                title="Rechercher"
+                style={{ position: "absolute", right: 0 }}
+                onClick={() => inputRef.current?.focus()}
+              >
+                Rechercher
+              </button>
             )}
-          />
-          {!!(!hidePredictions && predictions?.length) && (
+          </div>
+          {isListboxOpen && (
             <div className={styles.suggestions}>
-              {predictions.slice(0, 5).map((p, i) => (
+              {predictions.map((p) => (
                 <button
-                  key={i}
+                  key={p.id}
+                  type="button"
                   onClick={(e: any) => {
                     e.preventDefault();
                     onPlaceSelected(p.id);

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useAsyncFn } from "react-use";
+import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import ErrorMessage from "~/components/UI/ErrorMessage";
 import { useDepartmentAutocomplete, useOutsideClick } from "~/hooks";
 import { cls } from "~/lib/classname";
@@ -79,6 +80,30 @@ const EditDepartments = (props: Props) => {
   useEffect(() => {
     setActiveIndex(-1);
   }, [predictions]);
+
+  const announce = useAnnounce();
+  const announcedCountRef = useRef<number | null>(null);
+
+  // Reads out how many suggestions are available. Fires on a change of count, not
+  // on every keystroke, so it does not talk over the listbox semantics.
+  useEffect(() => {
+    if (hidePredictions || search.length < 2) {
+      announcedCountRef.current = null;
+      return;
+    }
+    const count = predictions.length;
+    if (announcedCountRef.current === count) return;
+    announcedCountRef.current = count;
+
+    let message: string;
+    if (count === 0) message = "Aucune suggestion trouvée, modifiez votre recherche";
+    else if (count === 1)
+      message = "1 suggestion trouvée, utilisez les flèches haut et bas pour la parcourir";
+    else
+      message = `${count} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir`;
+
+    announce(message, { delay: 1500 });
+  }, [predictions, hidePredictions, search, announce]);
 
   const handleChange = (e: any) => setSearch(e.target.value);
   const onPlaceSelected = async (id: string) => {

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -121,6 +121,16 @@ const EditDepartments = (props: Props) => {
     inputRef.current?.focus();
   };
 
+  const removeAnnounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // A removal announcement still pending when the component unmounts (modal
+  // closed right after a removal) must not fire into a page that moved on.
+  useEffect(
+    () => () => {
+      if (removeAnnounceTimerRef.current) clearTimeout(removeAnnounceTimerRef.current);
+    },
+    [],
+  );
+
   const removeDepartment = (dep: string) => {
     const remaining = selectedDepartments.filter((d) => d !== dep);
     setSelectedDepartments(remaining);
@@ -128,14 +138,20 @@ const EditDepartments = (props: Props) => {
     // <body>. Focus goes back to the search field because it is the only target
     // that always exists: when the last chip goes, the whole chip list unmounts.
     inputRef.current?.focus();
-    // "interrupt" so this direct answer to a user action is not queued behind the
-    // delayed suggestion counts.
-    announce(
+    const message =
       remaining.length === 0
         ? `Département ${formatDepartment(dep)} retiré. Vous devez sélectionner au moins un département.`
-        : `Département ${formatDepartment(dep)} retiré.`,
-      { priority: "interrupt" },
-    );
+        : `Département ${formatDepartment(dep)} retiré.`;
+    // VoiceOver drops a live-region write that lands while it is still reacting
+    // to the focus() above (measured 3-5 ms after focusin). The interrupt path
+    // of the announcer ignores options.delay, so the offset lives here: ~300 ms
+    // puts the write clear of the focus echo. "interrupt" so this direct answer
+    // to a user action is not queued behind the delayed suggestion counts.
+    if (removeAnnounceTimerRef.current) clearTimeout(removeAnnounceTimerRef.current);
+    removeAnnounceTimerRef.current = setTimeout(() => {
+      removeAnnounceTimerRef.current = null;
+      announce(message, { priority: "interrupt" });
+    }, 300);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -294,9 +294,8 @@ const EditDepartments = (props: Props) => {
             {!isInputFocused && search === "" && (
               <button
                 type="button"
-                className="fr-btn"
+                className="fr-btn absolute end-0"
                 title={t("Rechercher", "Rechercher")}
-                style={{ position: "absolute", right: 0 }}
                 onClick={() => inputRef.current?.focus()}
               >
                 {t("Rechercher", "Rechercher")}

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -220,8 +220,9 @@ const EditDepartments = (props: Props) => {
 
       case "Escape":
         event.preventDefault();
-        // Open: close and keep what was typed. Closed: clear the field, as the
-        // ARIA Authoring Practices Guide (APG) prescribes for an editable combobox.
+        // Open: close and keep what was typed. Closed: clear the field. This is the
+        // W3C combobox pattern the audit asked us to follow (ARIA Authoring Practices
+        // Guide, https://www.w3.org/WAI/ARIA/apg/patterns/combobox/), not a bug.
         if (isListboxOpen) setHidePredictions(true);
         else setSearch("");
         return;

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -121,6 +121,23 @@ const EditDepartments = (props: Props) => {
     inputRef.current?.focus();
   };
 
+  const removeDepartment = (dep: string) => {
+    const remaining = selectedDepartments.filter((d) => d !== dep);
+    setSelectedDepartments(remaining);
+    // The activated button unmounts along with its chip, and focus would fall on
+    // <body>. Focus goes back to the search field because it is the only target
+    // that always exists: when the last chip goes, the whole chip list unmounts.
+    inputRef.current?.focus();
+    // "interrupt" so this direct answer to a user action is not queued behind the
+    // delayed suggestion counts.
+    announce(
+      remaining.length === 0
+        ? `Département ${formatDepartment(dep)} retiré. Vous devez sélectionner au moins un département.`
+        : `Département ${formatDepartment(dep)} retiré.`,
+      { priority: "interrupt" },
+    );
+  };
+
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const count = predictions.length;
 
@@ -215,7 +232,9 @@ const EditDepartments = (props: Props) => {
               autoComplete="off"
               role="combobox"
               aria-expanded={isListboxOpen}
-              aria-controls={LISTBOX_ID}
+              // Pointed at only while the listbox exists: a dangling aria-controls
+              // is a dead reference for assistive technologies.
+              aria-controls={isListboxOpen ? LISTBOX_ID : undefined}
               // "list" and not "both": the suggestion engine scores by inclusion and
               // Levenshtein distance, so the first suggestion often does not start
               // with what was typed. Inline completion would overwrite the input
@@ -283,7 +302,7 @@ const EditDepartments = (props: Props) => {
                   // Without this the DSFR button falls back to type="submit" and
                   // removing a chip saves the form.
                   nativeButtonProps={{ type: "button" }}
-                  onClick={() => setSelectedDepartments((deps) => deps?.filter((d) => d !== dep))}
+                  onClick={() => removeDepartment(dep)}
                 />
               </div>
             ))}

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -22,15 +22,6 @@ const INPUT_ID = "departments-search";
 const LISTBOX_ID = "departments-suggestions";
 const getOptionId = (code: string) => `departments-option-${code}`;
 
-// French fallbacks: the keys live in fr/common.json only until they reach the translation flow.
-const SUGGESTIONS_FOUND_DEFAULTS = {
-  defaultValue_zero: "Aucune suggestion trouvée, modifiez votre recherche",
-  defaultValue_one:
-    "{{count}} suggestion trouvée, utilisez les flèches haut et bas pour la parcourir",
-  defaultValue_other:
-    "{{count}} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir",
-};
-
 interface Props {
   successCallback: () => void;
   setIsLoading?: (isLoading: boolean) => void;
@@ -114,7 +105,10 @@ const EditDepartments = (props: Props) => {
       const timer = setTimeout(() => {
         announcedCountRef.current = 0;
         announce(
-          t("EditDepartments.suggestions_found", { count: 0, ...SUGGESTIONS_FOUND_DEFAULTS }),
+          t("EditDepartments.suggestions_found", {
+            count: 0,
+            defaultValue: "Aucune suggestion, modifiez votre recherche",
+          }),
         );
       }, 1500);
       return () => clearTimeout(timer);
@@ -123,9 +117,14 @@ const EditDepartments = (props: Props) => {
     if (announcedCountRef.current === count) return undefined;
     announcedCountRef.current = count;
 
-    announce(t("EditDepartments.suggestions_found", { count, ...SUGGESTIONS_FOUND_DEFAULTS }), {
-      delay: 1500,
-    });
+    announce(
+      t("EditDepartments.suggestions_found", {
+        count,
+        defaultValue_one: "{{count}} suggestion",
+        defaultValue_other: "{{count}} suggestions",
+      }),
+      { delay: 1500 },
+    );
     return undefined;
   }, [predictions, hidePredictions, search, announce, t]);
 

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -87,7 +87,6 @@ const EditDepartments = (props: Props) => {
   const isListboxOpen = !hidePredictions && predictions.length > 0;
   const activeOption = isListboxOpen ? predictions[activeIndex] : undefined;
 
-  // Any change to the suggestion set drops the visual focus.
   useEffect(() => {
     setActiveIndex(-1);
   }, [predictions]);
@@ -218,7 +217,7 @@ const EditDepartments = (props: Props) => {
       case "Escape":
         event.preventDefault();
         // Open: close and keep what was typed. Closed: clear the field, as the
-        // APG prescribes for an editable combobox.
+        // ARIA Authoring Practices Guide (APG) prescribes for an editable combobox.
         if (isListboxOpen) setHidePredictions(true);
         else setSearch("");
         return;
@@ -269,20 +268,13 @@ const EditDepartments = (props: Props) => {
               id={INPUT_ID}
               placeholder={t("Rechercher", "Rechercher")}
               type="search"
-              // Browser autofill would cover the suggestion list, and a department
-              // search maps to no HTML autofill token.
               autoComplete="off"
               // The spell checker talks over the announcements in VoiceOver (measured 27/08).
               spellCheck={false}
               role="combobox"
               aria-expanded={isListboxOpen}
-              // Pointed at only while the listbox exists: a dangling aria-controls
-              // is a dead reference for assistive technologies.
               aria-controls={isListboxOpen ? LISTBOX_ID : undefined}
-              // "list" and not "both": the suggestion engine scores by inclusion and
-              // Levenshtein distance, so the first suggestion often does not start
-              // with what was typed. Inline completion would overwrite the input
-              // with unrelated text. Documented gap to the APG example.
+              // "list", not "both": suggestions are scored by similarity, so inline completion would overwrite the input
               aria-autocomplete="list"
               aria-activedescendant={activeOption ? getOptionId(activeOption.id) : undefined}
               value={search}

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -260,6 +260,11 @@ const EditDepartments = (props: Props) => {
               // Browser autofill would cover the suggestion list, and a department
               // search maps to no HTML autofill token.
               autoComplete="off"
+              // Department names are not prose: the spell checker underlines the
+              // query and VoiceOver reads "mal orthographié" over the live-region
+              // announcements (heard in the 27/08 session, masking "Aucune
+              // suggestion trouvée").
+              spellCheck={false}
               role="combobox"
               aria-expanded={isListboxOpen}
               // Pointed at only while the listbox exists: a dangling aria-controls

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -278,8 +278,11 @@ const EditDepartments = (props: Props) => {
                 <Button
                   iconId="fr-icon-close-line"
                   priority="tertiary no outline"
-                  title="Retirer le département"
+                  title={`Retirer le département ${formatDepartment(dep)}`}
                   size="small"
+                  // Without this the DSFR button falls back to type="submit" and
+                  // removing a chip saves the form.
+                  nativeButtonProps={{ type: "button" }}
                   onClick={() => setSelectedDepartments((deps) => deps?.filter((d) => d !== dep))}
                 />
               </div>

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -120,7 +120,7 @@ const EditDepartments = (props: Props) => {
   }, [predictions, hidePredictions, search, announce]);
 
   const handleChange = (e: any) => setSearch(e.target.value);
-  const onPlaceSelected = async (id: string) => {
+  const onPlaceSelected = async (id: string, { restoreFocus = true } = {}) => {
     if (!isDirty) setIsDirty(true);
     const place = await getPlaceSelected(id);
     if (!place) return;
@@ -132,7 +132,7 @@ const EditDepartments = (props: Props) => {
     setHidePredictions(true);
     setSearch("");
     setActiveIndex(-1);
-    inputRef.current?.focus();
+    if (restoreFocus) inputRef.current?.focus();
   };
 
   const removeAnnounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -212,8 +212,8 @@ const EditDepartments = (props: Props) => {
         return;
 
       case "Tab":
-        // Accept the focused option, then let focus move on normally.
-        if (activeOption) onPlaceSelected(activeOption.id);
+        // Tab has already moved focus on; the selection must not pull it back.
+        if (activeOption) onPlaceSelected(activeOption.id, { restoreFocus: false });
         setHidePredictions(true);
         return;
 

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { logger } from "logger";
+import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { useAsyncFn } from "react-use";
@@ -67,8 +68,17 @@ const EditDepartments = (props: Props) => {
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [isInputFocused, setIsInputFocused] = useState(false);
+  // Index of the option holding the visual focus. DOM focus never leaves the input,
+  // the position is carried by aria-activedescendant.
+  const [activeIndex, setActiveIndex] = useState(-1);
 
   const isListboxOpen = !hidePredictions && predictions.length > 0;
+  const activeOption = isListboxOpen ? predictions[activeIndex] : undefined;
+
+  // Any change to the suggestion set drops the visual focus.
+  useEffect(() => {
+    setActiveIndex(-1);
+  }, [predictions]);
 
   const handleChange = (e: any) => setSearch(e.target.value);
   const onPlaceSelected = async (id: string) => {
@@ -82,7 +92,62 @@ const EditDepartments = (props: Props) => {
     // leaves the text field: this is what makes Enter usable on an option.
     setHidePredictions(true);
     setSearch("");
+    setActiveIndex(-1);
     inputRef.current?.focus();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    const count = predictions.length;
+
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        if (count === 0) return;
+        if (!isListboxOpen) {
+          setHidePredictions(false);
+          setActiveIndex(event.altKey ? -1 : 0);
+          return;
+        }
+        if (event.altKey) return;
+        setActiveIndex((index) => (index + 1 >= count ? 0 : index + 1));
+        return;
+
+      case "ArrowUp":
+        event.preventDefault();
+        if (count === 0) return;
+        if (!isListboxOpen) {
+          setHidePredictions(false);
+          setActiveIndex(count - 1);
+          return;
+        }
+        setActiveIndex((index) => (index <= 0 ? count - 1 : index - 1));
+        return;
+
+      case "Enter":
+        // Closed listbox: implicit form submission is left untouched.
+        if (!isListboxOpen) return;
+        event.preventDefault();
+        if (activeOption) onPlaceSelected(activeOption.id);
+        else setHidePredictions(true);
+        return;
+
+      case "Escape":
+        event.preventDefault();
+        // Open: close and keep what was typed. Closed: clear the field, as the
+        // APG prescribes for an editable combobox.
+        if (isListboxOpen) setHidePredictions(true);
+        else setSearch("");
+        return;
+
+      case "Tab":
+        // Accept the focused option, then let focus move on normally.
+        if (activeOption) onPlaceSelected(activeOption.id);
+        setHidePredictions(true);
+        return;
+
+      default:
+        return;
+    }
   };
 
   useEffect(() => {
@@ -131,15 +196,12 @@ const EditDepartments = (props: Props) => {
               // with what was typed. Inline completion would overwrite the input
               // with unrelated text. Documented gap to the APG example.
               aria-autocomplete="list"
+              aria-activedescendant={activeOption ? getOptionId(activeOption.id) : undefined}
               value={search}
               onChange={handleChange}
               onFocus={() => setIsInputFocused(true)}
               onBlur={() => setIsInputFocused(false)}
-              onKeyDown={(event) => {
-                if (event.key === "Escape") {
-                  setHidePredictions(true);
-                }
-              }}
+              onKeyDown={handleKeyDown}
             />
             {!isInputFocused && search === "" && (
               <button
@@ -160,7 +222,7 @@ const EditDepartments = (props: Props) => {
               role="listbox"
               aria-label="Suggestions de départements"
             >
-              {predictions.map((p) => (
+              {predictions.map((p, index) => (
                 // `role="option"` on a <button> is allowed by ARIA in HTML, and it
                 // keeps the existing `.suggestions > button` styling untouched.
                 <button
@@ -168,8 +230,9 @@ const EditDepartments = (props: Props) => {
                   type="button"
                   role="option"
                   id={getOptionId(p.id)}
-                  aria-selected={false}
+                  aria-selected={index === activeIndex}
                   tabIndex={-1}
+                  className={index === activeIndex ? styles.active : undefined}
                   onClick={(e: any) => {
                     e.preventDefault();
                     onPlaceSelected(p.id);

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -105,11 +105,7 @@ const EditDepartments = (props: Props) => {
     const count = predictions.length;
 
     if (count === 0) {
-      // Timed from the LAST keystroke, not from the change of count: the effect
-      // cleanup restarts this timer on every keystroke (search is a dependency),
-      // so the message always lands ~1.5 s after typing stops, clear of the
-      // keyboard echo window where VoiceOver loses it. Once said, it is not
-      // repeated while the count stays at 0; a non-zero count re-arms it.
+      // ~1.5 s from the last keystroke clears the keyboard echo (measured 27/08); said only once.
       if (announcedCountRef.current === count) return undefined;
       const timer = setTimeout(() => {
         announcedCountRef.current = 0;
@@ -176,11 +172,7 @@ const EditDepartments = (props: Props) => {
             defaultValue: "Département {{department}} retiré.",
             interpolation: { escapeValue: false },
           });
-    // VoiceOver drops a live-region write that lands while it is still reacting
-    // to the focus() above (measured 3-5 ms after focusin). The interrupt path
-    // of the announcer ignores options.delay, so the offset lives here: ~300 ms
-    // puts the write clear of the focus echo. "interrupt" so this direct answer
-    // to a user action is not queued behind the delayed suggestion counts.
+    // ~300 ms clears the focus echo (measured 27/08); interrupt skips the queued counts.
     if (removeAnnounceTimerRef.current) clearTimeout(removeAnnounceTimerRef.current);
     removeAnnounceTimerRef.current = setTimeout(() => {
       removeAnnounceTimerRef.current = null;
@@ -280,10 +272,7 @@ const EditDepartments = (props: Props) => {
               // Browser autofill would cover the suggestion list, and a department
               // search maps to no HTML autofill token.
               autoComplete="off"
-              // Department names are not prose: the spell checker underlines the
-              // query and VoiceOver reads "mal orthographié" over the live-region
-              // announcements (heard in the 27/08 session, masking "Aucune
-              // suggestion trouvée").
+              // The spell checker talks over the announcements in VoiceOver (measured 27/08).
               spellCheck={false}
               role="combobox"
               aria-expanded={isListboxOpen}

--- a/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
+++ b/apps/client/src/components/User/EditDepartments/EditDepartments.tsx
@@ -2,6 +2,7 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import { logger } from "logger";
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { useSelector } from "react-redux";
 import { useAsyncFn } from "react-use";
 import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
@@ -21,6 +22,15 @@ const INPUT_ID = "departments-search";
 const LISTBOX_ID = "departments-suggestions";
 const getOptionId = (code: string) => `departments-option-${code}`;
 
+// French fallbacks: the keys live in fr/common.json only until they reach the translation flow.
+const SUGGESTIONS_FOUND_DEFAULTS = {
+  defaultValue_zero: "Aucune suggestion trouvée, modifiez votre recherche",
+  defaultValue_one:
+    "{{count}} suggestion trouvée, utilisez les flèches haut et bas pour la parcourir",
+  defaultValue_other:
+    "{{count}} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir",
+};
+
 interface Props {
   successCallback: () => void;
   setIsLoading?: (isLoading: boolean) => void;
@@ -28,6 +38,7 @@ interface Props {
 }
 
 const EditDepartments = (props: Props) => {
+  const { t } = useTranslation();
   const [error, setError] = useState("");
   const [selectedDepartments, setSelectedDepartments] = useState<string[]>([]);
   const [isDirty, setIsDirty] = useState(false);
@@ -102,7 +113,9 @@ const EditDepartments = (props: Props) => {
       if (announcedCountRef.current === count) return undefined;
       const timer = setTimeout(() => {
         announcedCountRef.current = 0;
-        announce("Aucune suggestion trouvée, modifiez votre recherche");
+        announce(
+          t("EditDepartments.suggestions_found", { count: 0, ...SUGGESTIONS_FOUND_DEFAULTS }),
+        );
       }, 1500);
       return () => clearTimeout(timer);
     }
@@ -110,14 +123,11 @@ const EditDepartments = (props: Props) => {
     if (announcedCountRef.current === count) return undefined;
     announcedCountRef.current = count;
 
-    const message =
-      count === 1
-        ? "1 suggestion trouvée, utilisez les flèches haut et bas pour la parcourir"
-        : `${count} suggestions trouvées, utilisez les flèches haut et bas pour les parcourir`;
-
-    announce(message, { delay: 1500 });
+    announce(t("EditDepartments.suggestions_found", { count, ...SUGGESTIONS_FOUND_DEFAULTS }), {
+      delay: 1500,
+    });
     return undefined;
-  }, [predictions, hidePredictions, search, announce]);
+  }, [predictions, hidePredictions, search, announce, t]);
 
   const handleChange = (e: any) => setSearch(e.target.value);
   const onPlaceSelected = async (id: string, { restoreFocus = true } = {}) => {
@@ -152,10 +162,20 @@ const EditDepartments = (props: Props) => {
     // <body>. Focus goes back to the search field because it is the only target
     // that always exists: when the last chip goes, the whole chip list unmounts.
     inputRef.current?.focus();
+    const department = formatDepartment(dep);
     const message =
       remaining.length === 0
-        ? `Département ${formatDepartment(dep)} retiré. Vous devez sélectionner au moins un département.`
-        : `Département ${formatDepartment(dep)} retiré.`;
+        ? t("EditDepartments.last_department_removed", {
+            department,
+            defaultValue:
+              "Département {{department}} retiré. Vous devez sélectionner au moins un département.",
+            interpolation: { escapeValue: false },
+          })
+        : t("EditDepartments.department_removed", {
+            department,
+            defaultValue: "Département {{department}} retiré.",
+            interpolation: { escapeValue: false },
+          });
     // VoiceOver drops a live-region write that lands while it is still reacting
     // to the focus() above (measured 3-5 ms after focusin). The interrupt path
     // of the announcer ignores options.delay, so the offset lives here: ~300 ms
@@ -248,14 +268,14 @@ const EditDepartments = (props: Props) => {
           */}
           <div className="fr-search-bar">
             <label className="fr-label" htmlFor={INPUT_ID}>
-              Rechercher
+              {t("Rechercher", "Rechercher")}
             </label>
             <input
               ref={inputRef}
               className="fr-input"
               name="location"
               id={INPUT_ID}
-              placeholder="Rechercher"
+              placeholder={t("Rechercher", "Rechercher")}
               type="search"
               // Browser autofill would cover the suggestion list, and a department
               // search maps to no HTML autofill token.
@@ -286,11 +306,11 @@ const EditDepartments = (props: Props) => {
               <button
                 type="button"
                 className="fr-btn"
-                title="Rechercher"
+                title={t("Rechercher", "Rechercher")}
                 style={{ position: "absolute", right: 0 }}
                 onClick={() => inputRef.current?.focus()}
               >
-                Rechercher
+                {t("Rechercher", "Rechercher")}
               </button>
             )}
           </div>
@@ -299,7 +319,7 @@ const EditDepartments = (props: Props) => {
               className={styles.suggestions}
               id={LISTBOX_ID}
               role="listbox"
-              aria-label="Suggestions de départements"
+              aria-label={t("EditDepartments.suggestions_label", "Suggestions de départements")}
             >
               {predictions.map((p, index) => (
                 // `role="option"` on a <button> is allowed by ARIA in HTML, and it
@@ -332,7 +352,11 @@ const EditDepartments = (props: Props) => {
                 <Button
                   iconId="fr-icon-close-line"
                   priority="tertiary no outline"
-                  title={`Retirer le département ${formatDepartment(dep)}`}
+                  title={t("EditDepartments.remove_department", {
+                    department: formatDepartment(dep),
+                    defaultValue: "Retirer le département {{department}}",
+                    interpolation: { escapeValue: false },
+                  })}
                   size="small"
                   // Without this the DSFR button falls back to type="submit" and
                   // removing a chip saves the form.

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -126,6 +126,24 @@ describe("EditDepartments, department combobox", () => {
     expect(screen.getByTitle("Retirer le département Paris (75)")).toBeInTheDocument();
   });
 
+  it("lets Tab move focus on after accepting the active option", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+    const input = getInput();
+
+    await user.type(input, "Paris");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    await user.keyboard("{ArrowDown}");
+
+    await user.tab();
+
+    // The async selection settles after Tab has moved focus: it must not pull it back.
+    await waitFor(() =>
+      expect(screen.getByTitle("Retirer le département Paris (75)")).toBeInTheDocument(),
+    );
+    expect(input).not.toHaveFocus();
+  });
+
   it("closes on Escape, then clears the field on a second Escape", async () => {
     const user = userEvent.setup();
     await renderComponent();

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -1,0 +1,179 @@
+import "@testing-library/jest-dom";
+import { act, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { initialMockStore } from "~/__fixtures__/reduxStore";
+import { testUser } from "~/__fixtures__/user";
+import { wrapWithProvidersAndRenderForTesting } from "../../../../../jest/lib/wrapWithProvidersAndRender";
+import EditDepartments from "../EditDepartments";
+
+jest.mock("next/router", () => require("next-router-mock"));
+
+jest.mock("utils/API", () => ({
+  __esModule: true,
+  default: {
+    updateUser: jest.fn().mockResolvedValue({}),
+    isAuth: jest.fn().mockReturnValue(true),
+  },
+}));
+
+const DEPARTMENTS = [
+  { nom: "Paris", code: "75" },
+  { nom: "Pas-de-Calais", code: "62" },
+];
+
+const reduxState = {
+  ...initialMockStore,
+  user: { ...initialMockStore.user, user: testUser },
+};
+
+const renderComponent = async () => {
+  const result = wrapWithProvidersAndRenderForTesting({
+    Component: EditDepartments,
+    compProps: { successCallback: jest.fn() },
+    reduxState,
+  });
+  // Let the one-off department fetch of useDepartmentAutocomplete settle.
+  await act(async () => {});
+  return result;
+};
+
+const getInput = () => screen.getByRole("combobox");
+
+describe("EditDepartments, department combobox", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      json: () => Promise.resolve(DEPARTMENTS),
+    }) as unknown as typeof fetch;
+  });
+
+  it("does not hijack a search role on the wrapping div", async () => {
+    const { container } = await renderComponent();
+    expect(container.querySelectorAll('[role="search"]')).toHaveLength(0);
+  });
+
+  it("exposes the APG combobox attributes, collapsed by default", async () => {
+    await renderComponent();
+    const input = getInput();
+
+    expect(input).toHaveAttribute("aria-expanded", "false");
+    expect(input).toHaveAttribute("aria-controls", "departments-suggestions");
+    expect(input).toHaveAttribute("aria-autocomplete", "list");
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+  });
+
+  it("opens a listbox of options once a search matches", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+
+    await user.type(getInput(), "Paris");
+
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    expect(getInput()).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("option", { name: "Paris" })).toBeInTheDocument();
+  });
+
+  it("moves the visual focus with the arrow keys without moving DOM focus", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+    const input = getInput();
+
+    await user.type(input, "Pa");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", "departments-option-75");
+    expect(screen.getByRole("option", { name: "Paris" })).toHaveAttribute("aria-selected", "true");
+    expect(input).toHaveFocus();
+
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", "departments-option-62");
+
+    // Wraps back to the first option.
+    await user.keyboard("{ArrowDown}");
+    expect(input).toHaveAttribute("aria-activedescendant", "departments-option-75");
+
+    // Wraps backwards to the last option.
+    await user.keyboard("{ArrowUp}");
+    expect(input).toHaveAttribute("aria-activedescendant", "departments-option-62");
+  });
+
+  it("selects the active option with Enter without submitting the form", async () => {
+    const user = userEvent.setup();
+    const API = require("utils/API").default;
+    await renderComponent();
+    const input = getInput();
+
+    await user.type(input, "Paris");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(API.updateUser).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveValue("");
+    expect(input).toHaveFocus();
+    expect(screen.getByTitle("Retirer le département Paris (75)")).toBeInTheDocument();
+  });
+
+  it("closes on Escape, then clears the field on a second Escape", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+    const input = getInput();
+
+    await user.type(input, "Paris");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(input).toHaveValue("Paris");
+
+    await user.keyboard("{Escape}");
+    expect(input).toHaveValue("");
+  });
+
+  it("keeps options out of the tab sequence", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+
+    await user.type(getInput(), "Paris");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    expect(screen.getByRole("option", { name: "Paris" })).toHaveAttribute("tabindex", "-1");
+  });
+
+  it("announces how many suggestions were found", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+
+    await user.type(getInput(), "Pa");
+
+    // The announcer holds the message back by 1500 ms so the interface can settle.
+    await waitFor(
+      () =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          /2 suggestions trouvées, utilisez les flèches haut et bas/,
+        ),
+      { timeout: 4000 },
+    );
+  });
+
+  it("does not submit the form when a department is removed", async () => {
+    const user = userEvent.setup();
+    const API = require("utils/API").default;
+    await renderComponent();
+
+    await user.type(getInput(), "Paris");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    const removeButton = screen.getByTitle("Retirer le département Paris (75)");
+    expect(removeButton).toHaveAttribute("type", "button");
+
+    await user.click(removeButton);
+
+    expect(API.updateUser).not.toHaveBeenCalled();
+    expect(screen.queryByTitle("Retirer le département Paris (75)")).not.toBeInTheDocument();
+  });
+});

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -54,7 +54,7 @@ describe("EditDepartments, department combobox", () => {
     expect(container.querySelectorAll('[role="search"]')).toHaveLength(0);
   });
 
-  it("exposes the APG combobox attributes, collapsed by default", async () => {
+  it("exposes the ARIA Authoring Practices Guide (APG) combobox attributes, collapsed by default", async () => {
     await renderComponent();
     const input = getInput();
 

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -66,6 +66,11 @@ describe("EditDepartments, department combobox", () => {
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
 
+  it("programmatically links the visible label to the search field", async () => {
+    await renderComponent();
+    expect(screen.getByLabelText(/Nom ou numéro du département/)).toBe(getInput());
+  });
+
   it("opens a listbox of options once a search matches", async () => {
     const user = userEvent.setup();
     await renderComponent();

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -21,16 +21,18 @@ const DEPARTMENTS = [
   { nom: "Pas-de-Calais", code: "62" },
 ];
 
-const reduxState = {
+const stateWithUser = (departments?: string[]) => ({
   ...initialMockStore,
-  user: { ...initialMockStore.user, user: testUser },
-};
+  user: { ...initialMockStore.user, user: { ...testUser, departments } },
+});
 
-const renderComponent = async () => {
+const setIsLoading = jest.fn();
+
+const renderComponent = async (departments?: string[]) => {
   const result = wrapWithProvidersAndRenderForTesting({
     Component: EditDepartments,
-    compProps: { successCallback: jest.fn() },
-    reduxState,
+    compProps: { successCallback: jest.fn(), setIsLoading },
+    reduxState: stateWithUser(departments),
   });
   // Let the one-off department fetch of useDepartmentAutocomplete settle.
   await act(async () => {});
@@ -57,8 +59,9 @@ describe("EditDepartments, department combobox", () => {
     const input = getInput();
 
     expect(input).toHaveAttribute("aria-expanded", "false");
-    expect(input).toHaveAttribute("aria-controls", "departments-suggestions");
     expect(input).toHaveAttribute("aria-autocomplete", "list");
+    // Both references point at nothing while the listbox is not rendered.
+    expect(input).not.toHaveAttribute("aria-controls");
     expect(input).not.toHaveAttribute("aria-activedescendant");
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
   });
@@ -71,6 +74,7 @@ describe("EditDepartments, department combobox", () => {
 
     await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
     expect(getInput()).toHaveAttribute("aria-expanded", "true");
+    expect(getInput()).toHaveAttribute("aria-controls", "departments-suggestions");
     expect(screen.getByRole("option", { name: "Paris" })).toBeInTheDocument();
   });
 
@@ -175,5 +179,56 @@ describe("EditDepartments, department combobox", () => {
 
     expect(API.updateUser).not.toHaveBeenCalled();
     expect(screen.queryByTitle("Retirer le département Paris (75)")).not.toBeInTheDocument();
+  });
+
+  // The test above cannot fail if the preventDefault on Enter is removed: with no
+  // department selected the submit button is disabled, so implicit submission
+  // cannot fire in the first place. This one runs the dangerous case.
+  it("does not submit on Enter when a department is already selected", async () => {
+    const user = userEvent.setup();
+    const API = require("utils/API").default;
+    await renderComponent(["75 - Paris"]);
+    const input = getInput();
+
+    // Guard: the scenario is only meaningful if implicit submission is possible.
+    expect(screen.getByRole("button", { name: /Valider/ })).toBeEnabled();
+
+    await user.type(input, "Pas-de");
+    await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument());
+
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(setIsLoading).not.toHaveBeenCalled();
+    expect(API.updateUser).not.toHaveBeenCalled();
+    expect(screen.getByTitle("Retirer le département Pas-de-Calais (62)")).toBeInTheDocument();
+  });
+
+  it("sends focus back to the field when a department is removed", async () => {
+    const user = userEvent.setup();
+    await renderComponent(["75 - Paris", "62 - Pas-de-Calais"]);
+
+    await user.click(screen.getByTitle("Retirer le département Paris (75)"));
+
+    expect(getInput()).toHaveFocus();
+    expect(document.body).not.toHaveFocus();
+    expect(screen.getByTitle("Retirer le département Pas-de-Calais (62)")).toBeInTheDocument();
+  });
+
+  it("does not lose focus nor stay silent when the last department is removed", async () => {
+    const user = userEvent.setup();
+    await renderComponent(["75 - Paris"]);
+
+    await user.click(screen.getByTitle("Retirer le département Paris (75)"));
+
+    // The whole chip list unmounts here, which is the case where focus used to
+    // fall on <body> and the error appeared with nothing said.
+    expect(screen.queryByTitle(/Retirer le département/)).not.toBeInTheDocument();
+    expect(screen.getByText("Vous devez sélectionner au moins un département")).toBeInTheDocument();
+    expect(getInput()).toHaveFocus();
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        /Département Paris \(75\) retiré\. Vous devez sélectionner au moins un département\./,
+      ),
+    );
   });
 });

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -163,6 +163,23 @@ describe("EditDepartments, department combobox", () => {
     );
   });
 
+  it("announces the absence of suggestions once typing stops", async () => {
+    const user = userEvent.setup();
+    await renderComponent();
+
+    await user.type(getInput(), "zz");
+
+    // Timed from the last keystroke: the message lands ~1.5 s after typing
+    // stops, outside the keyboard echo window where VoiceOver loses it.
+    await waitFor(
+      () =>
+        expect(screen.getByRole("status")).toHaveTextContent(
+          /Aucune suggestion trouvée, modifiez votre recherche/,
+        ),
+      { timeout: 4000 },
+    );
+  });
+
   it("does not submit the form when a department is removed", async () => {
     const user = userEvent.setup();
     const API = require("utils/API").default;

--- a/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
+++ b/apps/client/src/components/User/EditDepartments/__tests__/EditDepartments.a11y.test.tsx
@@ -177,13 +177,9 @@ describe("EditDepartments, department combobox", () => {
     await user.type(getInput(), "Pa");
 
     // The announcer holds the message back by 1500 ms so the interface can settle.
-    await waitFor(
-      () =>
-        expect(screen.getByRole("status")).toHaveTextContent(
-          /2 suggestions trouvées, utilisez les flèches haut et bas/,
-        ),
-      { timeout: 4000 },
-    );
+    await waitFor(() => expect(screen.getByRole("status")).toHaveTextContent(/2 suggestions/), {
+      timeout: 4000,
+    });
   });
 
   it("announces the absence of suggestions once typing stops", async () => {
@@ -197,7 +193,7 @@ describe("EditDepartments, department combobox", () => {
     await waitFor(
       () =>
         expect(screen.getByRole("status")).toHaveTextContent(
-          /Aucune suggestion trouvée, modifiez votre recherche/,
+          /Aucune suggestion, modifiez votre recherche/,
         ),
       { timeout: 4000 },
     );


### PR DESCRIPTION
Audit RGAA Ideance, RGA-15. Le champ de recherche de départements (étape « Territoire » de l'inscription, et modale de l'espace utilisateur) devient une vraie combobox pour les lecteurs d'écran : navigation complète au clavier, nombre de suggestions annoncé, boutons de suppression nommés, et le focus ne se perd plus quand on retire un département.

L'étiquette visible du champ arrive dans la PR suivante (RGA-14, construite sur celle-ci).

Micro-détail visuel : le champ n'affiche plus le soulignement rouge du correcteur orthographique (désactivé : il n'a rien à corriger sur des noms de départements, et sa vocalisation couvrait nos annonces).
