### PR TITLE
fix(a11y): compléments d'annonces et de libellés (RGAA 7.1, 8.7, 10.2)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -653,14 +653,15 @@
     "title": "Inscrivez-vous à notre lettre d’information mensuelle !",
     "description": "Suivez l'évolution du service Réfugiés.info",
     "label": "Adresse email (requise)",
-    "confirmMessageTitle": "Yay...",
-    "confirmMessageText": "Mail <b>{{email}}</b> correctement enregistré !",
+    "confirmMessageTitle": "Yay !",
+    "confirmMessageText": "Votre inscription à la newsletter a bien été enregistrée",
     "errorsEmailnotvalid": "Ceci n'est pas un email, vérifiez l'orthographe.",
     "errorsAlreadyexists": "Cette adresse mail est déjà inscrite à la newsletter Réfugiés.info !",
     "errorsSystemerror": "Une erreur s'est produite",
     "ok": "S'inscrire"
   },
   "MobileApp": {
+    "smsSent": "Yay ! Un lien de téléchargement a été envoyé à ce numéro",
     "rankingText": "Top 3 des applications publiques",
     "rankingLabel": "Note : 5 sur 5",
     "ratingAlt": "Note sur 5 :",

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -87,6 +87,7 @@
     "titleThemes": "Les thématiques de l'intégration",
     "positionButton": "Utiliser ma position",
     "positionEnable": "Vous devez activer la géolocalisation pour votre navigateur",
+    "positionDepartmentSelected": "Département {{department}} sélectionné",
     "notDeployedText": "Le référencement des actions locales débute dans le département – {{department}}. Votre recherche peut aboutir à peu de résultats.",
     "fiches_zero": "fiche",
     "fiches_one": "fiche",

--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -500,6 +500,8 @@
     "en_anglais": "en anglais",
     "en_ukrainien": "en ukrainien",
     "not_listenable": "Non écoutable",
+    "translation_in_progress": "En cours de traduction",
+    "translation_available": "Traduction disponible",
     "loading": "Chargement de la langue"
   },
   "topLink": "Haut de page",

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -127,20 +127,17 @@ export const SubscribeNewsletterModal = () => {
       API.contacts({ email })
         .then(() => {
           Event("NEWSLETTER", "subscribe", "newsletter modal");
+          const confirmMessage = t(
+            "NewsletterForm.confirmMessageText",
+            "Votre inscription à la newsletter a bien été enregistrée",
+          );
           Swal.fire({
-            title: "Yay...",
-            text: "Mail correctement enregistré !",
+            title: t("NewsletterForm.confirmMessageTitle", "Yay !"),
+            text: confirmMessage,
             icon: "success",
             timer: 1500,
           });
-          // Le libellé partagé avec la section d'accueil porte du gras pour l'affichage,
-          // une région vocale ne restitue que du texte.
-          announce(
-            t("NewsletterForm.confirmMessageText", {
-              defaultValue: "Mail correctement enregistré !",
-              email,
-            }).replace(/<[^>]*>/g, ""),
-          );
+          announce(confirmMessage);
           setEmail("");
         })
         .catch((e) => {

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileAppSmsForm/MobileAppSmsForm.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileAppSmsForm/MobileAppSmsForm.tsx
@@ -44,7 +44,9 @@ const MobileAppSmsForm = () => {
       API.smsDownloadApp({ phone, locale: languageSelected || "fr" })
         .then(() => {
           setShowToast(true);
-          announce(t("Dispositif.smsFormSent"));
+          announce(
+            t("MobileApp.smsSent", "Yay ! Un lien de téléchargement a été envoyé à ce numéro"),
+          );
           Event("SEND_SMS", "download app", "homepage");
           setPhone("");
         })
@@ -96,7 +98,7 @@ const MobileAppSmsForm = () => {
       </Button>
 
       <Toast open={showToast} closeCallback={() => setShowToast(false)}>
-        {t("Dispositif.smsFormSent")}
+        {t("MobileApp.smsSent", "Yay ! Un lien de téléchargement a été envoyé à ce numéro")}
       </Toast>
     </form>
   );

--- a/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/Newsletter/Newsletter.tsx
@@ -69,17 +69,11 @@ const Newsletter = () => {
                 closable
                 onClose={() => setNewsletterFormState("default")}
                 severity="success"
-                description={
-                  <span
-                    dangerouslySetInnerHTML={{
-                      __html: t("NewsletterForm.confirmMessageText", {
-                        defaultValue: "Mail correctement enregistré !",
-                        email: email,
-                      }),
-                    }}
-                  ></span>
-                }
-                title={t("NewsletterForm.confirmMessageTitle", "Yay...")}
+                description={t(
+                  "NewsletterForm.confirmMessageText",
+                  "Votre inscription à la newsletter a bien été enregistrée",
+                )}
+                title={t("NewsletterForm.confirmMessageTitle", "Yay !")}
                 className={cls("w-full bg-white transition")}
               />
             )}

--- a/apps/client/src/components/Pages/recherche/LocationMenu/GeoLocationMenuItem.tsx
+++ b/apps/client/src/components/Pages/recherche/LocationMenu/GeoLocationMenuItem.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
+import { useAnnounce } from "~/components/Accessibility/ScreenReaderAnnouncer";
 import { cls, cn } from "~/lib/classname";
 import { onEnterOrSpace } from "~/lib/onEnterOrSpace";
 import { addToQueryActionCreator } from "~/services/SearchResults/searchResults.actions";
@@ -11,6 +12,7 @@ import styles from "./GeoLocationMenuItem.module.css";
 const GeoLocationMenuItem: React.FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
+  const announce = useAnnounce();
   // Initialize with true if geolocation is supported (check synchronously)
   const [geolocationSupported, setGeolocationSupported] = useState(
     typeof navigator !== "undefined" && "geolocation" in navigator,
@@ -32,12 +34,23 @@ const GeoLocationMenuItem: React.FC = () => {
               `https://geo.api.gouv.fr/communes?lat=${res.coords.latitude}&lon=${res.coords.longitude}&fields=departement&format=json&geometry=centre`,
             )
             .then((response) => {
-              if (response.data[0]?.departement?.nom) {
+              const department = response.data[0]?.departement?.nom;
+              if (department) {
                 dispatch(
                   addToQueryActionCreator({
-                    departments: [response.data[0].departement.nom],
+                    departments: [department],
                     sort: "location",
                   }),
+                );
+                announce(
+                  t(
+                    "Recherche.positionDepartmentSelected",
+                    "Département {{department}} sélectionné",
+                    {
+                      department,
+                    },
+                  ),
+                  { priority: "interrupt" },
                 );
               }
             });

--- a/apps/client/src/components/Pages/recherche/LocationMenu/GeoLocationMenuItem.tsx
+++ b/apps/client/src/components/Pages/recherche/LocationMenu/GeoLocationMenuItem.tsx
@@ -34,7 +34,9 @@ const GeoLocationMenuItem: React.FC = () => {
               `https://geo.api.gouv.fr/communes?lat=${res.coords.latitude}&lon=${res.coords.longitude}&fields=departement&format=json&geometry=centre`,
             )
             .then((response) => {
-              const department = response.data[0]?.departement?.nom;
+              // The geo API answers with a list of communes; guard against an empty or malformed body.
+              const communes = Array.isArray(response.data) ? response.data : [];
+              const department = communes.length > 0 ? communes[0]?.departement?.nom : undefined;
               if (department) {
                 dispatch(
                   addToQueryActionCreator({

--- a/apps/client/src/components/UI/LanguageSelector/LanguageItem.tsx
+++ b/apps/client/src/components/UI/LanguageSelector/LanguageItem.tsx
@@ -125,6 +125,12 @@ const LanguageItem = memo(
           {type === "page" && (
             <span dir="ltr" className="ms-auto">
               <i
+                role="img"
+                aria-label={
+                  disabled
+                    ? t("LanguageDropdown.translation_in_progress", "En cours de traduction")
+                    : t("LanguageDropdown.translation_available", "Traduction disponible")
+                }
                 className={cn(
                   disabled ? "ri-progress-5-line" : "fr-icon-success-fill !text-default-success",
                 )}

--- a/apps/client/src/components/UI/Toast/Toast.tsx
+++ b/apps/client/src/components/UI/Toast/Toast.tsx
@@ -1,4 +1,5 @@
 import { ToastClose, ToastDescription, Toast as ToastRoot } from "@radix-ui/react-toast";
+import { useTranslation } from "next-i18next";
 import type React from "react";
 import { cn } from "~/lib/classname";
 import styles from "./Toast.module.scss";
@@ -12,6 +13,7 @@ interface Props {
 }
 
 const Toast = ({ open, children, type = "success", closeCallback }: Props) => {
+  const { t } = useTranslation();
   // The viewport is mounted only while a toast is shown (RGAA 8.9).
   useDeclareToast(open);
 
@@ -28,7 +30,7 @@ const Toast = ({ open, children, type = "success", closeCallback }: Props) => {
         />
         {children}
       </ToastDescription>
-      <ToastClose aria-label="Close" className={styles.close}>
+      <ToastClose aria-label={t("close", "Fermer")} className={styles.close}>
         <i className={"fr-icon-close-line"} aria-hidden />
       </ToastClose>
     </ToastRoot>

--- a/apps/client/src/components/UI/Toast/__tests__/ToastPresence.test.tsx
+++ b/apps/client/src/components/UI/Toast/__tests__/ToastPresence.test.tsx
@@ -58,7 +58,7 @@ describe("ToastViewportWhenNeeded", () => {
     expect(notificationRegion()).not.toBeNull();
 
     // Programmatic close, with focus never having entered the toast.
-    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    fireEvent.click(screen.getByRole("button", { name: "close" }));
 
     await advanceTime(100);
     expect(notificationRegion()).not.toBeNull(); // S1: still there at t+100
@@ -71,7 +71,7 @@ describe("ToastViewportWhenNeeded", () => {
     render(<Harness openAtStart={true} />);
     await advanceTime(0);
 
-    const closeButton = screen.getByRole("button", { name: "Close" });
+    const closeButton = screen.getByRole("button", { name: "close" });
     closeButton.focus();
     expect(document.activeElement).toBe(closeButton);
 


### PR DESCRIPTION
Audit RGAA Ideance, RGA-16, compléments après la repasse d'exhaustivité de la grille avant la phase de tests. Trois gestes sur le même mécanisme que la PR #3888 : l'icône d'état de chaque langue de la fiche annonce « En cours de traduction » ou « Traduction disponible » au lieu de n'être qu'un pictogramme, le bouton de fermeture des notifications n'annonce plus « Close » en anglais, et le département coché automatiquement après « Utiliser ma position » est annoncé. Rien ne bouge à l'écran.

S'y ajoutent les deux textes demandés par Julie sur le ticket : le message de succès de la newsletter devient « Yay ! Votre inscription à la newsletter a bien été enregistrée » (section d'accueil et modale), et celui du SMS de l'accueil « Yay ! Un lien de téléchargement a été envoyé à ce numéro ». La fenêtre de confirmation de la modale passe par les traductions au passage.

Clés nouvelles à verser au flux de traduction : `LanguageDropdown.translation_in_progress`, `LanguageDropdown.translation_available`, `Recherche.positionDepartmentSelected`, `MobileApp.smsSent` (français seulement). Clés modifiées en français : `NewsletterForm.confirmMessageTitle` et `NewsletterForm.confirmMessageText`. Le bouton de fermeture réutilise une clé existante en 8 langues.
