### PR TITLE
fix(a11y): alternatives des logos partenaires (RGAA 1.1)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -45,8 +45,7 @@
     "ressourcesImgAlt": "Kit de communication de Réfugiés.info",
     "resourcesCTA": "Voir les outils",
     "webinaireCTA": "Participer à un webinaire",
-    "StructuresLogosText": "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !",
-    "StructuresLogosVocalisation": "Nos partenaires :"
+    "StructuresLogosText": "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !"
   },
   "Recherche": {
     "pageTitle": "Recherche",

--- a/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
@@ -14,56 +14,46 @@ import PierreValdo from "~/assets/homepage/structures-logos/Dispositif-Pierre-Va
 
 const StructuresLogos = () => {
   const { t } = useTranslation();
-  const logos: { image: StaticImageData; alt: string; title: string }[] = [
+  const logos: { image: StaticImageData; alt: string }[] = [
     {
       image: FTDA,
-      title: "France Terre d'Asile",
-      alt: "",
+      alt: "France Terre d'Asile",
     },
     {
       image: SOS,
-      title: "Groupe SOS",
-      alt: "",
+      alt: "Groupe SOS",
     },
     {
       image: FranceTravail,
-      title: "France Travail",
-      alt: "",
+      alt: "France Travail",
     },
     {
       image: COS,
-      title: "Fondation COS",
-      alt: "",
+      alt: "Fondation COS Alexandre Glasberg",
     },
     {
       image: FH,
-      title: "France Horizon",
-      alt: "",
+      alt: "France Horizon",
     },
     {
       image: Coallia,
-      title: "Coallia",
-      alt: "",
+      alt: "Coallia",
     },
     {
       image: PierreValdo,
-      title: "Entraide Pierre Valdo",
-      alt: "",
+      alt: "Entraide Pierre Valdo",
     },
     {
       image: HIS,
-      title: "GIP Habitat et Interventions Sociales",
-      alt: "",
+      alt: "HIS - Habitat et Interventions Sociales",
     },
     {
       image: ForumRefugie,
-      title: "Forum Refugiés",
-      alt: "",
+      alt: "Forum Réfugiés",
     },
     {
       image: FederationActeurs,
-      title: "Fédération des Acteurs de la Solidarité",
-      alt: "",
+      alt: "FAS - Fédération des acteurs de la solidarité",
     },
   ];
 
@@ -79,10 +69,6 @@ const StructuresLogos = () => {
           "Homepage.StructuresLogosText",
           "Plus de 300 000 professionnels ont déjà adopté Réfugiés.info pour accompagner leurs bénéficiaires !",
         )}
-      </p>
-      <p className="sr-only">
-        {t("Homepage.StructuresLogosVocalisation", "Nos partenaires :")}{" "}
-        {logos.map((logo) => logo.title).join(", ")}
       </p>
     </section>
   );


### PR DESCRIPTION
Audit RGAA Ideance, RGA-9, complément après la repasse d'exhaustivité de la grille avant la phase de tests. Les 10 logos partenaires de la page d'accueil reçoivent l'alternative textuelle demandée par la grille, avec le nom exact de chaque structure (liste validée par Julie sur le ticket). Le paragraphe caché « Nos partenaires : ... » qui listait les noms pour les lecteurs d'écran est retiré dans la foulée, sinon chaque nom serait annoncé deux fois. Rien ne bouge à l'écran.

Les noms des structures ne passent pas par une clé de traduction : ce sont des noms propres, identiques dans les 8 langues. Une clé supprimée : `Homepage.StructuresLogosVocalisation`.
