### PR TITLE
fix(a11y): titre de l'encart d'avis et compléments des pages éditoriales (RGAA 9.1, 1.2, 1.3, 6.1, 7.1, 8.9)

### DIFF
--- a/apps/client/public/locales/fr/common.json
+++ b/apps/client/public/locales/fr/common.json
@@ -719,6 +719,7 @@
     "impact_p1": "Sur Réfugiés.info, une information est considérée comme adaptée lorsqu’elle est fiable, à jour, claire, spécifique, traduite, écoutable, et actionnable.",
     "impact_p2": "Une fois produite, cette information doit être ensuite diffusée auprès des usagers afin qu’ils puissent l’utiliser. Réfugiés.info est désormais un média reconnu, fréquenté chaque mois par environ 100 000 étrangers primo-arrivants et réfugiés, ainsi que 30 000 à 40 000 professionnels.",
     "impact_p3": "La délivrance d’une information adaptée est la <strong>première brique pour le bon fonctionnement des administrations</strong> et <strong>la bonne mise en œuvre de la politique d’intégration des étrangers</strong> en France.",
+    "impact_booklet_alt": "Réfugiés.info, 5 ans au service de l'information des personnes réfugiées.",
     "impact_arguments_figures_title": "En chiffres",
     "impact_arguments_title_1": "Réfugiés.info fluidifie le travail des administrations",
     "impact_arguments_badge_1": "Impact pour l’État",

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -547,7 +547,7 @@ exports[`publier renders publier 1`] = `
         <div
           class="flex flex-col gap-4 lg:flex-row lg:items-stretch lg:justify-center lg:gap-10"
         >
-          <div
+          <article
             class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white"
           >
             <div
@@ -613,8 +613,8 @@ exports[`publier renders publier 1`] = `
                 </div>
               </div>
             </div>
-          </div>
-          <div
+          </article>
+          <article
             class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white"
           >
             <div
@@ -680,8 +680,8 @@ exports[`publier renders publier 1`] = `
                 </div>
               </div>
             </div>
-          </div>
-          <div
+          </article>
+          <article
             class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white"
           >
             <div
@@ -747,7 +747,7 @@ exports[`publier renders publier 1`] = `
                 </div>
               </div>
             </div>
-          </div>
+          </article>
         </div>
         <div
           class="mt-10 text-center lg:mt-20"
@@ -800,11 +800,11 @@ exports[`publier renders publier 1`] = `
               >
                 Créez votre compte Réfugiés.info
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Chaque compte est personnel. Vos collègues pourront aussi créer leur propre compte pour modifier les fiches de votre structure.
-              </div>
+              </p>
               <a
                 class="fr-btn fr-btn--tertiary fr-btn--lg fr-icon-arrow-right-line fr-btn--icon-right"
                 href="#register"
@@ -849,16 +849,16 @@ exports[`publier renders publier 1`] = `
               >
                 Rédigez votre fiche
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Vous vous adressez à des personnes réfugiées ou des personnes les aidant dans leur recherche.
-              </div>
-              <div
+              </p>
+              <p
                 class="text-large mb-6"
               >
                 Le niveau de langue étant très variable, le contenu de votre fiche doit donc être synthétique et vulgarisé.
-              </div>
+              </p>
               <a
                 class="fr-btn fr-btn--tertiary fr-btn--lg fr-icon-arrow-right-line fr-btn--icon-right"
                 href="https://help.refugies.info/fr/category/charte-editoriale-2fq3x7/"
@@ -903,11 +903,11 @@ exports[`publier renders publier 1`] = `
               >
                 Ajoutez la structure responsable
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 À la fin de votre rédaction, précisez la structure responsable de cette action : la vôtre ou une organisation amie que vous souhaitez recenser vous-même.
-              </div>
+              </p>
             </div>
             <div
               class="relative order-1 flex w-auto shrink-0 items-start justify-center lg:w-[480px] border-artwork-minor-blue-france border-s-4 ps-8 pb-[60px] lg:border-none lg:ps-0 lg:pb-0"
@@ -945,16 +945,16 @@ exports[`publier renders publier 1`] = `
               >
                 L’équipe éditoriale de Réfugiés.info relit et publie votre fiche
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Notre équipe éditoriale relit votre fiche et vous contacte s’il manque des informations essentielles.
-              </div>
-              <div
+              </p>
+              <p
                 class="text-large mb-6"
               >
                 Vous êtes informé par email lorsque la fiche est visible par les utilisateurs.
-              </div>
+              </p>
               <div
                 class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2"
               >
@@ -1002,16 +1002,16 @@ exports[`publier renders publier 1`] = `
               >
                 Traduction en 7 langues de votre fiche
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Votre fiche est traduite par de vrais humains. Nous nous appuyons sur un réseau de bénévoles et d’experts linguistes pour traduire et vulgariser l’information dans un langage adapté aux personnes réfugiées.
-              </div>
-              <div
+              </p>
+              <p
                 class="text-large mb-6"
               >
                 Vos actions sont ainsi traduites gratuitement en 7 langues : anglais, arabe, pachto, persan/dari, tigrinya, ukrainien et russe.
-              </div>
+              </p>
             </div>
             <div
               class="relative order-1 flex w-auto shrink-0 items-start justify-center lg:w-[480px] border-artwork-minor-blue-france border-s-4 ps-8 pb-[60px] lg:border-none lg:ps-0 lg:pb-0"
@@ -1049,16 +1049,16 @@ exports[`publier renders publier 1`] = `
               >
                 Mettez à jour votre action régulièrement
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Votre action peut rapidement évoluer (dates des sessions de formation, formulaires de candidature, fréquence des cours de français, etc.), vous êtes garant de la mise à jour des informations.
-              </div>
-              <div
+              </p>
+              <p
                 class="text-large mb-6"
               >
                 Attention, une action obsolète sera supprimée par l’équipe éditoriale.
-              </div>
+              </p>
               <span
                 class="hidden lg:block from-beige/0 to-beige absolute -start-1 bottom-0 h-[200px] w-1 bg-gradient-to-b"
               />
@@ -1116,7 +1116,6 @@ exports[`publier renders publier 1`] = `
               href="https://kit.refugies.info/formation"
               rel="noopener noreferrer"
               target="_blank"
-              title="Séances découverte"
             >
               <div
                 class="flex h-full flex-col"
@@ -1153,6 +1152,7 @@ exports[`publier renders publier 1`] = `
                 class="mt-6 w-full pt-2 text-right"
               >
                 <i
+                  aria-hidden="true"
                   class="fr-icon-arrow-right-line text-title-blue-france"
                 />
               </div>
@@ -1162,7 +1162,6 @@ exports[`publier renders publier 1`] = `
               href="https://help.refugies.info/fr/"
               rel="noopener noreferrer"
               target="_blank"
-              title="Tutoriels et centre d’aide"
             >
               <div
                 class="flex h-full flex-col"
@@ -1199,13 +1198,13 @@ exports[`publier renders publier 1`] = `
                 class="mt-6 w-full pt-2 text-right"
               >
                 <i
+                  aria-hidden="true"
                   class="fr-icon-arrow-right-line text-title-blue-france"
                 />
               </div>
             </a>
             <button
               class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white hover:bg-background-alt-grey active:bg-active-tint"
-              title="Live chat"
             >
               <div
                 class="flex h-full flex-col"
@@ -1242,6 +1241,7 @@ exports[`publier renders publier 1`] = `
                 class="mt-6 w-full pt-2 text-right"
               >
                 <i
+                  aria-hidden="true"
                   class="fr-icon-arrow-right-line text-title-blue-france"
                 />
               </div>
@@ -1269,9 +1269,11 @@ exports[`publier renders publier 1`] = `
               <div
                 class="text-title-blue-france text-alt-title lg:text-alt-title-big font-bold"
               >
-                <div>
+                <p
+                  class="text-alt-title lg:text-alt-title-big mb-0"
+                >
                   0
-                </div>
+                </p>
               </div>
               <p
                 class="text-title-blue-france text-chapo mt-6 mb-0 font-bold"
@@ -1285,9 +1287,11 @@ exports[`publier renders publier 1`] = `
               <div
                 class="text-title-blue-france text-alt-title lg:text-alt-title-big font-bold"
               >
-                <div>
+                <p
+                  class="text-alt-title lg:text-alt-title-big mb-0"
+                >
                   0
-                </div>
+                </p>
               </div>
               <p
                 class="text-title-blue-france text-chapo mt-6 mb-0 font-bold"
@@ -1301,9 +1305,11 @@ exports[`publier renders publier 1`] = `
               <div
                 class="text-title-blue-france text-alt-title lg:text-alt-title-big font-bold"
               >
-                <div>
+                <p
+                  class="text-alt-title lg:text-alt-title-big mb-0"
+                >
                   0
-                </div>
+                </p>
               </div>
               <p
                 class="text-title-blue-france text-chapo mt-6 mb-0 font-bold"

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -229,7 +229,7 @@ exports[`traduire renders traduire 1`] = `
           <div
             class="flex flex-col gap-4 lg:flex-row lg:items-stretch lg:justify-center lg:gap-10"
           >
-            <div
+            <article
               class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white"
             >
               <div
@@ -263,8 +263,8 @@ exports[`traduire renders traduire 1`] = `
                   </p>
                 </div>
               </div>
-            </div>
-            <div
+            </article>
+            <article
               class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white"
             >
               <div
@@ -298,8 +298,8 @@ exports[`traduire renders traduire 1`] = `
                   </p>
                 </div>
               </div>
-            </div>
-            <div
+            </article>
+            <article
               class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white"
             >
               <div
@@ -333,7 +333,7 @@ exports[`traduire renders traduire 1`] = `
                   </p>
                 </div>
               </div>
-            </div>
+            </article>
           </div>
         </div>
       </div>
@@ -371,7 +371,6 @@ exports[`traduire renders traduire 1`] = `
             >
               <span
                 class="flag fi fi-en"
-                title="en"
               />
               <span
                 class="text-h6 md:text-h5 font-bold"
@@ -431,11 +430,11 @@ exports[`traduire renders traduire 1`] = `
                 </strong>
                  Réfugiés.info
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Indiquez votre adresse mail et un mot de passe, vous êtes prêt à utiliser l'outil de traduction.
-              </div>
+              </p>
               <a
                 class="fr-btn fr-btn--tertiary fr-btn--lg fr-icon-arrow-right-line fr-btn--icon-right"
                 href="#register"
@@ -484,11 +483,11 @@ exports[`traduire renders traduire 1`] = `
                 </strong>
                  de traduction
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Une fois votre langue choisie, vous accédez à toutes les fiches à traduire. Cliquez sur une fiche pour commencer à la traduire.
-              </div>
+              </p>
             </div>
             <div
               class="relative order-1 flex w-auto shrink-0 items-start justify-center lg:w-[480px] border-artwork-minor-blue-france border-s-4 ps-8 pb-[60px] lg:border-none lg:ps-0 lg:pb-0"
@@ -529,11 +528,11 @@ exports[`traduire renders traduire 1`] = `
                 </strong>
                  à partir de la proposition automatique
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Quand vous arrivez sur une fiche, vous trouverez une première traduction. Attention, elle est automatique. Il faut la retravailler et la corriger !
-              </div>
+              </p>
               <div
                 class="bg-contrast-beige-gris-galet border-default-grey mb-6 border p-4"
               >
@@ -592,16 +591,16 @@ exports[`traduire renders traduire 1`] = `
                 </strong>
                  votre traduction
               </h3>
-              <div
+              <p
                 class="text-large mb-6"
               >
                 Un expert va relire votre traduction avant de publier la fiche.
-              </div>
-              <div
+              </p>
+              <p
                 class="text-large mb-6"
               >
                 Vous allez recevoir un mail dès que la fiche que vous avez traduite sera visible sur le site Réfugiés.info et sur l'application mobile.
-              </div>
+              </p>
               <div
                 class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2 !bottom-0"
               >
@@ -712,7 +711,6 @@ exports[`traduire renders traduire 1`] = `
               href="https://help.refugies.info/fr/category/traduire-1dvep4w/"
               rel="noopener noreferrer"
               target="_blank"
-              title="Vidéos tutoriels"
             >
               <div
                 class="flex h-full flex-col"
@@ -747,13 +745,13 @@ exports[`traduire renders traduire 1`] = `
                 class="mt-6 w-full pt-2 text-right"
               >
                 <i
+                  aria-hidden="true"
                   class="fr-icon-arrow-right-line text-title-blue-france"
                 />
               </div>
             </a>
             <button
               class="lg:max-w-[22.5rem] p-6 md:p-8 flex-1 flex flex-col justify-between border border-default-grey text-left bg-white hover:bg-background-alt-grey active:bg-active-tint"
-              title="Live chat"
             >
               <div
                 class="flex h-full flex-col"
@@ -788,6 +786,7 @@ exports[`traduire renders traduire 1`] = `
                 class="mt-6 w-full pt-2 text-right"
               >
                 <i
+                  aria-hidden="true"
                   class="fr-icon-arrow-right-line text-title-blue-france"
                 />
               </div>

--- a/apps/client/src/__tests__/mentions-legales.test.tsx
+++ b/apps/client/src/__tests__/mentions-legales.test.tsx
@@ -1,0 +1,23 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import MentionsLegales from "../pages/mentions-legales";
+
+jest.mock("next/router", () => require("next-router-mock"));
+
+describe("mentions-legales", () => {
+  it("underlines every body link so it stands out from the surrounding text", () => {
+    render(<MentionsLegales />);
+
+    const links = screen.getAllByRole("link");
+    expect(links.map((link) => link.textContent?.trim())).toEqual([
+      "contact@email.refugies.info",
+      "notre politique de confidentialité",
+      "contact@email.refugies.info",
+      "Google Cloud France",
+    ]);
+    for (const link of links) {
+      // `underline` opts the link out of the global reset in `scss/_dsfr-fix.scss`.
+      expect(link).toHaveClass("underline");
+    }
+  });
+});

--- a/apps/client/src/components/Backend/screens/UserProfile/__test__/__snapshots__/UserProfile.component.test.tsx.snap
+++ b/apps/client/src/components/Backend/screens/UserProfile/__test__/__snapshots__/UserProfile.component.test.tsx.snap
@@ -553,7 +553,6 @@ exports[`UserProfile should render correctly 1`] = `
                     </span>
                     <span
                       class="flag fi fi-en"
-                      title="en"
                     />
                   </label>
                   <div

--- a/apps/client/src/components/Modals/WriteContentModal/WriteContentCard/WriteContentCard.tsx
+++ b/apps/client/src/components/Modals/WriteContentModal/WriteContentCard/WriteContentCard.tsx
@@ -17,8 +17,9 @@ const WriteContentCard = (props: Props) => (
   <button
     className={cls(styles.container, styles[props.color], props.selected && styles.selected)}
     onClick={props.onSelect}
+    aria-pressed={props.selected}
   >
-    <Image src={props.imageSrc} alt={props.type} width={200} height={162} />
+    <Image src={props.imageSrc} alt="" width={200} height={162} />
     <div className={styles.inner}>
       <div>
         <p className={styles.title}>Rédiger une fiche</p>

--- a/apps/client/src/components/Pages/staticPages/common/Card/Card.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Card/Card.tsx
@@ -24,7 +24,7 @@ const CARD_HOVER_CLASSNAME = "hover:bg-background-alt-grey active:bg-active-tint
 
 const ArrowRight = () => (
   <div className="mt-6 w-full pt-2 text-right">
-    <i className="fr-icon-arrow-right-line text-title-blue-france" />
+    <i className="fr-icon-arrow-right-line text-title-blue-france" aria-hidden="true" />
   </div>
 );
 
@@ -70,7 +70,6 @@ const Card = (props: Props) => {
       <Link
         href={props.link}
         className={cls(CARD_CLASSNAME, CARD_HOVER_CLASSNAME, props.className, "block")}
-        title={props.title}
         target="_blank"
         rel="noopener noreferrer"
       >
@@ -85,7 +84,6 @@ const Card = (props: Props) => {
       <button
         className={cls(CARD_CLASSNAME, CARD_HOVER_CLASSNAME, props.className)}
         onClick={props.onClick}
-        title={props.title}
       >
         {content}
         <ArrowRight />
@@ -93,7 +91,7 @@ const Card = (props: Props) => {
     );
   }
 
-  return <div className={cls(CARD_CLASSNAME, props.className)}>{content}</div>;
+  return <article className={cls(CARD_CLASSNAME, props.className)}>{content}</article>;
 };
 
 export default Card;

--- a/apps/client/src/components/Pages/staticPages/common/CountUpFigure/CountUpFigure.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/CountUpFigure/CountUpFigure.tsx
@@ -12,7 +12,9 @@ const CountUpFigure = (props: Props) => {
       <div className="text-title-blue-france text-alt-title lg:text-alt-title-big font-bold">
         <InView>
           {({ inView, ref }) => (
-            <div ref={ref}>{inView ? <CountUp end={props.number} separator=" " /> : 0}</div>
+            <p ref={ref} className="text-alt-title lg:text-alt-title-big mb-0">
+              {inView ? <CountUp end={props.number} separator=" " /> : 0}
+            </p>
           )}
         </InView>
       </div>

--- a/apps/client/src/components/Pages/staticPages/common/Register/Register.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Register/Register.tsx
@@ -19,7 +19,9 @@ interface Props {
   subtitleForm: string;
   subtitleLoggedIn: string;
   btnLoggedIn: string;
-  onClickLoggedIn: () => void;
+  onClickLoggedIn?: () => void;
+  /** When the action is a plain navigation it must be a link, not a button (RGAA 7.1). */
+  hrefLoggedIn?: string;
   subtitleMobile: string;
   associatedRole: RoleName.TRAD | RoleName.CONTRIB;
 }
@@ -125,7 +127,9 @@ const Register = (props: Props) => {
           <p className="text-chapo mb-6">{isAuth ? props.subtitleLoggedIn : props.subtitleForm}</p>
           {isAuth ? (
             <Button
-              onClick={props.onClickLoggedIn}
+              {...(props.hrefLoggedIn
+                ? { linkProps: { href: props.hrefLoggedIn } }
+                : { onClick: props.onClickLoggedIn })}
               iconId="fr-icon-add-circle-line"
               iconPosition="right"
             >

--- a/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
@@ -91,9 +91,9 @@ const StepContent = (props: Props) => {
               </ul>
             </div>
           ) : (
-            <div key={i} className="text-large mb-6">
+            <p key={i} className="text-large mb-6">
               {text}
-            </div>
+            </p>
           ),
         )}
         {props.cta && (

--- a/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
@@ -90,10 +90,15 @@ const StepContent = (props: Props) => {
                 ))}
               </ul>
             </div>
-          ) : (
+          ) : typeof text === "string" ? (
             <p key={i} className="text-large mb-6">
               {text}
             </p>
+          ) : (
+            // A ready-made element (a list, for instance) cannot live inside a <p>.
+            <div key={i} className="text-large mb-6">
+              {text}
+            </div>
           ),
         )}
         {props.cta && (

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionContributors.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionContributors.tsx
@@ -31,7 +31,7 @@ export const SectionContributors = (props: Props) => {
               <div className="relative inline-block">
                 <Image
                   src={CommunityIlluDispositifs}
-                  alt=""
+                  alt={`${props.nbDispositifPorteurs} ${t("MissionImpact.community_dispositifs_title")}`}
                   width={240}
                   height={80}
                   style={{ objectFit: "contain" }}
@@ -54,7 +54,7 @@ export const SectionContributors = (props: Props) => {
               <div className="relative inline-block">
                 <Image
                   src={CommunityIlluCda}
-                  alt=""
+                  alt={`${props.nbCDA} ${t("MissionImpact.community_cda_title")}`}
                   width={240}
                   height={80}
                   style={{ objectFit: "contain" }}
@@ -77,7 +77,7 @@ export const SectionContributors = (props: Props) => {
               <div className="relative inline-block">
                 <Image
                   src={CommunityIlluTraducteurs}
-                  alt=""
+                  alt={`${props.nbTranslators} ${t("MissionImpact.community_traducteurs_title")}`}
                   width={232}
                   height={80}
                   style={{ objectFit: "contain" }}

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionImpact.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionImpact.tsx
@@ -23,16 +23,15 @@ export const SectionImpact = () => {
               imageUrl={PDFScreenshot.src}
               horizontal
               linkProps={{
-                href:
-                  typeof window !== "undefined"
-                    ? `${window.location.origin}/Livret-Impact-Refugies.infos-2024.pdf`
-                    : "#",
+                // Static file served from the site root: the link must be real on the server
+                // render too, and next/link must not prefix it with the locale.
+                href: "/Livret-Impact-Refugies.infos-2024.pdf",
+                locale: false,
                 target: "_blank",
                 rel: "noopener noreferrer",
               }}
-              imageAlt=""
+              imageAlt={t("MissionImpact.impact_booklet_alt")}
               title="Livret d'impact"
-              aria-label="Livret d'impact - cliquez pour le télécharger"
               desc="Mai 2024"
               endDetail="PDF - 61,88 Ko"
               className="fr-card--download mt-10 max-w-[24rem] md:mt-14"

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/SectionUsers.tsx
@@ -34,11 +34,10 @@ export const SectionUsers = () => {
             <figure>
               <Image
                 src={UsersGraph1}
-                alt=""
+                alt={t("MissionImpact.users_legend_1")}
                 className="mx-auto lg:mx-5"
                 width={416}
                 height={271}
-                aria-labelledby="users_legend_1"
               />
               <figcaption
                 id="users_legend_1"
@@ -69,8 +68,7 @@ export const SectionUsers = () => {
             <figure>
               <Image
                 src={UsersGraph2}
-                alt=""
-                aria-labelledby="users_legend_2"
+                alt={t("MissionImpact.users_legend_2")}
                 className="mx-auto lg:mx-10"
                 width={376}
                 height={191}

--- a/apps/client/src/components/Pages/staticPages/mission-et-impact/__tests__/SectionImpact.test.tsx
+++ b/apps/client/src/components/Pages/staticPages/mission-et-impact/__tests__/SectionImpact.test.tsx
@@ -1,0 +1,32 @@
+import "@testing-library/jest-dom";
+import { setLink } from "@codegouvfr/react-dsfr/link";
+import { render, screen } from "@testing-library/react";
+import Link from "next/link";
+// The jsdom test environment resolves "react-dom/server" to the browser build, which needs
+// MessageChannel: the node build is the one Next uses on the server anyway.
+import { renderToString } from "react-dom/server.node";
+import { SectionImpact } from "../SectionImpact";
+
+// Same registration as `_app.tsx`: DSFR cards render their link with next/link.
+setLink({ Link });
+
+const bookletPath = "/Livret-Impact-Refugies.infos-2024.pdf";
+
+describe("SectionImpact", () => {
+  it("links the impact booklet to the PDF on the server render", () => {
+    // Server markup: the href must not depend on `window`, which does not exist there.
+    const html = renderToString(<SectionImpact />);
+
+    expect(html).toContain(`href="${bookletPath}"`);
+    expect(html).not.toContain('href="#"');
+  });
+
+  it("exposes the booklet card without a stray aria-label and with the image alternative", () => {
+    render(<SectionImpact />);
+
+    const link = screen.getByRole("link", { name: "Livret d'impact" });
+    expect(link).toHaveAttribute("href", bookletPath);
+    expect(link.closest(".fr-card")).not.toHaveAttribute("aria-label");
+    expect(screen.getByRole("img")).toHaveAttribute("alt", "MissionImpact.impact_booklet_alt");
+  });
+});

--- a/apps/client/src/components/UI/Flag/Flag.tsx
+++ b/apps/client/src/components/UI/Flag/Flag.tsx
@@ -8,9 +8,6 @@ interface Props {
 
 const Flag = (props: Props) =>
   props.langueCode ? (
-    <span
-      className={cls(styles.flag, `fi fi-${props.langueCode}`, props.className)}
-      title={props.langueCode}
-    />
+    <span className={cls(styles.flag, `fi fi-${props.langueCode}`, props.className)} />
   ) : null;
 export default Flag;

--- a/apps/client/src/pages/mentions-legales.tsx
+++ b/apps/client/src/pages/mentions-legales.tsx
@@ -34,11 +34,9 @@ const MentionsLegales = () => {
           rectification, de modification et de suppression concernant des données qui vous
           concernent personnellement. Ce droit peut être exercé par voie électronique à l’adresse
           email suivante :{" "}
-          <a title="Email" href="mailto:contact@email.refugies.info">
-            contact@email.refugies.info
-          </a>
-          . Ou par courrier postal, daté et signé, accompagné d&apos;une copie d’un titre
-          d’identité, à l&apos;adresse suivante :
+          <a href="mailto:contact@email.refugies.info">contact@email.refugies.info</a>. Ou par
+          courrier postal, daté et signé, accompagné d&apos;une copie d’un titre d’identité, à
+          l&apos;adresse suivante :
         </p>
         <p>
           <strong>
@@ -70,11 +68,8 @@ const MentionsLegales = () => {
         textes, vidéos, animations, sons, logos et icônes, sont la propriété exclusive de
         l&apos;éditeur du site, à l’exception des marques, logos ou contenus appartenant à d’autres
         organisations. Pour toute demande d’autorisation ou d’information, veuillez nous contacter
-        par email :{" "}
-        <a title="Email" href="mailto:contact@email.refugies.info">
-          contact@email.refugies.info
-        </a>
-        . Des conditions spécifiques sont prévues pour la presse.
+        par email : <a href="mailto:contact@email.refugies.info">contact@email.refugies.info</a>.
+        Des conditions spécifiques sont prévues pour la presse.
       </p>
 
       <h2>Hébergeur</h2>

--- a/apps/client/src/pages/mentions-legales.tsx
+++ b/apps/client/src/pages/mentions-legales.tsx
@@ -34,9 +34,11 @@ const MentionsLegales = () => {
           rectification, de modification et de suppression concernant des données qui vous
           concernent personnellement. Ce droit peut être exercé par voie électronique à l’adresse
           email suivante :{" "}
-          <a href="mailto:contact@email.refugies.info">contact@email.refugies.info</a>. Ou par
-          courrier postal, daté et signé, accompagné d&apos;une copie d’un titre d’identité, à
-          l&apos;adresse suivante :
+          <a className="underline" href="mailto:contact@email.refugies.info">
+            contact@email.refugies.info
+          </a>
+          . Ou par courrier postal, daté et signé, accompagné d&apos;une copie d’un titre
+          d’identité, à l&apos;adresse suivante :
         </p>
         <p>
           <strong>
@@ -55,7 +57,11 @@ const MentionsLegales = () => {
       <p>
         Les informations personnelles collectées ne sont en aucun cas confiées à des tiers. Pour
         plus d&apos;information consultez la page relative à{" "}
-        <Link href={getPath("/politique-de-confidentialite", locale)} prefetch={false}>
+        <Link
+          className="underline"
+          href={getPath("/politique-de-confidentialite", locale)}
+          prefetch={false}
+        >
           <strong>notre politique de confidentialité</strong>
         </Link>
         .
@@ -68,15 +74,24 @@ const MentionsLegales = () => {
         textes, vidéos, animations, sons, logos et icônes, sont la propriété exclusive de
         l&apos;éditeur du site, à l’exception des marques, logos ou contenus appartenant à d’autres
         organisations. Pour toute demande d’autorisation ou d’information, veuillez nous contacter
-        par email : <a href="mailto:contact@email.refugies.info">contact@email.refugies.info</a>.
-        Des conditions spécifiques sont prévues pour la presse.
+        par email :{" "}
+        <a className="underline" href="mailto:contact@email.refugies.info">
+          contact@email.refugies.info
+        </a>
+        . Des conditions spécifiques sont prévues pour la presse.
       </p>
 
       <h2>Hébergeur</h2>
 
       <p>
         Le site Refugies.info est hébergé par la société{" "}
-        <Link prefetch={false} href="https://cloud.google.com" target="_blank" rel="noopener">
+        <Link
+          className="underline"
+          prefetch={false}
+          href="https://cloud.google.com"
+          target="_blank"
+          rel="noopener"
+        >
           Google Cloud France
         </Link>
         . 8 rue de Londres 75009 Paris (SIRET 910 738 392 00018)

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -1,7 +1,6 @@
 import { RoleName, type TranslationStatisticsResponse } from "@refugies-info/api-types";
 import { logger } from "logger";
 import Image from "next/image";
-import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useInView } from "react-intersection-observer";
@@ -44,8 +43,6 @@ interface Props {
 }
 
 const RecensezVotreAction = (props: Props) => {
-  const router = useRouter();
-
   // active links
   const [activeView, setActiveView] = useState<View | null>(null);
   const [refHero, inViewHero] = useInView({ threshold: 0 });
@@ -84,11 +81,6 @@ const RecensezVotreAction = (props: Props) => {
         .sort((a, b) => NEED_ORDER[a.need] - NEED_ORDER[b.need]),
     [props],
   );
-
-  const navigateToTranslations = useCallback(() => {
-    router.push("/backend/user-translation");
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   return (
     <div className="w-full">
@@ -342,7 +334,7 @@ const RecensezVotreAction = (props: Props) => {
         <Anchor id="register" />
         <div className="fr-container">
           <Register
-            onClickLoggedIn={navigateToTranslations}
+            hrefLoggedIn="/backend/user-translation"
             subtitleForm="Connectez-vous ou créez votre compte pour commencer à traduire les fiches."
             subtitleLoggedIn="Vous savez tout, vous pouvez traduire votre première fiche."
             btnLoggedIn="Traduire une fiche"

--- a/apps/client/src/pages/traduire.tsx
+++ b/apps/client/src/pages/traduire.tsx
@@ -2,7 +2,7 @@ import { RoleName, type TranslationStatisticsResponse } from "@refugies-info/api
 import { logger } from "logger";
 import Image from "next/image";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useInView } from "react-intersection-observer";
 import WhoIcon1 from "~/assets/staticPages/common/card-icon-bubble.svg";
 import CardIconCheck from "~/assets/staticPages/common/card-icon-check.svg";

--- a/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutStandard.tsx
@@ -45,10 +45,11 @@ const VoteLayoutStandard = forwardRef<HTMLDivElement, VoteLayoutStandardProps>(
         ref={ref}
         className={cn("mb-4 flex flex-col gap-2 rounded-sm bg-white p-4 shadow-lg", className)}
       >
-        <p className="mb-2 text-xl font-bold">
+        {/* text-default-grey cancels the DSFR heading colour to keep the previous rendering */}
+        <h2 className="text-default-grey mb-2 text-xl font-bold">
           {t("ui.northStar_title", "Cette page vous a-t-elle été utile ?")}{" "}
           <span aria-hidden="true">✨</span>
-        </p>
+        </h2>
 
         <div className="grid grid-cols-2 gap-2">
           <Button


### PR DESCRIPTION
Audit RGAA Ideance, RGA-12, compléments après la repasse d'exhaustivité de la grille avant la phase de tests.

Premier geste : le titre « Cette page est-elle utile ? » de l'encart d'avis devient un vrai titre de niveau 2, comme « Partager la fiche » l'est déjà depuis la PR #3881 (point relevé par Julie sur le ticket). Il vit dans le paquet UI partagé, c'est pour cela qu'il avait échappé à la première passe. Une classe de couleur annule la couleur de titre que le DSFR applique aux balises de titre : le rendu est identique au pixel près.

Deuxième geste, sur les pages Mission et impact, Publier, Traduire et Mentions légales : les images qui portent une information reçoivent une alternative (chiffres de la communauté, légendes des usagers), les images décoratives n'en ont plus, les attributs `title` parasites des drapeaux et des liens email sont retirés, une flèche décorative est masquée, les blocs de texte redeviennent des paragraphes et les cartes des articles, et le bouton « Traduire » en mode connecté devient un vrai lien vers la page de traduction. Rien ne bouge à l'écran.
