### PR TITLE
fix(a11y): icônes décoratives restantes (RGAA 8.9)

### DIFF
--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -253,6 +253,7 @@ exports[`publier renders publier 1`] = `
                         Bénéficiez d'un outil gratuit et traduit
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-subtract-line before:!bg-title-blue-france"
                       />
                     </button>
@@ -303,6 +304,7 @@ exports[`publier renders publier 1`] = `
                         Donnez de la visibilité à votre action
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -344,6 +346,7 @@ exports[`publier renders publier 1`] = `
                         Recevez des candidatures adaptées
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -385,6 +388,7 @@ exports[`publier renders publier 1`] = `
                         Participez à un service public ouvert
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -1367,6 +1371,7 @@ exports[`publier renders publier 1`] = `
                           Pourquoi je dois écrire moi-même la fiche ?
                         </span>
                         <i
+                          aria-hidden="true"
                           class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                         />
                       </button>
@@ -1408,6 +1413,7 @@ exports[`publier renders publier 1`] = `
                           Je ne suis pas à l'aise avec le numérique, est-ce facile ?
                         </span>
                         <i
+                          aria-hidden="true"
                           class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                         />
                       </button>
@@ -1449,6 +1455,7 @@ exports[`publier renders publier 1`] = `
                           En combien de temps ma fiche sera publiée ?
                         </span>
                         <i
+                          aria-hidden="true"
                           class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                         />
                       </button>
@@ -1490,6 +1497,7 @@ exports[`publier renders publier 1`] = `
                           Est-ce que je peux écrire une fiche pour une structure dont je ne fais pas partie ?
                         </span>
                         <i
+                          aria-hidden="true"
                           class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                         />
                       </button>
@@ -1531,6 +1539,7 @@ exports[`publier renders publier 1`] = `
                           Pourquoi est-il nécessaire de simplifier le contenu de ma fiche ?
                         </span>
                         <i
+                          aria-hidden="true"
                           class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                         />
                       </button>

--- a/apps/client/src/__tests__/__snapshots__/recherche.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/recherche.test.tsx.snap
@@ -133,6 +133,7 @@ exports[`recherche renders search results 1`] = `
                     </span>
                      
                     <i
+                      aria-hidden="true"
                       class="ri-arrow-down-s-line"
                     />
                   </button>
@@ -164,6 +165,7 @@ exports[`recherche renders search results 1`] = `
                     title="Recherche.resetButton Français"
                   >
                     <i
+                      aria-hidden="true"
                       class="ri-close-circle-fill"
                     />
                   </button>
@@ -191,6 +193,7 @@ exports[`recherche renders search results 1`] = `
                     </span>
                      
                     <i
+                      aria-hidden="true"
                       class="ri-arrow-down-s-line"
                     />
                   </button>
@@ -218,6 +221,7 @@ exports[`recherche renders search results 1`] = `
                     </span>
                      
                     <i
+                      aria-hidden="true"
                       class="ri-arrow-down-s-line"
                     />
                   </button>
@@ -245,6 +249,7 @@ exports[`recherche renders search results 1`] = `
                     </span>
                      
                     <i
+                      aria-hidden="true"
                       class="ri-arrow-down-s-line"
                     />
                   </button>
@@ -272,6 +277,7 @@ exports[`recherche renders search results 1`] = `
                     </span>
                      
                     <i
+                      aria-hidden="true"
                       class="ri-arrow-down-s-line"
                     />
                   </button>
@@ -299,6 +305,7 @@ exports[`recherche renders search results 1`] = `
                     </span>
                      
                     <i
+                      aria-hidden="true"
                       class="ri-arrow-down-s-line"
                     />
                   </button>
@@ -382,6 +389,7 @@ exports[`recherche renders search results 1`] = `
                 Filters.sortView
               </span>
               <i
+                aria-hidden="true"
                 class="ri-expand-up-down-line fr-icon--sm"
               />
             </button>

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -849,6 +849,7 @@ exports[`traduire renders traduire 1`] = `
                         Quel niveau je dois avoir pour devenir traducteur ?
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -890,6 +891,7 @@ exports[`traduire renders traduire 1`] = `
                         Combien de fiches je dois traduire ?
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -931,6 +933,7 @@ exports[`traduire renders traduire 1`] = `
                         Combien de temps est nécessaire pour traduire une fiche ?
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -972,6 +975,7 @@ exports[`traduire renders traduire 1`] = `
                         Quels sont les avantages de traduire des fiches sur Réfugiés.info ?
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>
@@ -1013,6 +1017,7 @@ exports[`traduire renders traduire 1`] = `
                         Est-ce que de nouvelles langues seront bientôt disponibles ?
                       </span>
                       <i
+                        aria-hidden="true"
                         class="flex before:!h-4 before:!w-4 fr-icon-add-line"
                       />
                     </button>

--- a/apps/client/src/components/Modals/NewProfileModal/NewProfileModal.tsx
+++ b/apps/client/src/components/Modals/NewProfileModal/NewProfileModal.tsx
@@ -53,7 +53,7 @@ const NewProfileModal = () => {
       show={show}
       title={
         <>
-          <i className="fr-icon-warning-line me-2" />
+          <i className="fr-icon-warning-line me-2" aria-hidden="true" />
           Votre compte Réfugiés.info fait peau neuve&nbsp;!
         </>
       }

--- a/apps/client/src/components/Pages/recherche/LocationMenu/GeoLocationMenuItem.tsx
+++ b/apps/client/src/components/Pages/recherche/LocationMenu/GeoLocationMenuItem.tsx
@@ -66,7 +66,10 @@ const GeoLocationMenuItem: React.FC = () => {
           onKeyDown={(e) => onEnterOrSpace(e, getLocation)}
           className={cn("w-full", styles.button)}
         >
-          <i className={cls("fr-icon-send-plane-fill", "fr-icon--sm", styles.icon)} />
+          <i
+            className={cls("fr-icon-send-plane-fill", "fr-icon--sm", styles.icon)}
+            aria-hidden="true"
+          />
           <span className={styles.buttonText}>
             {t("Recherche.positionButton", "Utiliser ma position")}
           </span>

--- a/apps/client/src/components/Pages/recherche/ResultsFilter/ResultsFilter.tsx
+++ b/apps/client/src/components/Pages/recherche/ResultsFilter/ResultsFilter.tsx
@@ -152,7 +152,10 @@ const ResultsFilter = (props: Props): React.ReactNode => {
                     aria-label={`${t(currentSortOption?.value || "")}, ${t("selected")}`}
                   >
                     <span className={styles.sort_label}>{t(currentSortOption?.value || "")}</span>
-                    <i className={fr.cx("ri-expand-up-down-line", "fr-icon--sm")}></i>
+                    <i
+                      className={fr.cx("ri-expand-up-down-line", "fr-icon--sm")}
+                      aria-hidden="true"
+                    ></i>
                   </button>
                 </DropdownMenu.Trigger>
                 <DropdownMenu.Portal>

--- a/apps/client/src/components/Pages/recherche/SearchHeader/Filter/DropdownButton/DropdownButton.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchHeader/Filter/DropdownButton/DropdownButton.tsx
@@ -75,7 +75,10 @@ export const DropdownButton = React.forwardRef<HTMLButtonElement, Props>(functio
         {!icon && value.length === 0 && !icon && (
           <>
             <span className={cls(styles.label)}>{label}</span>{" "}
-            <i className={isOpen ? "ri-arrow-up-s-line" : "ri-arrow-down-s-line"}></i>
+            <i
+              className={isOpen ? "ri-arrow-up-s-line" : "ri-arrow-down-s-line"}
+              aria-hidden="true"
+            ></i>
           </>
         )}
       </button>
@@ -86,7 +89,7 @@ export const DropdownButton = React.forwardRef<HTMLButtonElement, Props>(functio
           onClick={handleOnClear}
           title={`${t("Recherche.resetButton", "Réinitialiser le filtre")} ${label}`}
         >
-          <i className="ri-close-circle-fill"></i>
+          <i className="ri-close-circle-fill" aria-hidden="true"></i>
         </button>
       )}
     </div>

--- a/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.mobile.tsx
+++ b/apps/client/src/components/Pages/recherche/ThemeMenu/ThemeItem.mobile.tsx
@@ -37,7 +37,7 @@ const ThemeItemMobile: React.FC<Props> = ({ themeId, label, needCount, color }) 
             >
               {needCount}
             </b>
-            <i className={cls("fr-icon-arrow-down-s-line", styles.arrow)} />
+            <i className={cls("fr-icon-arrow-down-s-line", styles.arrow)} aria-hidden="true" />
           </span>
         </Accordion.Trigger>
       </Accordion.Header>

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
@@ -117,6 +117,7 @@ const Accordion = (props: Props) => {
                       {item.title}
                     </span>
                     <i
+                      aria-hidden="true"
                       className={cn(
                         "flex before:!h-4 before:!w-4",
                         isItemOpen

--- a/apps/client/src/components/UI/Badge/Badge.tsx
+++ b/apps/client/src/components/UI/Badge/Badge.tsx
@@ -14,7 +14,10 @@ const DSFRBadge = (props: Props) => {
   return (
     <Badge className={props.className} severity={props.severity} small={props.small} noIcon>
       {props.icon && (
-        <i className={cls(styles.icon, props.small && styles.small, props.icon, "me-1")} />
+        <i
+          className={cls(styles.icon, props.small && styles.small, props.icon, "me-1")}
+          aria-hidden="true"
+        />
       )}
       {props.children}
     </Badge>

--- a/apps/client/src/components/UI/SearchButton/SearchButton.tsx
+++ b/apps/client/src/components/UI/SearchButton/SearchButton.tsx
@@ -20,7 +20,7 @@ const SearchButton: React.FC<Props> = ({ onChange }) => {
   return (
     <form className={styles.container} onSubmit={(e) => e.preventDefault()}>
       <div className={styles.zone}>
-        <i className={cls("fr-icon-search-line", styles.icon)} />
+        <i className={cls("fr-icon-search-line", styles.icon)} aria-hidden="true" />
         <label htmlFor="theme-search-button" className="sr-only">
           {t("Recherche.themesPlaceholder", "Rechercher dans les thèmes")}
         </label>

--- a/packages/ui/src/components/composites/Map/MapPanelItem.tsx
+++ b/packages/ui/src/components/composites/Map/MapPanelItem.tsx
@@ -18,7 +18,7 @@ const AccordionLabel = ({ title, city }: { title: string; city?: string | null }
       <span className="text-title-xs mb-2 font-semibold">{title}</span>
       {city && (
         <p className="text-default-grey text-corps-sm mb-0 print:hidden">
-          <i className="fr-icon-building-line before:scale-75" />
+          <i className="fr-icon-building-line before:scale-75" aria-hidden="true" />
           {city}
         </p>
       )}

--- a/packages/ui/src/components/composites/MetaData/MetaDataCard.tsx
+++ b/packages/ui/src/components/composites/MetaData/MetaDataCard.tsx
@@ -61,7 +61,10 @@ export const MetaDataCard = ({
             {onClick && (
               <>
                 {state === "invalid" && (
-                  <i className="fr-icon-warning-fill text-action-high-red-marianne inline-block translate-x-1 scale-75 p-1" />
+                  <i
+                    className="fr-icon-warning-fill text-action-high-red-marianne inline-block translate-x-1 scale-75 p-1"
+                    aria-hidden="true"
+                  />
                 )}
                 <Button
                   iconId="fr-icon-edit-line"

--- a/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
+++ b/packages/ui/src/components/composites/MetaData/MetaDataItem.tsx
@@ -41,7 +41,7 @@ export const MetaDataItem = ({
     >
       {icon &&
         (typeof icon === "string" ? (
-          <i className={cn(icon, "[&::before]:![--icon-size:1.5rem]")} />
+          <i className={cn(icon, "[&::before]:![--icon-size:1.5rem]")} aria-hidden="true" />
         ) : (
           icon
         ))}
@@ -70,7 +70,10 @@ export const MetaDataItem = ({
       {onClick && (
         <span className="ml-auto flex items-center">
           {state === "invalid" && (
-            <i className="fr-icon-warning-fill text-action-high-red-marianne inline-block translate-x-1 scale-75 p-1" />
+            <i
+              className="fr-icon-warning-fill text-action-high-red-marianne inline-block translate-x-1 scale-75 p-1"
+              aria-hidden="true"
+            />
           )}
           <Button
             iconId="fr-icon-edit-line"

--- a/packages/ui/src/components/composites/RIAccordion/RIAccordion.tsx
+++ b/packages/ui/src/components/composites/RIAccordion/RIAccordion.tsx
@@ -39,8 +39,8 @@ export const RIAccordion = (props: RIAccordionProps) => {
             {title}
           </span>
           <span className="flex items-center">
-            <i className="ri-add-fill scale-75" />
-            <i className="ri-subtract-fill scale-75" />
+            <i className="ri-add-fill scale-75" aria-hidden="true" />
+            <i className="ri-subtract-fill scale-75" aria-hidden="true" />
           </span>
         </div>
       }


### PR DESCRIPTION
Audit RGAA Ideance, RGA-6, complément après la repasse d'exhaustivité de la grille avant la phase de tests. La prescription 8.9 listait « entre autres » des icônes que la première passe n'avait pas toutes traitées (point relevé par Julie sur le ticket). Balayage complet des 13 pages auditées pour ne pas y revenir : le + / - des deux accordéons, le pictogramme d'avertissement de la fenêtre « Votre compte fait peau neuve », et les icônes décoratives restantes (pictogrammes des métadonnées et des cartes, loupe du champ de recherche, flèches des filtres et des encarts) ne sont plus annoncés par les lecteurs d'écran. L'information reste portée par le texte à côté. Rien ne bouge à l'écran.
