### PR TITLE
fix(a11y): contrastes de texte et de composants graphiques (RGAA 3.2, 3.3)

### DIFF
--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -956,7 +956,7 @@ exports[`publier renders publier 1`] = `
                 Vous êtes informé par email lorsque la fiche est visible par les utilisateurs.
               </div>
               <div
-                class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2"
+                class="text-large bg-action-high-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2"
               >
                 Votre fiche est publiée ! 
                 <span

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -603,7 +603,7 @@ exports[`traduire renders traduire 1`] = `
                 Vous allez recevoir un mail dès que la fiche que vous avez traduite sera visible sur le site Réfugiés.info et sur l'application mobile.
               </div>
               <div
-                class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2 !bottom-0"
+                class="text-large bg-action-high-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2 !bottom-0"
               >
                 La traduction est publiée 
                 <span

--- a/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
+++ b/apps/client/src/components/Modals/SubscribeNewsletterModal/SubscribeNewsletterModal.tsx
@@ -204,7 +204,12 @@ export const SubscribeNewsletterModal = () => {
           />
         ) : (
           <ButtonContainer>
-            <FButton type="light-action" name="close-outline" onClick={toggle}>
+            <FButton
+              type="light-action"
+              name="close-outline"
+              onClick={toggle}
+              className={styles.secondary_button}
+            >
               <div> {t("Retour", "Retour")}</div>
             </FButton>
             <FButton

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -107,8 +107,7 @@ const MobileApp = () => {
               className="inline-flex gap-3"
             >
               {Array.from({ length: 5 }).map((_, index) => (
-                // TODO @ledjay : fix yellow colors from DSFR
-                <i key={index} className="fr-icon-star-fill h-4 w-4 text-[#fcc63a]" />
+                <i key={index} className="fr-icon-star-fill h-4 w-4 text-[#6A6AF4]" />
               ))}
             </span>
             {t("MobileApp.rankingText", "Top 3 des applications publiques")}

--- a/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
@@ -30,7 +30,7 @@ const StepContent = (props: Props) => {
     () => (
       <div
         className={cls(
-          "text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white",
+          "text-large bg-action-high-blue-france z-10 rounded-full p-4 text-center font-bold text-white",
           "absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2",
           props.buttonStepEnd && "!bottom-0",
         )}

--- a/apps/client/src/components/UI/FInput/FInput.tsx
+++ b/apps/client/src/components/UI/FInput/FInput.tsx
@@ -46,7 +46,7 @@ const FInput = (props: Props) => {
           {!props.error ? (
             <EVAIcon name={props.prependName} fill={props.prependFill || colors.gray90} />
           ) : (
-            <EVAIcon name={props.errorIcon || props.prependName} fill="#F44336" />
+            <EVAIcon name={props.errorIcon || props.prependName} fill={colors.error} />
           )}
         </InputGroupText>
       )}
@@ -82,7 +82,7 @@ const FInput = (props: Props) => {
       {(props.append || props.error) && (
         <InputGroupText className={styles.append} onClick={props.onAppendClick}>
           {props.error && props.errorType !== "wrongPassword" ? (
-            <EVAIcon name="alert-triangle" fill="#F44336" />
+            <EVAIcon name="alert-triangle" fill={colors.error} />
           ) : (
             <EVAIcon name={props.appendName} fill={props.appendFill || colors.gray90} />
           )}

--- a/apps/client/src/components/UI/LanguageSelector/LanguageItem.tsx
+++ b/apps/client/src/components/UI/LanguageSelector/LanguageItem.tsx
@@ -70,7 +70,7 @@ const LanguageItem = memo(
             (currentLanguage === item.i18nCode && !disabled) || forceActive ? styles.selected : "",
             type === "page" && "[&:before]:hidden",
             disabled &&
-              `disabled [&_*]:text-disabled-grey hover:bg-white [&_*]:pointer-events-none [&_*]:cursor-not-allowed ${styles.disabled}`,
+              `disabled [&_*]:text-mention-grey hover:bg-white [&_*]:pointer-events-none [&_*]:cursor-not-allowed ${styles.disabled}`,
             className,
           )}
           disabled={disabled}

--- a/apps/client/src/components/UI/SearchButton/SearchButton.module.css
+++ b/apps/client/src/components/UI/SearchButton/SearchButton.module.css
@@ -31,6 +31,13 @@
 
 .input {
   flex: 1 0 0;
+  color: var(--text-default-grey);
+}
+
+/* The field sits on a grey background: the browser default placeholder, half transparent, is too faint. */
+.input::placeholder {
+  color: var(--text-mention-grey);
+  opacity: 1;
 }
 
 .input[dir="rtl"] {

--- a/apps/client/src/scss/_colors.scss
+++ b/apps/client/src/scss/_colors.scss
@@ -6,7 +6,7 @@ $darkColor: #212121;
 $darkGrey: #5e5e5e;
 $darkOrange: #ea6206;
 $erreur: #ffcecb;
-$error: #f44336;
+$error: #ce0500;
 $focus: #2d9cdb;
 $gray10: #fbfbfb;
 $gray20: #f2f2f2;

--- a/apps/client/src/scss/_colors.scss
+++ b/apps/client/src/scss/_colors.scss
@@ -36,9 +36,9 @@ $standby: #fdd497;
 $validation: #def6c2;
 $validationDefault: #8bc34a;
 $validationHover: #4caf50;
-$vert: #2ca12a;
+$vert: #18753c;
 $vert2: #008205;
-$vertFonce: #219653;
+$vertFonce: #1e7b3e;
 $white: #fff;
 $yellow: #ffeb3b;
 

--- a/apps/client/src/scss/components/auth.module.scss
+++ b/apps/client/src/scss/components/auth.module.scss
@@ -128,7 +128,7 @@
 .separator {
   @include dsfr-text("large");
 
-  color: var(--text-disabled-grey);
+  color: var(--text-mention-grey);
   display: flex;
   align-items: center;
   gap: u(6);

--- a/apps/client/src/scss/components/modals.module.scss
+++ b/apps/client/src/scss/components/modals.module.scss
@@ -4,10 +4,15 @@
   min-width: 100px;
 
   .modal_content {
-    background: #e0e0e0;
+    background: $white;
     border: hidden;
     box-shadow: 0 4px 40px rgb(0 0 0 / 25%);
     border-radius: $radius;
     mix-blend-mode: normal;
+
+    // The light button has a transparent border, so it loses its outline on a white card.
+    .secondary_button {
+      border: 1px solid $gray80;
+    }
   }
 }

--- a/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
+++ b/packages/ui/src/components/composites/vote/VoteLayoutSticky.tsx
@@ -54,7 +54,7 @@ const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
             priority={vote === true ? "primary" : "secondary"}
             className={cn(
               "flex h-[2.5rem] items-end gap-2 rounded-s-[50rem] shadow-none transition-all",
-              vote === false && "text-disabled-grey",
+              vote === false && "text-mention-grey",
             )}
           >
             <div className="relative">
@@ -77,7 +77,7 @@ const VoteLayoutSticky = forwardRef<HTMLDivElement, VoteLayoutStickyProps>(
             onClick={handleClickNo}
             className={cn(
               "flex h-[2.5rem] items-end gap-2 rounded-e-[50rem] shadow-none transition-all",
-              vote === true && "text-disabled-grey",
+              vote === true && "text-mention-grey",
             )}
           >
             <span className="fr-icon-thumb-down-line" aria-hidden="true"></span>


### PR DESCRIPTION
Audit RGAA Ideance, RGA-18. Le vert du bouton « Envoyer », le rouge des messages d'erreur et le jaune des étoiles de notation passent aux couleurs DSFR pour repasser au-dessus des seuils de contraste, et la carte de la boîte de dialogue newsletter passe du gris `#e0e0e0` au blanc : sur le gris le rouge DSFR plafonne à 4,36:1 alors que 4,5:1 est requis, sur blanc il monte à 5,76:1. Le bouton « Retour » de cette boîte reçoit une bordure grise pour ne pas perdre sa forme sur le fond devenu blanc.

Cinq autres gris trop clairs relevés par la grille passent au gris DSFR lisible : le texte « ou connectez-vous avec » des écrans de connexion, le champ de recherche par thème, le bouton de vote non sélectionné de l'encart flottant, les langues indisponibles du sélecteur de la fiche, et la pastille « Votre fiche est publiée ! » dont le fond violet devient bleu marine (aucune couleur de texte ne passait le seuil sur ce violet, c'est le seul point où l'on change le fond plutôt que le texte ; à valider côté design). Les langues indisponibles sont des boutons désactivés, que le RGAA exempte du critère : on les fonce quand même, c'est plus lisible et sans risque.

Les captures avant/après des huit points, avec les ratios mesurés et les liens vers les pages en prod, sont sur le ticket Linear RGA-18 : https://linear.app/refugiesinfo/issue/RGA-18

Le vert et le rouge sont des jetons de couleur partagés : ils changent aussi dans le back-office et le middle-office, sur les boutons de validation et les messages d'erreur. C'est assumé. Deux instantanés de test sont régénérés, aucun autre ne bouge.
