### PR TITLE
fix(a11y): responsive 320 px et zoom 200 % (RGAA 10.11, 10.4, 10.1)

### DIFF
--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -924,7 +924,7 @@ exports[`publier renders publier 1`] = `
                 Vous êtes informé par email lorsque la fiche est visible par les utilisateurs.
               </div>
               <div
-                class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2"
+                class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white relative mt-2 inline-block md:max-lg:hidden lg:absolute lg:start-0 lg:mt-0 lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2"
               >
                 Votre fiche est publiée ! 
                 <span
@@ -948,6 +948,16 @@ exports[`publier renders publier 1`] = `
                 style="color: transparent; object-fit: contain;"
                 width="440"
               />
+            </div>
+            <div
+              class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white hidden md:max-lg:block absolute start-0 bottom-[60px]"
+            >
+              Votre fiche est publiée ! 
+              <span
+                aria-hidden="true"
+              >
+                🎉
+              </span>
             </div>
           </div>
           <div

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`publier renders publier 1`] = `
       class="sticky top-0 z-20 bg-white"
     >
       <div
-        class="container flex flex-nowrap items-start justify-between gap-10 py-4 md:py-10"
+        class="container flex flex-wrap md:flex-nowrap items-start justify-between gap-10 py-4 md:py-10"
       >
         <div
           class="nav"

--- a/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/publier.test.tsx.snap
@@ -371,7 +371,7 @@ exports[`publier renders publier 1`] = `
               </div>
             </div>
             <div
-              class="flex w-1/2 items-center justify-center"
+              class="flex items-center w-1/2 justify-center"
             >
               <img
                 alt=""

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -570,7 +570,7 @@ exports[`traduire renders traduire 1`] = `
                 Vous allez recevoir un mail dès que la fiche que vous avez traduite sera visible sur le site Réfugiés.info et sur l'application mobile.
               </div>
               <div
-                class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2 !bottom-0"
+                class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white relative mt-2 inline-block md:max-lg:hidden lg:absolute lg:start-0 lg:mt-0 lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2 lg:!bottom-0"
               >
                 La traduction est publiée 
                 <span
@@ -594,6 +594,16 @@ exports[`traduire renders traduire 1`] = `
                 style="color: transparent; object-fit: contain;"
                 width="440"
               />
+            </div>
+            <div
+              class="text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white hidden md:max-lg:block absolute start-0 bottom-[60px] !bottom-0"
+            >
+              La traduction est publiée 
+              <span
+                aria-hidden="true"
+              >
+                🎉
+              </span>
             </div>
           </div>
         </div>

--- a/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
+++ b/apps/client/src/__tests__/__snapshots__/traduire.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`traduire renders traduire 1`] = `
       class="sticky top-0 z-20 bg-white"
     >
       <div
-        class="container flex flex-nowrap items-start justify-between gap-10 py-4 md:py-10"
+        class="container flex flex-wrap md:flex-nowrap items-start justify-between gap-10 py-4 md:py-10"
       >
         <div
           class="nav"

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
@@ -4,7 +4,12 @@
 
 .modal {
   @include media-min("tablet-up") {
-    width: 500px;
+    // 37.5rem, soit la largeur que le contenu imposait deja par un min-width :
+    // le dialogue faisait 500 px et son contenu 600, qui depassait sur la droite.
+    // On dimensionne le dialogue lui-meme, et on le borne par la fenetre pour
+    // qu'il ne sorte plus a 200 % d'agrandissement du texte (RGAA 10.4).
+    width: 37.5rem;
+    max-width: calc(100vw - 3.5rem);
   }
 
   .close {

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
@@ -20,6 +20,13 @@
     box-shadow: 0 0 16px rgb(0 0 0 / 30%);
     border-radius: 0;
     border: none;
+
+    // Dans une fenetre de 256 px de haut, la modale mesurait 866 px et etait
+    // coupee en bas, sans moyen d'atteindre la fin de la liste (RGAA 10.11).
+    // 3.5rem = les marges haute et basse que reactstrap pose sur .modal-dialog.
+    // En rem, donc la borne suit l'agrandissement du texte (RGAA 10.4).
+    max-height: calc(100vh - 3.5rem);
+    overflow-y: auto;
   }
 
   .modal_header {

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
@@ -4,10 +4,10 @@
 
 .modal {
   @include media-min("tablet-up") {
-    // 37.5rem, soit la largeur que le contenu imposait deja par un min-width :
-    // le dialogue faisait 500 px et son contenu 600, qui depassait sur la droite.
-    // On dimensionne le dialogue lui-meme, et on le borne par la fenetre pour
-    // qu'il ne sorte plus a 200 % d'agrandissement du texte (RGAA 10.4).
+    // 37.5rem, i.e. the width the content already imposed through a min-width:
+    // the dialog was 500 px wide and its content 600, which overflowed on the right.
+    // The dialog itself is now sized, and bounded by the viewport so that it no
+    // longer overflows at 200 % text zoom (RGAA 10.4).
     width: 37.5rem;
     max-width: calc(100vw - 3.5rem);
   }
@@ -26,10 +26,10 @@
     border-radius: 0;
     border: none;
 
-    // Dans une fenetre de 256 px de haut, la modale mesurait 866 px et etait
-    // coupee en bas, sans moyen d'atteindre la fin de la liste (RGAA 10.11).
-    // 3.5rem = les marges haute et basse que reactstrap pose sur .modal-dialog.
-    // En rem, donc la borne suit l'agrandissement du texte (RGAA 10.4).
+    // In a 256 px tall viewport, the modal was 866 px tall and cut off at the
+    // bottom, with no way to reach the end of the list (RGAA 10.11).
+    // 3.5rem = the top and bottom margins reactstrap sets on .modal-dialog.
+    // In rem, so the bound follows text zoom (RGAA 10.4).
     max-height: calc(100vh - 3.5rem);
     overflow-y: auto;
   }

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.module.scss
@@ -104,12 +104,6 @@
       background-color: $bleuCharte;
       border: 0.5px solid $bleuCharte;
     }
-
-    .vertical_center {
-      display: flex;
-      align-items: center;
-      padding-left: 20px;
-    }
   }
 
   // Cols
@@ -125,12 +119,6 @@
   .progress_col {
     display: flex;
     align-items: center;
-  }
-
-  .button_col {
-    display: flex;
-    padding-right: 15px;
-    justify-content: flex-end;
   }
 
   .icon_col {

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
@@ -2,7 +2,7 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import type { GetLanguagesResponse } from "@refugies-info/api-types";
 import { useTranslation } from "next-i18next";
 import { isMobile } from "react-device-detect";
-import { Col, ListGroupItem, Modal, ModalBody, Row } from "reactstrap";
+import { ListGroupItem, Modal, ModalBody } from "reactstrap";
 import { getPath } from "routes";
 import { LanguageSelector } from "~/components/UI/LanguageSelector";
 import useLocale from "~/hooks/useLocale";
@@ -55,24 +55,23 @@ const LanguageModal = (props: Props) => {
             tag="div"
             className={styles.list_group_item + " " + styles.unavailable}
           >
-            <Row>
-              <Col xs="8" className={cn(styles.vertical_center)}>
-                <p className="mb-0">
-                  {t("Homepage.traduire", "Vous pouvez nous aider à traduire !")}
-                </p>
-              </Col>
-              <Col xs="4" className={styles.button_col}>
-                <Button
-                  linkProps={{
-                    href: getPath("/traduire", locale),
-                    prefetch: false,
-                    onClick: props.toggle,
-                  }}
-                >
-                  {t("Homepage.btnTranslate", "Traduire")}
-                </Button>
-              </Col>
-            </Row>
+            {/* La grille reactstrap Col xs=8 / xs=4 n'avait aucune variante : sous
+                380 px le bouton ne tenait pas dans son quart et recouvrait le
+                texte. Un flex qui passe a la ligne regle les deux (RGAA 10.11). */}
+            <div className="flex flex-wrap items-center justify-between gap-4">
+              <p className="mb-0">
+                {t("Homepage.traduire", "Vous pouvez nous aider à traduire !")}
+              </p>
+              <Button
+                linkProps={{
+                  href: getPath("/traduire", locale),
+                  prefetch: false,
+                  onClick: props.toggle,
+                }}
+              >
+                {t("Homepage.btnTranslate", "Traduire")}
+              </Button>
+            </div>
           </ListGroupItem>
         )}
       </ModalBody>

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
@@ -22,10 +22,10 @@ const LanguageModal = (props: Props) => {
   const { t } = useTranslation();
   const locale = useLocale();
 
-  // La largeur et la hauteur de la modale sont bornees par la fenetre dans la
-  // feuille de style : a 200 % d'agrandissement du texte elle sortait a droite,
-  // et dans une fenetre de 256 px de haut elle etait coupee en bas sans moyen
-  // d'atteindre la fin de la liste (RGAA 10.4 et 10.11).
+  // The modal width and height are bounded by the viewport in the stylesheet:
+  // at 200 % text zoom it overflowed on the right, and in a 256 px tall viewport
+  // it was cut off at the bottom with no way to reach the end of the list
+  // (RGAA 10.4 and 10.11).
   return (
     <Modal
       isOpen={props.show}
@@ -59,9 +59,9 @@ const LanguageModal = (props: Props) => {
             tag="div"
             className={styles.list_group_item + " " + styles.unavailable}
           >
-            {/* La grille reactstrap Col xs=8 / xs=4 n'avait aucune variante : sous
-                380 px le bouton ne tenait pas dans son quart et recouvrait le
-                texte. Un flex qui passe a la ligne regle les deux (RGAA 10.11). */}
+            {/* The reactstrap Col xs=8 / xs=4 grid had no responsive variant: below
+                380 px the button did not fit in its quarter and overlapped the
+                text. A wrapping flex container fixes both (RGAA 10.11). */}
             <div className="flex flex-wrap items-center justify-between gap-4">
               <p className="mb-0">
                 {t("Homepage.traduire", "Vous pouvez nous aider à traduire !")}

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
@@ -22,13 +22,17 @@ const LanguageModal = (props: Props) => {
   const { t } = useTranslation();
   const locale = useLocale();
 
+  // 37.5rem valent 1200 px quand l'agrandissement du texte porte la racine a 32 px :
+  // la modale sortait alors de la fenetre. On borne par la largeur disponible, et la
+  // feuille de style lui donne un defilement vertical quand elle depasse en hauteur
+  // (RGAA 10.4 et 10.11).
   return (
     <Modal
       isOpen={props.show}
       toggle={props.toggle}
       labelledBy="language-modal-title"
       className={cn(styles.modal)}
-      contentClassName={cn(styles.modal_content, "md:min-w-[37.5rem]")}
+      contentClassName={cn(styles.modal_content, "md:min-w-[min(37.5rem,100%)]")}
     >
       <ModalBody className={cn(styles.modal_body)}>
         <div className="flex flex-col gap-8">

--- a/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
+++ b/apps/client/src/components/Modals/LanguageModal/LanguageModal.tsx
@@ -22,17 +22,17 @@ const LanguageModal = (props: Props) => {
   const { t } = useTranslation();
   const locale = useLocale();
 
-  // 37.5rem valent 1200 px quand l'agrandissement du texte porte la racine a 32 px :
-  // la modale sortait alors de la fenetre. On borne par la largeur disponible, et la
-  // feuille de style lui donne un defilement vertical quand elle depasse en hauteur
-  // (RGAA 10.4 et 10.11).
+  // La largeur et la hauteur de la modale sont bornees par la fenetre dans la
+  // feuille de style : a 200 % d'agrandissement du texte elle sortait a droite,
+  // et dans une fenetre de 256 px de haut elle etait coupee en bas sans moyen
+  // d'atteindre la fin de la liste (RGAA 10.4 et 10.11).
   return (
     <Modal
       isOpen={props.show}
       toggle={props.toggle}
       labelledBy="language-modal-title"
       className={cn(styles.modal)}
-      contentClassName={cn(styles.modal_content, "md:min-w-[min(37.5rem,100%)]")}
+      contentClassName={cn(styles.modal_content)}
     >
       <ModalBody className={cn(styles.modal_body)}>
         <div className="flex flex-col gap-8">

--- a/apps/client/src/components/Modals/NewProfileModal/NewProfileModal.tsx
+++ b/apps/client/src/components/Modals/NewProfileModal/NewProfileModal.tsx
@@ -67,12 +67,17 @@ const NewProfileModal = () => {
         Pour continuer à accéder au contenu, merci de{" "}
         <strong>compléter votre profil en cliquant sur le bouton ci-dessous</strong>.
       </p>
-      <div className={cls("flex justify-between items-start", styles.actions)}>
+      {/* The actions row could not wrap and the inner column used the Bootstrap
+          `flex-column` utility, which this build does not generate (the utilities
+          API import is commented out in scss/_bootstrap.scss): the three actions
+          stayed on one line and pushed the help link out of the viewport below
+          380 px. A wrapping row and the Tailwind `flex-col` fix both (RGAA 10.11). */}
+      <div className={cls("flex flex-wrap justify-between items-start gap-4", styles.actions)}>
         <Button priority="secondary" onClick={logout} className={styles.danger}>
           Me déconnecter
         </Button>
 
-        <div className="flex flex-column items-end gap-2">
+        <div className="flex flex-col items-end gap-2">
           <Button
             iconId="fr-icon-arrow-right-line"
             iconPosition="right"

--- a/apps/client/src/components/Navigation/Navbar/Navbar.module.scss
+++ b/apps/client/src/components/Navigation/Navbar/Navbar.module.scss
@@ -15,15 +15,14 @@
       }
     }
 
-    // A 200 % d'agrandissement du texte, les quatre boutons d'acces rapide
-    // mesuraient 1185 px dans une fenetre de 1280 et poussaient un defilement
-    // horizontal de la page. Le groupe passe a la ligne au lieu de deborder
-    // (RGAA 10.4).
-    // flex-wrap seul ne suffit pas : .fr-header__tools porte flex: 1 0 auto,
-    // donc il ne retrecit jamais sous la largeur de son contenu et le groupe
-    // garde une largeur disponible infinie. Il faut l'autoriser a retrecir et
-    // lever le min-width automatique de la chaine flex. A taille de texte
-    // normale le contenu tient, donc rien ne bouge.
+    // At 200 % text zoom, the four quick access buttons measured 1185 px in a
+    // 1280 px wide viewport and forced a horizontal scroll on the page. The group
+    // now wraps instead of overflowing (RGAA 10.4).
+    // flex-wrap alone is not enough: .fr-header__tools has flex: 1 0 auto, so it
+    // never shrinks below its content width and the group keeps an infinite
+    // available width. It must be allowed to shrink, and the automatic min-width
+    // of the flex chain must be lifted. At normal text size the content fits, so
+    // nothing changes.
     :global .fr-header__tools {
       flex-shrink: 1;
       min-width: 0;
@@ -39,8 +38,8 @@
       min-width: 0;
     }
 
-    // Meme cause pour la barre de navigation principale : au meme zoom, le
-    // dernier item depassait de 10 px (RGAA 10.4).
+    // Same cause for the main navigation bar: at the same zoom, the last item
+    // overflowed by 10 px (RGAA 10.4).
     :global .fr-nav__list {
       flex-wrap: wrap;
     }

--- a/apps/client/src/components/Navigation/Navbar/Navbar.module.scss
+++ b/apps/client/src/components/Navigation/Navbar/Navbar.module.scss
@@ -14,6 +14,36 @@
         max-height: 3.3rem;
       }
     }
+
+    // A 200 % d'agrandissement du texte, les quatre boutons d'acces rapide
+    // mesuraient 1185 px dans une fenetre de 1280 et poussaient un defilement
+    // horizontal de la page. Le groupe passe a la ligne au lieu de deborder
+    // (RGAA 10.4).
+    // flex-wrap seul ne suffit pas : .fr-header__tools porte flex: 1 0 auto,
+    // donc il ne retrecit jamais sous la largeur de son contenu et le groupe
+    // garde une largeur disponible infinie. Il faut l'autoriser a retrecir et
+    // lever le min-width automatique de la chaine flex. A taille de texte
+    // normale le contenu tient, donc rien ne bouge.
+    :global .fr-header__tools {
+      flex-shrink: 1;
+      min-width: 0;
+    }
+
+    :global .fr-header__tools-links {
+      min-width: 0;
+    }
+
+    :global .fr-header__tools-links .fr-btns-group {
+      flex-wrap: wrap;
+      justify-content: flex-end;
+      min-width: 0;
+    }
+
+    // Meme cause pour la barre de navigation principale : au meme zoom, le
+    // dernier item depassait de 10 px (RGAA 10.4).
+    :global .fr-nav__list {
+      flex-wrap: wrap;
+    }
   }
 }
 

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
@@ -24,10 +24,9 @@ interface Props {
   availableLanguages?: string[] | null | undefined;
   key?: string;
   /**
-   * Force le choix entre `mobileMode` et `desktopMode` au lieu de le deduire de
-   * `isMobile`. A utiliser quand le composant vit dans une mise en page dont le
-   * point de rupture est porte par une feuille de style, pour que les deux
-   * basculent ensemble.
+   * Forces the choice between `mobileMode` and `desktopMode` instead of deriving
+   * it from `isMobile`. Use it when the component lives in a layout whose
+   * breakpoint is defined by a stylesheet, so that both switch together.
    */
   isCompact?: boolean;
 }

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu.tsx
@@ -23,6 +23,13 @@ interface Props {
   itemsDesign?: "radio" | "default";
   availableLanguages?: string[] | null | undefined;
   key?: string;
+  /**
+   * Force le choix entre `mobileMode` et `desktopMode` au lieu de le deduire de
+   * `isMobile`. A utiliser quand le composant vit dans une mise en page dont le
+   * point de rupture est porte par une feuille de style, pour que les deux
+   * basculent ensemble.
+   */
+  isCompact?: boolean;
 }
 
 const LanguageMenu = ({
@@ -35,6 +42,7 @@ const LanguageMenu = ({
   availableLanguages = null,
   itemsDesign = "default",
   key,
+  isCompact,
 }: Props) => {
   const [langMenuOpened, setLangMenuOpened] = useState(false);
 
@@ -49,6 +57,7 @@ const LanguageMenu = ({
   }
 
   const { isMobile } = useWindowSize();
+  const compact = isCompact ?? isMobile;
 
   const stylesDisabled = useStylesDisabled();
   const { t } = useTranslation();
@@ -73,7 +82,7 @@ const LanguageMenu = ({
   return (
     <>
       {stylesDisabled && <span>{t("Toolbar.Langue", "Langue :")}</span>}
-      {(isMobile && mobileMode === "accordion") || (!isMobile && desktopMode === "accordion") ? (
+      {(compact && mobileMode === "accordion") || (!compact && desktopMode === "accordion") ? (
         <Accordion
           label={
             <>
@@ -93,7 +102,7 @@ const LanguageMenu = ({
         </Accordion>
       ) : null}
 
-      {(isMobile && mobileMode === "dropdown") || (!isMobile && desktopMode === "dropdown") ? (
+      {(compact && mobileMode === "dropdown") || (!compact && desktopMode === "dropdown") ? (
         <DropdownRoot
           className={cn(className)}
           ref={dropdownRef}
@@ -127,7 +136,7 @@ const LanguageMenu = ({
         </DropdownRoot>
       ) : null}
 
-      {(isMobile && mobileMode === "modal") || (!isMobile && desktopMode === "modal") ? (
+      {(compact && mobileMode === "modal") || (!compact && desktopMode === "modal") ? (
         <Dialog.Root open={langMenuOpened} onOpenChange={setLangMenuOpened} key={key}>
           <Dialog.Trigger asChild>
             <Button priority="tertiary no outline" className={cn("flex gap-2", className)}>

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
@@ -3,7 +3,7 @@ import { cn, useWindowSize } from "@refugies-info/ui";
 import { useTranslation } from "next-i18next";
 import LanguageMenu from "~/components/Navigation/Navbar/QuickAccessMenu/LanguageMenu";
 import LoginButton from "~/components/Navigation/Navbar/QuickAccessMenu/LoginButton";
-import { useLocale } from "~/hooks";
+import { useLocale, useMediaQuery } from "~/hooks";
 import { getPath } from "~/routes";
 
 // This component retunrs an array of JSX items specifically for the DSFR Header component
@@ -16,7 +16,12 @@ import { getPath } from "~/routes";
 
 const QuickAccessMenu = () => {
   const { t } = useTranslation();
-  const { isMobile, zoomLevel } = useWindowSize();
+  const { zoomLevel } = useWindowSize();
+  // On negocie exactement la media query du DSFR plutot que d'en ecrire une
+  // complementaire : a 992 px pile, Chrome fait matcher a la fois
+  // (min-width: 62em) et (max-width: 61.9999em), et les deux mises en page se
+  // superposaient. La valeur par defaut garde le rendu serveur en mode bureau.
+  const isDsfrCompactHeader = !useMediaQuery("(min-width: 62em)", true);
   const locale = useLocale();
 
   const menuItems = [
@@ -40,12 +45,20 @@ const QuickAccessMenu = () => {
       iconId="fr-icon-message-2-line"
       priority="tertiary no outline"
     >
-      {isMobile
+      {/* Meme point de rupture que la mise en page de l'en-tete : sinon le
+          libelle long s'affichait dans la barre de bureau des 200 % de zoom. */}
+      {isDsfrCompactHeader
         ? t("Toolbar.TraduireUneFiche", "Traduire une fiche")
         : t("Toolbar.Traduire", "Traduire")}
     </Button>,
     <LanguageMenu
       key="language"
+      // Le DSFR bascule sa barre d'outils vers le menu burger a 62em, et l'unite
+      // em d'une media query ne suit pas l'agrandissement du texte. Sans ce
+      // garde, le menu se croyait sur mobile a partir de 200 % de zoom texte et
+      // rendait son accordeon dans la barre de bureau, qui debordait alors de
+      // 952 px (RGAA 10.4).
+      isCompact={isDsfrCompactHeader}
       className={cn(zoomLevel >= 175 && "!w-full")}
       dropDownClassName={cn(zoomLevel >= 175 && "!w-full")}
     />,

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
@@ -17,10 +17,10 @@ import { getPath } from "~/routes";
 const QuickAccessMenu = () => {
   const { t } = useTranslation();
   const { zoomLevel } = useWindowSize();
-  // On negocie exactement la media query du DSFR plutot que d'en ecrire une
-  // complementaire : a 992 px pile, Chrome fait matcher a la fois
-  // (min-width: 62em) et (max-width: 61.9999em), et les deux mises en page se
-  // superposaient. La valeur par defaut garde le rendu serveur en mode bureau.
+  // We negate the exact DSFR media query rather than writing a complementary
+  // one: at exactly 992 px, Chrome matches both (min-width: 62em) and
+  // (max-width: 61.9999em), and the two layouts overlapped. The default value
+  // keeps the server render in desktop mode.
   const isDsfrCompactHeader = !useMediaQuery("(min-width: 62em)", true);
   const locale = useLocale();
 
@@ -45,26 +45,26 @@ const QuickAccessMenu = () => {
       iconId="fr-icon-message-2-line"
       priority="tertiary no outline"
     >
-      {/* Meme point de rupture que la mise en page de l'en-tete : sinon le
-          libelle long s'affichait dans la barre de bureau des 200 % de zoom. */}
+      {/* Same breakpoint as the header layout: otherwise the long label showed
+          up in the desktop bar from 200 % zoom onwards. */}
       {isDsfrCompactHeader
         ? t("Toolbar.TraduireUneFiche", "Traduire une fiche")
         : t("Toolbar.Traduire", "Traduire")}
     </Button>,
     <LanguageMenu
       key="language"
-      // Le DSFR bascule sa barre d'outils vers le menu burger a 62em, et l'unite
-      // em d'une media query ne suit pas l'agrandissement du texte. Sans ce
-      // garde, le menu se croyait sur mobile a partir de 200 % de zoom texte et
-      // rendait son accordeon dans la barre de bureau, qui debordait alors de
-      // 952 px (RGAA 10.4).
+      // The DSFR moves its tools bar into the burger menu at 62em, and the em
+      // unit of a media query does not follow text zoom. Without this guard, the
+      // menu believed it was on mobile from 200 % text zoom onwards and rendered
+      // its accordion in the desktop bar, which then overflowed by 952 px
+      // (RGAA 10.4).
       isCompact={isDsfrCompactHeader}
       className={cn(zoomLevel >= 175 && "!w-full")}
       dropDownClassName={cn(zoomLevel >= 175 && "!w-full")}
     />,
-    // Le bouton de connexion reste dans la liste a toutes les largeurs (RGAA 10.11).
-    // Le DSFR le rend dans la barre d'outils au-dessus de 62em et dans le menu
-    // burger en dessous : le retirer sous 48em le rendait inatteignable partout.
+    // The login button stays in the list at every width (RGAA 10.11).
+    // The DSFR renders it in the tools bar above 62em and in the burger menu
+    // below: removing it under 48em made it unreachable everywhere.
     <LoginButton key="login" />,
   ];
 

--- a/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
+++ b/apps/client/src/components/Navigation/Navbar/QuickAccessMenu/QuickAccessMenu.tsx
@@ -49,10 +49,13 @@ const QuickAccessMenu = () => {
       className={cn(zoomLevel >= 175 && "!w-full")}
       dropDownClassName={cn(zoomLevel >= 175 && "!w-full")}
     />,
-    !isMobile ? <LoginButton key="login" /> : null,
+    // Le bouton de connexion reste dans la liste a toutes les largeurs (RGAA 10.11).
+    // Le DSFR le rend dans la barre d'outils au-dessus de 62em et dans le menu
+    // burger en dessous : le retirer sous 48em le rendait inatteignable partout.
+    <LoginButton key="login" />,
   ];
 
-  return [...menuItems];
+  return menuItems.filter((item) => item !== null);
 };
 
 export { QuickAccessMenu };

--- a/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
@@ -8,8 +8,11 @@ const FreeResources = () => {
   const { t } = useTranslation();
 
   return (
-    <section className="bg-alt-blue-france w-full py-20" id="free-ressources">
-      <div className="container grid grid-cols-2 items-center gap-10">
+    <section className="bg-alt-blue-france w-full py-10 md:py-20" id="free-ressources">
+      {/* grid-cols-2 n'avait aucune variante : la section n'etant rendue qu'au-dessus
+          de 768 px, le cas ne se posait pas. A 320 px cela donnait deux colonnes de
+          124 px (RGAA 10.11). */}
+      <div className="container grid grid-cols-1 items-center gap-10 md:grid-cols-2">
         <div>
           <h2>{t("Homepage.resourcesTitle", "Des ressources gratuites à votre disposition")}</h2>
           <p>

--- a/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/FreeResources/FreeResources.tsx
@@ -9,9 +9,9 @@ const FreeResources = () => {
 
   return (
     <section className="bg-alt-blue-france w-full py-10 md:py-20" id="free-ressources">
-      {/* grid-cols-2 n'avait aucune variante : la section n'etant rendue qu'au-dessus
-          de 768 px, le cas ne se posait pas. A 320 px cela donnait deux colonnes de
-          124 px (RGAA 10.11). */}
+      {/* grid-cols-2 had no responsive variant: as the section was only rendered
+          above 768 px, the case never came up. At 320 px it produced two 124 px
+          wide columns (RGAA 10.11). */}
       <div className="container grid grid-cols-1 items-center gap-10 md:grid-cols-2">
         <div>
           <h2>{t("Homepage.resourcesTitle", "Des ressources gratuites à votre disposition")}</h2>

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -166,6 +166,22 @@ const MobileApp = () => {
         ) : (
           <MobileAppSmsForm />
         )}
+        {/* Sous 768 px, le formulaire d'envoi par SMS disparaissait entierement :
+            perte de fonctionnalite au sens du critere 10.11. On le remet sous les
+            boutons de store, sans toucher au titre mobile qui releve d'un choix
+            editorial documente (PR #2709). L'intertitre reutilise la clef du titre
+            de bureau, deja traduite dans les 8 langues. */}
+        {isMobile && (
+          <div className="mt-10">
+            <h3 className="text-lg">
+              {t(
+                "MobileApp.titleDesktop",
+                "Envoyez un lien de téléchargement de l’application à vos bénéficiaires !",
+              )}
+            </h3>
+            <MobileAppSmsForm />
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -169,16 +169,17 @@ const MobileApp = () => {
         {/* Below 768 px, the SMS sending form disappeared entirely: a loss of
             functionality in the sense of criterion 10.11. It is put back under the
             store buttons, without touching the mobile title, which comes from a
-            documented editorial choice (PR #2709). The subheading reuses the
+            documented editorial choice (PR #2709). The heading sits at the same level as the
+            mobile title (two sibling blocks of the section, RGAA 9.1) and reuses the
             desktop title key, already translated in the 8 languages. */}
         {isMobile && (
           <div className="mt-10">
-            <h3 className="text-lg">
+            <h2 className="text-lg">
               {t(
                 "MobileApp.titleDesktop",
                 "Envoyez un lien de téléchargement de l’application à vos bénéficiaires !",
               )}
-            </h3>
+            </h2>
             <MobileAppSmsForm />
           </div>
         )}

--- a/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/MobileApp/MobileApp.tsx
@@ -166,11 +166,11 @@ const MobileApp = () => {
         ) : (
           <MobileAppSmsForm />
         )}
-        {/* Sous 768 px, le formulaire d'envoi par SMS disparaissait entierement :
-            perte de fonctionnalite au sens du critere 10.11. On le remet sous les
-            boutons de store, sans toucher au titre mobile qui releve d'un choix
-            editorial documente (PR #2709). L'intertitre reutilise la clef du titre
-            de bureau, deja traduite dans les 8 langues. */}
+        {/* Below 768 px, the SMS sending form disappeared entirely: a loss of
+            functionality in the sense of criterion 10.11. It is put back under the
+            store buttons, without touching the mobile title, which comes from a
+            documented editorial choice (PR #2709). The subheading reuses the
+            desktop title key, already translated in the 8 languages. */}
         {isMobile && (
           <div className="mt-10">
             <h3 className="text-lg">

--- a/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
@@ -59,9 +59,19 @@ const StructuresLogos = () => {
 
   return (
     <section className="flex flex-col items-center justify-center gap-4 px-4 py-10 md:px-32 xl:px-4">
-      <div className="flex flex-wrap justify-center gap-x-10">
+      {/* Sous 768 px, les logos passent a 48 px et les gouttieres se resserrent :
+          a 72 px ils tenaient a deux par ligne et la section faisait 592 px de
+          haut a 320 px. Meme contenu, moins de defilement (RGAA 10.11). */}
+      <div className="flex flex-wrap justify-center gap-x-6 gap-y-4 md:gap-x-10">
         {logos.map((logo, index) => (
-          <Image key={index} src={logo.image} alt={logo.alt} width={72} height={72} />
+          <Image
+            key={index}
+            src={logo.image}
+            alt={logo.alt}
+            width={72}
+            height={72}
+            className="h-12 w-12 object-contain md:h-[72px] md:w-[72px]"
+          />
         ))}
       </div>
       <p className="text-center text-lg">

--- a/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/StructuresLogos/StructuresLogos.tsx
@@ -59,9 +59,9 @@ const StructuresLogos = () => {
 
   return (
     <section className="flex flex-col items-center justify-center gap-4 px-4 py-10 md:px-32 xl:px-4">
-      {/* Sous 768 px, les logos passent a 48 px et les gouttieres se resserrent :
-          a 72 px ils tenaient a deux par ligne et la section faisait 592 px de
-          haut a 320 px. Meme contenu, moins de defilement (RGAA 10.11). */}
+      {/* Below 768 px, the logos go down to 48 px and the gutters get tighter: at
+          72 px only two fit per row and the section was 592 px tall at 320 px.
+          Same content, less scrolling (RGAA 10.11). */}
       <div className="flex flex-wrap justify-center gap-x-6 gap-y-4 md:gap-x-10">
         {logos.map((logo, index) => (
           <Image

--- a/apps/client/src/components/Pages/homepage/Sections/WhyAccordions/WhyAccordions.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/WhyAccordions/WhyAccordions.tsx
@@ -105,13 +105,22 @@ const WhyAccordions = (props: Props) => {
     },
   ];
 
+  // Sous 768 px, seuls les deux items ci-dessus etaient rendus : les deux
+  // derniers items de bureau, dont celui qui porte la video de mediation,
+  // disparaissaient (RGAA 10.11). Les deux premiers items ne sont pas des
+  // versions tronquees des items de bureau, ils sont ecrits en francais simplifie
+  // et s'adressent a la personne refugiee. On garde donc ce registre et on ajoute
+  // les deux items manquants a la suite, plutot que de basculer tout le mobile sur
+  // les textes de bureau, ce qui ferait perdre le francais simplifie.
+  const accordionItemsCompact = [...accordionItemsMobile, ...accordionItemsDesktop.slice(2)];
+
   return (
     <div className="container md:py-20">
       <h2 className="mb-20">
         {t("Homepage.whyTitle", "Pourquoi et quand utiliser Réfugiés.info ?")}
       </h2>
       <Accordion
-        items={isMobile ? accordionItemsMobile : accordionItemsDesktop}
+        items={isMobile ? accordionItemsCompact : accordionItemsDesktop}
         withImages
         initOpen
         multiOpen={!!isTablet}

--- a/apps/client/src/components/Pages/homepage/Sections/WhyAccordions/WhyAccordions.tsx
+++ b/apps/client/src/components/Pages/homepage/Sections/WhyAccordions/WhyAccordions.tsx
@@ -105,13 +105,13 @@ const WhyAccordions = (props: Props) => {
     },
   ];
 
-  // Sous 768 px, seuls les deux items ci-dessus etaient rendus : les deux
-  // derniers items de bureau, dont celui qui porte la video de mediation,
-  // disparaissaient (RGAA 10.11). Les deux premiers items ne sont pas des
-  // versions tronquees des items de bureau, ils sont ecrits en francais simplifie
-  // et s'adressent a la personne refugiee. On garde donc ce registre et on ajoute
-  // les deux items manquants a la suite, plutot que de basculer tout le mobile sur
-  // les textes de bureau, ce qui ferait perdre le francais simplifie.
+  // Below 768 px, only the two items above were rendered: the last two desktop
+  // items, including the one carrying the mediation video, disappeared
+  // (RGAA 10.11). The first two items are not truncated versions of the desktop
+  // items, they are written in simplified French and address the refugee
+  // directly. That register is kept and the two missing items are appended
+  // after them, rather than switching the whole mobile view to the desktop
+  // texts, which would lose the simplified French.
   const accordionItemsCompact = [...accordionItemsMobile, ...accordionItemsDesktop.slice(2)];
 
   return (

--- a/apps/client/src/components/Pages/recherche/SearchHeader/Filter/MenuLayouts/DialogMenuLayout.tsx
+++ b/apps/client/src/components/Pages/recherche/SearchHeader/Filter/MenuLayouts/DialogMenuLayout.tsx
@@ -2,7 +2,7 @@ import Button from "@codegouvfr/react-dsfr/Button";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslation } from "next-i18next";
 import type React from "react";
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import DropdownButton from "~/components/Pages/recherche/SearchHeader/Filter/DropdownButton";
 import type { LayoutProps } from "~/components/Pages/recherche/SearchHeader/Filter/MenuLayouts";
@@ -31,6 +31,19 @@ export function DialogMenuLayout({
   const [open, setOpen] = useState(false);
   const [isAnimatingOut, setIsAnimatingOut] = useState(false);
   const descriptionId = useId();
+
+  // The Crisp bubble (z-index 1000001) sits above this dialog (1000000, lowered on
+  // purpose in e272e9e7b so tooltips stay reachable) and covers the end of the
+  // "Recherche.seeAllButtonWithCount" footer button from 970 px down to 320 px. The dialog fills the
+  // screen, so hiding the bubble while it is open takes nothing away and keeps the
+  // button entirely visible; the bubble comes back on close (RGAA 10.11).
+  useEffect(() => {
+    if (!open) return;
+    window.$crisp?.push(["do", "chat:hide"]);
+    return () => {
+      window.$crisp?.push(["do", "chat:show"]);
+    };
+  }, [open]);
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!newOpen) {

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.module.scss
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.module.scss
@@ -54,6 +54,11 @@
   max-width: 100%;
 }
 
+// Remplace l'attribut frameborder, obsolete en HTML5 (RGAA 10.1).
+.youtube {
+  border: 0;
+}
+
 .no_cookie {
   display: flex;
   padding: u(2);

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.module.scss
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.module.scss
@@ -54,7 +54,7 @@
   max-width: 100%;
 }
 
-// Remplace l'attribut frameborder, obsolete en HTML5 (RGAA 10.1).
+// Replaces the frameborder attribute, obsolete in HTML5 (RGAA 10.1).
 .youtube {
   border: 0;
 }

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
@@ -170,9 +170,11 @@ const Accordion = (props: Props) => {
         <div
           className={cn(
             "flex items-center",
-            // Le conteneur passe en colonne sous 992 px : la moitie de largeur n'a
-            // de sens que dans la mise en page a deux colonnes. En dessous, elle
-            // reduisait l'illustration a 144 px de large (RGAA 10.11).
+            // Le conteneur passe en colonne sous 768 px (isMobile) : la moitie de
+            // largeur n'a de sens que dans la mise en page a deux colonnes. En
+            // dessous, elle reduisait l'illustration a 144 px de large (RGAA 10.11).
+            // Entre 768 et 992 px, la branche isTablet ci-dessus affiche le media
+            // dans le contenu de l'accordeon.
             isMobile ? "w-full" : "w-1/2",
             props.mediaAlign === "center" ? "justify-center" : "justify-end",
             props.items[open[0]]?.className,

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
@@ -169,7 +169,11 @@ const Accordion = (props: Props) => {
       {!isTablet && props.withImages && open.length > 0 && (
         <div
           className={cn(
-            "flex w-1/2 items-center",
+            "flex items-center",
+            // Le conteneur passe en colonne sous 992 px : la moitie de largeur n'a
+            // de sens que dans la mise en page a deux colonnes. En dessous, elle
+            // reduisait l'illustration a 144 px de large (RGAA 10.11).
+            isMobile ? "w-full" : "w-1/2",
             props.mediaAlign === "center" ? "justify-center" : "justify-end",
             props.items[open[0]]?.className,
           )}

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
@@ -170,11 +170,11 @@ const Accordion = (props: Props) => {
         <div
           className={cn(
             "flex items-center",
-            // Le conteneur passe en colonne sous 768 px (isMobile) : la moitie de
-            // largeur n'a de sens que dans la mise en page a deux colonnes. En
-            // dessous, elle reduisait l'illustration a 144 px de large (RGAA 10.11).
-            // Entre 768 et 992 px, la branche isTablet ci-dessus affiche le media
-            // dans le contenu de l'accordeon.
+            // The container switches to a column below 768 px (isMobile): the half
+            // width only makes sense in the two column layout. Below that, it
+            // shrank the illustration to 144 px wide (RGAA 10.11).
+            // Between 768 and 992 px, the isTablet branch above displays the media
+            // inside the accordion content.
             isMobile ? "w-full" : "w-1/2",
             props.mediaAlign === "center" ? "justify-center" : "justify-end",
             props.items[open[0]]?.className,

--- a/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/Accordion/Accordion.tsx
@@ -71,7 +71,6 @@ const Accordion = (props: Props) => {
             height={item.mediaHeight || "315"}
             src={item.youtube}
             title="YouTube video player"
-            frameBorder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
             allowFullScreen
             className={cn(styles.youtube, "w-full")}

--- a/apps/client/src/components/Pages/staticPages/common/SecondaryNavbar/SecondaryNavbar.module.scss
+++ b/apps/client/src/components/Pages/staticPages/common/SecondaryNavbar/SecondaryNavbar.module.scss
@@ -1,10 +1,11 @@
-@import "~/scss/mixins/responsive";
-
 .nav {
-  @include media-max("xl-limit") {
-    /* stylelint-disable-next-line selector-class-pattern */
-    :global(.fr-segmented__elements) {
-      flex-wrap: wrap;
-    }
+  /* The segmented control used to wrap its elements only below the `xl-limit`
+     media query, which is evaluated against the browser default font size: at
+     200% text zoom on a 1280px window it did not apply and the four elements
+     overflowed the viewport. Let them wrap at every width; at 100% they still
+     fit on one line wherever they did before (RGAA 10.4). */
+  /* stylelint-disable-next-line selector-class-pattern */
+  :global(.fr-segmented__elements) {
+    flex-wrap: wrap;
   }
 }

--- a/apps/client/src/components/Pages/staticPages/common/SecondaryNavbar/SecondaryNavbar.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/SecondaryNavbar/SecondaryNavbar.tsx
@@ -29,7 +29,7 @@ const SecondaryNavbar = (props: Props) => {
 
   return (
     <div className="sticky top-0 z-20 bg-white">
-      <div className="container flex flex-nowrap items-start justify-between gap-10 py-4 md:py-10">
+      <div className="container flex flex-wrap md:flex-nowrap items-start justify-between gap-10 py-4 md:py-10">
         <div className={styles.nav}>
           <SegmentedControl
             hideLegend

--- a/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/StepContent/StepContent.tsx
@@ -1,6 +1,5 @@
 import Badge from "@codegouvfr/react-dsfr/Badge";
 import Button from "@codegouvfr/react-dsfr/Button";
-import { useWindowSize } from "@refugies-info/ui";
 import type React from "react";
 import { useMemo } from "react";
 import Image from "~/components/UI/Image";
@@ -24,14 +23,37 @@ interface Props {
 }
 
 const StepContent = (props: Props) => {
-  const { isTablet } = useWindowSize();
-
-  const buttonStep = useMemo(
+  // The badge used to pick its column with the JS `isTablet` flag while the
+  // columns themselves follow the Tailwind breakpoints. Below `md` it was
+  // absolutely positioned inside a text column with no bottom padding, so it
+  // covered the last paragraphs of the step; at 200% text zoom the JS said
+  // "mobile" while the CSS said "tablet" and the same overlap came back. The
+  // badge is now rendered twice and CSS decides which copy shows: in the text
+  // column, in the flow below `md` and absolute above `lg`; in the image
+  // column between `md` and `lg` (RGAA 10.11).
+  const badgeClassName =
+    "text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white";
+  const textColumnBadge = useMemo(
     () => (
       <div
         className={cls(
-          "text-large bg-artwork-minor-blue-france z-10 rounded-full p-4 text-center font-bold text-white",
-          "absolute start-0 bottom-[60px] lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2",
+          badgeClassName,
+          "relative mt-2 inline-block md:max-lg:hidden",
+          "lg:absolute lg:start-0 lg:mt-0 lg:bottom-[120px] lg:-translate-x-1/2 lg:rtl:translate-x-1/2",
+          props.buttonStepEnd && "lg:!bottom-0",
+        )}
+      >
+        {props.buttonStep}
+      </div>
+    ),
+    [props.buttonStep, props.buttonStepEnd],
+  );
+  const imageColumnBadge = useMemo(
+    () => (
+      <div
+        className={cls(
+          badgeClassName,
+          "hidden md:max-lg:block absolute start-0 bottom-[60px]",
           props.buttonStepEnd && "!bottom-0",
         )}
       >
@@ -107,7 +129,7 @@ const StepContent = (props: Props) => {
             {props.cta.text}
           </Button>
         )}
-        {!isTablet && props.buttonStep && buttonStep}
+        {props.buttonStep && textColumnBadge}
 
         {/* fade border */}
         {props.dottedLine && (
@@ -146,7 +168,7 @@ const StepContent = (props: Props) => {
           ></span>
         )}
       </div>
-      {isTablet && props.buttonStep && buttonStep}
+      {props.buttonStep && imageColumnBadge}
     </div>
   );
 };

--- a/apps/client/src/components/Pages/staticPages/common/WorkTogether/WorkTogether.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/WorkTogether/WorkTogether.tsx
@@ -99,7 +99,11 @@ const WorkTogether = () => {
       <h2 className="mx-4 mb-0 text-center">
         {t("WorkTogether.title", "Travaillons ensemble ! Vous êtes... ?")}
       </h2>
-      <div className="container grid grid-cols-1 items-center gap-10 max-xl:w-[50.5rem] max-md:w-full sm:grid-cols-2 xl:w-full xl:grid-cols-3">
+      {/* A 768 px pile, max-md ne s'applique plus alors que max-xl s'applique
+          encore : la grille sortait a 808 px dans une fenetre de 768. La borne va
+          dans la valeur de width, car la classe container pose deja un max-width
+          qui l'emporterait sur un max-w-full (RGAA 10.11). */}
+      <div className="container grid grid-cols-1 items-center gap-10 max-xl:w-[min(50.5rem,100%)] max-md:w-full sm:grid-cols-2 xl:w-full xl:grid-cols-3">
         {cardsContent.map(({ title, description, link, cta, icon, image }) => (
           <div key={title} className="border-default-grey h-full border p-8">
             <div className="flex h-full flex-col gap-4">

--- a/apps/client/src/components/Pages/staticPages/common/WorkTogether/WorkTogether.tsx
+++ b/apps/client/src/components/Pages/staticPages/common/WorkTogether/WorkTogether.tsx
@@ -99,10 +99,10 @@ const WorkTogether = () => {
       <h2 className="mx-4 mb-0 text-center">
         {t("WorkTogether.title", "Travaillons ensemble ! Vous êtes... ?")}
       </h2>
-      {/* A 768 px pile, max-md ne s'applique plus alors que max-xl s'applique
-          encore : la grille sortait a 808 px dans une fenetre de 768. La borne va
-          dans la valeur de width, car la classe container pose deja un max-width
-          qui l'emporterait sur un max-w-full (RGAA 10.11). */}
+      {/* At exactly 768 px, max-md no longer applies while max-xl still does:
+          the grid overflowed to 808 px in a 768 px wide viewport. The bound goes
+          into the width value, because the container class already sets a
+          max-width that would win over a max-w-full (RGAA 10.11). */}
       <div className="container grid grid-cols-1 items-center gap-10 max-xl:w-[min(50.5rem,100%)] max-md:w-full sm:grid-cols-2 xl:w-full xl:grid-cols-3">
         {cardsContent.map(({ title, description, link, cta, icon, image }) => (
           <div key={title} className="border-default-grey h-full border p-8">

--- a/apps/client/src/components/UI/LanguageSelector/LanguageItem.module.scss
+++ b/apps/client/src/components/UI/LanguageSelector/LanguageItem.module.scss
@@ -11,9 +11,9 @@
   padding-block: var(--block-padding);
   position: relative;
 
-  // Le nom de la langue ne se coupe pas, mais la ligne peut passer a la ligne
-  // suivante : sous 380 px le libelle, l'etiquette et le pourcentage ne tenaient
-  // pas sur une ligne et debordaient de leur boite (RGAA 10.11).
+  // The language name does not break, but the row may wrap onto the next line:
+  // below 380 px the label, the tag and the percentage did not fit on one line
+  // and overflowed their box (RGAA 10.11).
   flex-wrap: wrap;
 
   :global(.langLabel) {

--- a/apps/client/src/components/UI/LanguageSelector/LanguageItem.module.scss
+++ b/apps/client/src/components/UI/LanguageSelector/LanguageItem.module.scss
@@ -10,7 +10,15 @@
   padding-inline: var(--inline-padding);
   padding-block: var(--block-padding);
   position: relative;
-  white-space: nowrap;
+
+  // Le nom de la langue ne se coupe pas, mais la ligne peut passer a la ligne
+  // suivante : sous 380 px le libelle, l'etiquette et le pourcentage ne tenaient
+  // pas sur une ligne et debordaient de leur boite (RGAA 10.11).
+  flex-wrap: wrap;
+
+  :global(.langLabel) {
+    white-space: nowrap;
+  }
 
   &:focus-visible {
     z-index: 2;

--- a/apps/client/src/hooks/index.ts
+++ b/apps/client/src/hooks/index.ts
@@ -8,6 +8,7 @@ export { default as useFavorites } from "./useFavorites";
 export { default as useLanguages } from "./useLanguages";
 export { default as useLocale } from "./useLocale";
 export { default as useLogin } from "./useLogin";
+export { default as useMediaQuery } from "./useMediaQuery";
 export { default as useOutsideClick } from "./useOutsideClick";
 export { default as useParamsFromHistory } from "./useParamsFromHistory";
 export { default as useRegisterFlow } from "./useRegisterFlow";

--- a/apps/client/src/hooks/useMediaQuery.ts
+++ b/apps/client/src/hooks/useMediaQuery.ts
@@ -1,18 +1,18 @@
 import { useEffect, useState } from "react";
 
 /**
- * Suit une media query CSS.
+ * Tracks a CSS media query.
  *
- * A ne pas confondre avec `isMobile` de `useWindowSize`, qui compare la largeur
- * de la fenetre a la taille de police de la racine. Les deux divergent des que
- * l'utilisateur agrandit le texte : l'unite `em` d'une media query se mesure sur
- * la taille de police par defaut du navigateur, que l'agrandissement du texte ne
- * change pas, alors que la racine, elle, grandit. Quand un composant doit suivre
- * le meme point de rupture qu'une feuille de style (celle du DSFR par exemple),
- * c'est ce hook qu'il faut, pas `isMobile`.
+ * Not to be confused with `isMobile` from `useWindowSize`, which compares the
+ * viewport width to the root font size. The two diverge as soon as the user
+ * zooms the text: the `em` unit of a media query is measured against the
+ * browser default font size, which text zoom does not change, whereas the root
+ * font size does grow. When a component must follow the same breakpoint as a
+ * stylesheet (the DSFR one for instance), this hook is the one to use, not
+ * `isMobile`.
  *
- * `defaultValue` est la valeur du premier rendu, cote serveur et avant montage.
- * La choisir egale au comportement d'origine evite un saut a l'hydratation.
+ * `defaultValue` is the value of the first render, server side and before mount.
+ * Choosing it equal to the original behaviour avoids a jump at hydration.
  */
 export const useMediaQuery = (query: string, defaultValue = false): boolean => {
   const [matches, setMatches] = useState(defaultValue);

--- a/apps/client/src/hooks/useMediaQuery.ts
+++ b/apps/client/src/hooks/useMediaQuery.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Suit une media query CSS.
+ *
+ * A ne pas confondre avec `isMobile` de `useWindowSize`, qui compare la largeur
+ * de la fenetre a la taille de police de la racine. Les deux divergent des que
+ * l'utilisateur agrandit le texte : l'unite `em` d'une media query se mesure sur
+ * la taille de police par defaut du navigateur, que l'agrandissement du texte ne
+ * change pas, alors que la racine, elle, grandit. Quand un composant doit suivre
+ * le meme point de rupture qu'une feuille de style (celle du DSFR par exemple),
+ * c'est ce hook qu'il faut, pas `isMobile`.
+ *
+ * `defaultValue` est la valeur du premier rendu, cote serveur et avant montage.
+ * La choisir egale au comportement d'origine evite un saut a l'hydratation.
+ */
+export const useMediaQuery = (query: string, defaultValue = false): boolean => {
+  const [matches, setMatches] = useState(defaultValue);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+
+    const mql = window.matchMedia(query);
+    const update = () => setMatches(mql.matches);
+
+    update();
+    mql.addEventListener("change", update);
+    return () => mql.removeEventListener("change", update);
+  }, [query]);
+
+  return matches;
+};
+
+export default useMediaQuery;

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -90,7 +90,7 @@ const Homepage = (props: Props) => {
 
       <Hero targetArrow="themes" />
 
-      {!isMobile && <StructuresLogos />}
+      <StructuresLogos />
 
       <Carrousel
         className="mb-20"

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -142,7 +142,7 @@ const Homepage = (props: Props) => {
 
       <Newsletter />
 
-      {!isMobile && <WorkTogether />}
+      <WorkTogether />
     </div>
   );
 };

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -134,7 +134,7 @@ const Homepage = (props: Props) => {
         ))}
       </Carrousel>
 
-      {!isMobile && <FreeResources />}
+      <FreeResources />
 
       <WhyAccordions nbDemarches={props.contentStatistics.nbDemarches || 0} />
 

--- a/packages/ui/src/components/composites/carrousel/Carrousel.tsx
+++ b/packages/ui/src/components/composites/carrousel/Carrousel.tsx
@@ -279,7 +279,7 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
               {t.title}
             </h2>
           )}
-          <div className="z-10 flex items-center gap-2 max-md:order-last max-md:mt-4 max-md:mr-4 max-md:ml-auto max-md:flex-wrap max-md:justify-end">
+          <div className="z-10 flex items-center gap-2 max-md:order-last max-md:mt-4 max-md:me-4 max-md:ms-auto max-md:flex-wrap max-md:justify-end">
             <Button
               aria-label={`${t.prev} (${prevSlide + 1} ${t.countSeparator} ${childrenArray.length})`}
               onClick={handlePrevClick}

--- a/packages/ui/src/components/composites/carrousel/Carrousel.tsx
+++ b/packages/ui/src/components/composites/carrousel/Carrousel.tsx
@@ -260,15 +260,26 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
       };
     }, [handleScroll, checkScrollability]);
 
+    // Below md the navigation row (two arrows and the "see more" link) used to
+    // be absolutely positioned at the bottom right, on a single line that could
+    // not wrap: at 320 px the "previous" arrow sat at x = -24, out of the
+    // viewport (RGAA 10.11). The header wrapper now dissolves into the section
+    // (`contents`), the row flows after the list and wraps when it is too wide,
+    // so the section grows with it instead of overlapping the cards. The list
+    // keeps a full width there: as a flex item with auto margins it would
+    // otherwise size to its content and push the page into horizontal scroll.
     return (
-      <section className={cn("relative w-full max-md:pb-14", className)} dir={dir}>
-        <div className="container mx-auto mb-8 flex w-full gap-4 lg:justify-between">
+      <section className={cn("relative w-full max-md:flex max-md:flex-col", className)} dir={dir}>
+        <div className="container mx-auto mb-8 flex w-full gap-4 max-md:contents lg:justify-between">
           {t.title && (
-            <h2 id={componentId} className="!mb-0 w-full !text-2xl font-bold max-sm:pe-[30%]">
+            <h2
+              id={componentId}
+              className="!mb-0 w-full !text-2xl font-bold max-md:!mb-8 max-md:px-4 max-sm:pe-[30%]"
+            >
               {t.title}
             </h2>
           )}
-          <div className="z-10 flex items-center gap-2 max-md:absolute max-md:right-4 max-md:bottom-0">
+          <div className="z-10 flex items-center gap-2 max-md:order-last max-md:mt-4 max-md:mr-4 max-md:ml-auto max-md:flex-wrap max-md:justify-end">
             <Button
               aria-label={`${t.prev} (${prevSlide + 1} ${t.countSeparator} ${childrenArray.length})`}
               onClick={handlePrevClick}
@@ -300,7 +311,7 @@ export const Carrousel = forwardRef<CarrouselHandle, CarrouselProps>(
         <ul
           ref={scrollContainerRef}
           className={cn(
-            "carrousel noscrollbar m-auto flex list-none gap-4 p-0",
+            "carrousel noscrollbar m-auto flex list-none gap-4 p-0 max-md:w-full",
             "snap-x snap-mandatory overflow-x-auto scroll-smooth",
             "scrollbar-hide [-ms-overflow-style:none] [scrollbar-width:none] [&::WebkitScrollbar]:hidden",
             enableContainerPadding &&


### PR DESCRIPTION
Audit RGAA, RGA-19 (https://linear.app/refugiesinfo/issue/RGA-19) : tout le contenu de l'accueil reste visible jusqu'à 320 px et au zoom 200 % (sections rétablies sur mobile, « Se connecter », boîtes de langue et « peau neuve », en-tête, carrousels), plus la bulle du chat sur Recherche et la pastille « Votre fiche est publiée ! » sur Publier et Traduire. Deux choix à valider par Julie : le formulaire SMS de retour sur mobile, et l'accordéon qui mélange français facile et registre professionnel.
